### PR TITLE
[Breaking] Modify ShellOut#run_command to take an options Hash.

### DIFF
--- a/lib/kitchen/driver/base.rb
+++ b/lib/kitchen/driver/base.rb
@@ -113,11 +113,12 @@ module Kitchen
         info(msg)
       end
 
-      def run_command(cmd, use_sudo = nil, log_subject = nil)
-        use_sudo = config[:use_sudo] if use_sudo.nil?
-        log_subject = Util.to_snake_case(self.class.to_s)
-
-        super(cmd, use_sudo, log_subject)
+      def run_command(cmd, options = {})
+        base_options = {
+          :use_sudo => config[:use_sudo],
+          :log_subject => Util.to_snake_case(self.class.to_s)
+        }.merge(options)
+        super(cmd, base_options)
       end
 
       def kb_setup_cmd

--- a/lib/kitchen/shell_out.rb
+++ b/lib/kitchen/shell_out.rb
@@ -32,20 +32,40 @@ module Kitchen
     # Executes a command in a subshell on the local running system.
     #
     # @param cmd [String] command to be executed locally
-    # @param use_sudo [TrueClass, FalseClass] whether or not to use sudo
-    # @param log_subject [String] used in the output or log header for clarity
-    #   and context
+    # @param options [Hash] additional configuration of command
+    # @option options [TrueClass, FalseClass] :use_sudo whether or not to use
+    #   sudo
+    # @option options [String] :log_subject used in the output or log header
+    #   for clarity and context. Default is "local".
+    # @option options [String] :cwd the directory to chdir to before running
+    #   the command
+    # @option options [Hash] :environment a Hash of environment variables to
+    #   set before the command is run. By default, the environment will
+    #   *always* be set to 'LC_ALL' => 'C' to prevent issues with multibyte
+    #   characters in Ruby 1.8. To avoid this, use :environment => nil for
+    #   *no* extra environment settings, or
+    #   :environment => {'LC_ALL'=>nil, ...} to set other environment settings
+    #   without changing the locale.
+    # @option options [Integer] :timeout Numeric value for the number of
+    #   seconds to wait on the child process before raising an Exception.
+    #   This is calculated as the total amount of time that ShellOut waited on
+    #   the child process without receiving any output (i.e., IO.select
+    #   returned nil). Default is 60000 seconds. Note: the stdlib Timeout
+    #   library is not used.
+    # @return [String] the standard output of the command as a String
     # @raise [ShellCommandFailed] if the command fails
     # @raise [Error] for all other unexpected exceptions
-    def run_command(cmd, use_sudo = false, log_subject = "local")
+    def run_command(cmd, options = {})
+      use_sudo = options[:use_sudo].nil? ? false : options[:use_sudo]
       cmd = "sudo #{cmd}" if use_sudo
-      subject = "[#{log_subject} command]"
+      subject = "[#{options[:log_subject] || "local"} command]"
 
       info("#{subject} BEGIN (#{display_cmd(cmd)})")
-      sh = Mixlib::ShellOut.new(cmd, :live_stream => logger, :timeout => 60000)
+      sh = Mixlib::ShellOut.new(cmd, shell_opts(options))
       sh.run_command
       info("#{subject} END #{Util.duration(sh.execution_time)}")
       sh.error!
+      sh.stdout
     rescue Mixlib::ShellOut::ShellCommandFailed => ex
       raise ShellCommandFailed, ex.message
     rescue Exception => error
@@ -60,6 +80,13 @@ module Kitchen
       last_char = cmd[cmd.size - 1]
 
       newline == "\n" ? "#{first_line}\\n...#{last_char}" : cmd
+    end
+
+    def shell_opts(options)
+      filtered_opts = options.reject do |key, value|
+        [:use_sudo, :log_subject].include?(key)
+      end
+      { :live_stream => logger, :timeout => 60000 }.merge(filtered_opts)
     end
   end
 end


### PR DESCRIPTION
This will allow users of the method to pass additional configuration to
the shelled out command such as environment variables, current working
director, customized timeout value, etc.

This mixin module (Kitchen::ShellOut) is used internally and exposed to
Driver implementors as `#run_command` in all `Driver::Base` subclasses.
