### PR TITLE
Loosen mixlib-cli restriction

### DIFF
--- a/test-kitchen.gemspec
+++ b/test-kitchen.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.add_dependency('fog')
   s.add_dependency('foodcritic', '>= 1.4.0')
   s.add_dependency('hashr', '~> 0.0.20')
-  s.add_dependency('mixlib-cli', '~> 1.2.2')
+  s.add_dependency('mixlib-cli', '~> 1.2')
   s.add_dependency('highline', '>= 1.6.9')
   s.add_dependency('vagrant', '~> 1.0.2')
   s.add_dependency('yajl-ruby', '~> 1.1.0')


### PR DESCRIPTION
Can't place `test-kitchen` in a Gemfile with the latest `chef`:

```
Bundler could not find compatible versions for gem "mixlib-cli":
  In Gemfile:
    test-kitchen (>= 0) ruby depends on
      mixlib-cli (~> 1.2.2) ruby

    chef (~> 10.18.0) ruby depends on
      mixlib-cli (1.3.0)
```

I'm guessing that `mixlib-cli` `>= 1.2.0, < 2.0.0` is a legit restriction here.
