### PR TITLE
Make work for Windows test subjects

### DIFF
--- a/cookbooks/test-kitchen/recipes/compat.rb
+++ b/cookbooks/test-kitchen/recipes/compat.rb
@@ -36,4 +36,5 @@ ruby_block "Give root access to the forwarded ssh agent" do
     # fail "Could not find running ssh agent - Is config.ssh.forward_agent enabled in Vagrantfile?" unless ENV['SSH_AUTH_SOCK']
   end
   action :create
+  not_if {RUBY_PLATFORM =~ /mingw32/}
 end

--- a/cookbooks/test-kitchen/recipes/default.rb
+++ b/cookbooks/test-kitchen/recipes/default.rb
@@ -34,12 +34,19 @@ project = node['test-kitchen']['project']
 source_root = project['source_root']
 test_root = project['test_root']
 
-package "rsync" do
-  action :install
-end
+case node['platform']
+when 'windows'
+  execute "stage project source to test root" do
+    command "xcopy /E /H /Y /I #{source_root.gsub('/', '\\')} #{test_root.gsub('/', '\\')} "
+  end  
+else
+  package "rsync" do
+    action :install
+  end
 
-execute "stage project source to test root" do
-  command "rsync -aHv --update --progress --checksum #{source_root}/ #{test_root} "
+  execute "stage project source to test root" do
+    command "rsync -aHv --update --progress --checksum #{source_root}/ #{test_root} "
+  end
 end
 
 # make the project_root available to other recipes


### PR DESCRIPTION
with these change test-kitchen works for windows test subjects over winrm (with vagrant-windows, https://github.com/leftathome/vagrant-windows)
