### PR TITLE
[KITCHEN-4]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+Release Notes - test-kitchen Version ???
+
+    ** Bug
+        * [KITCHEN-4] - decouple rvm use for running integration/unit tests
+
 Release Notes - test-kitchen - Version 0.5.4
 
 ** Bug

--- a/lib/test-kitchen/project/base.rb
+++ b/lib/test-kitchen/project/base.rb
@@ -85,12 +85,7 @@ module TestKitchen
       end
 
       def runtimes(arg=nil)
-        set_or_return(:runtimes, arg, :default =>
-          if language == 'ruby' || language == 'chef'
-            ['1.9.2']
-          else
-            []
-          end)
+        set_or_return(:runtimes, arg, :default => [])
       end
 
       def install(arg=nil)

--- a/lib/test-kitchen/project/ruby.rb
+++ b/lib/test-kitchen/project/ruby.rb
@@ -22,14 +22,14 @@ module TestKitchen
 
       def install_command(runtime=nil, test_path=guest_test_root)
         cmd = "cd #{test_path}"
-        cmd << " && rvm use #{runtime}" if runtime
+        cmd << " && rvm use #{runtime}" unless runtime.empty?
         cmd << " && gem install bundler"
         cmd << " && #{install}"
       end
 
       def test_command(runtime=nil, test_path=guest_test_root)
         cmd = "cd #{test_path}"
-        cmd << " && rvm use #{runtime}" if runtime
+        cmd << " && rvm use #{runtime}" unless runtime.empty?
         cmd << " && #{script}"
       end
     end


### PR DESCRIPTION
- decouple rvm use for running integration/unit tests
  - This defaults rvm runtimes to empty, as documented in the README
