### PR TITLE
[KITCHEN-29] - implement --platform to limit test

### DIFF
--- a/lib/test-kitchen/cli.rb
+++ b/lib/test-kitchen/cli.rb
@@ -27,7 +27,8 @@ module TestKitchen
 
       option :platform,
         :long  => "--platform PLATFORM",
-        :description => "The platform to use. If not specified tests will be run against all platforms."
+        :description => "The platform to use. If not specified tests will be run against all platforms.",
+        :default => nil
 
       option :configuration,
         :long  => "--configuration CONFIG",

--- a/lib/test-kitchen/cli/test.rb
+++ b/lib/test-kitchen/cli/test.rb
@@ -27,8 +27,14 @@ module TestKitchen
         banner "kitchen test (options)"
 
         def run
-          warn_for_non_buildable_platforms(env.platform_names)
-          env.project.each_build(env.platform_names,
+          if config[:platform]
+            test_platforms = [config[:platform]]
+          else
+            test_platforms = env.platform_names
+          end
+
+          warn_for_non_buildable_platforms(test_platforms)
+          env.project.each_build(test_platforms,
                              config[:configuration]) do |platform,configuration|
             runner = TestKitchen::Runner.for_platform(env,
               {:platform => platform, :configuration => configuration})


### PR DESCRIPTION
- explicitly set default for config[:platform] to nil
- tests against the platform-version, e.g. 'ubuntu-12.04'
