### PR TITLE
[KITCHEN-17] - support ignoring lint rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,8 @@ additional project configuration.
 `configuration` - Specify one or more configurations as a string. See
 the [configurations section](#configurations)
 
-`lint` - Specify whether to perform lint checking with foodcritic with a boolean.
+`lint` - Specify whether to perform lint checking with foodcritic with
+a boolean. Can also specify a list of tags to ignore, see example.
 
 `exclude` - Exclude a configuration from a particular platform passing
 it a hash with the platforms and configuration to exclude. See example
@@ -279,6 +280,25 @@ Disable lint checking for the zsh cookbook:
 ```ruby
 cookbook "zsh" do
   lint false
+end
+```
+
+Ignore certain foodcritic rules in the lint check, which must pass in
+an array. For example to ignore the ["prefer strings over symbols"](http://acrmp.github.com/foodcritic/#FC001) and
+["check for solo"](http://acrmp.github.com/foodcritic/#FC003) rules:
+
+```ruby
+cookbook "mycookbook" do
+  lint(:ignore => ["FC001", "FC003"])
+end
+```
+
+To ignore just the "prefer strings over symbols rule", it still needs
+to be an array at this time.
+
+```ruby
+cookbook "mycookbook" do
+  lint(:ignore => ["FC001"])
 end
 ```
 

--- a/lib/test-kitchen/project/cookbook.rb
+++ b/lib/test-kitchen/project/cookbook.rb
@@ -37,9 +37,13 @@ module TestKitchen
       def preflight_command(cmd = nil)
         return nil unless lint
         parent_dir = File.join(root_path, '..')
+        ignore_tags = ''
+        if lint.respond_to?(:has_key?) && lint[:ignore].respond_to?(:join)
+          ignore_tags = " -t ~#{lint[:ignore].join(' -t ~')}"
+        end
         set_or_return(:preflight_command, cmd, :default =>
           "knife cookbook test -o #{parent_dir} #{name}" +
-          " && foodcritic -f ~FC007 -f correctness #{root_path}")
+          " && foodcritic -f ~FC007 -f correctness#{ignore_tags} #{root_path}")
       end
 
       def script(arg=nil)

--- a/spec/test-kitchen/dsl_spec.rb
+++ b/spec/test-kitchen/dsl_spec.rb
@@ -118,6 +118,13 @@ module TestKitchen::DSL
       lint[:tags].must_equal ['correctness', 'style']
       lint[:include_rules].must_equal '/custom/rules'
     end
+    it "can specify tags as an array to ignore for the lint check" do
+      lint = dsl.cookbook('mysql') do
+        lint(:ignore => %w{FC001 FC003})
+      end.lint
+      assert(lint)
+      lint[:ignore].must_equal ['FC001', 'FC003']
+    end
     it "can specify configurations additively" do
       dsl.cookbook('mysql') do
         configuration 'client'

--- a/spec/test-kitchen/project/cookbook_spec.rb
+++ b/spec/test-kitchen/project/cookbook_spec.rb
@@ -179,6 +179,10 @@ module TestKitchen
         it "fails for any correctness warning except undeclared metadata dependencies" do
           lint_cmd.must_equal "foodcritic -f ~FC007 -f correctness cookbooks/example"
         end
+        it "includes ignored tags to the lint command" do
+          cookbook.lint(:ignore => %w{FC001 FC003})
+          lint_cmd.must_equal "foodcritic -f ~FC007 -f correctness -t ~FC001 -t ~FC003 cookbooks/example"
+        end
       end
     end
   end


### PR DESCRIPTION
- Adds capability for lint[:ignore] to be an array of foodcritic rules
  that should be ignored.
- Appends the rules to ignore to foodcritic in the
  `preflight_command`.
- Users can still specify their own preflight command overriding these
  rules entirely.
