### PR TITLE
switch driver alias (-d) to (-D) in Init generator

### DIFF
--- a/lib/kitchen/generator/init.rb
+++ b/lib/kitchen/generator/init.rb
@@ -30,7 +30,7 @@ module Kitchen
 
       include Thor::Actions
 
-      class_option :driver, :type => :array, :aliases => "-d",
+      class_option :driver, :type => :array, :aliases => "-D",
         :default => "kitchen-vagrant",
         :desc => "One or more Kitchen Driver gems to be added to the Gemfile"
 


### PR DESCRIPTION
this causes a conflict with the berkshelf (-d) debug flag
this will cause issues if we chain the generators together
