### PR TITLE
Expose provisioner in configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,39 +22,27 @@ and run the `bundle` command to install:
 
     $ bundle install
 
-This will expose the `test-kitchen` CLI. Run `bundle exec kitchen init` to get started:
+This will expose the `test-kitchen` CLI. Run `kitchen init` to get started:
 
     $ kitchen init
 
 You will be prompted with a series of questions. In this guide, we
-will be using the [kitchen vagrant driver](https://github.com/opscode/kitchen-vagrant).
+will be using the [kitchen vagrant driver](https://github.com/opscode/kitchen-vagrant):
 
-```text
-$ bundle exec kitchen init
+      $ kitchen init
       create  .kitchen.yml
       append  Rakefile
       create  test/integration/default
       append  .gitignore
       append  .gitignore
-      Add a Driver plugin to your Gemfile?
-      (y/n)> y
-      Enter gem name, `list', or `skip'>
-      kitchen-vagrant
-      append  Gemfile
-      You must run `bundle install' to fetch any new gems.
-```
 
-Run the `bundle` command again to install the new vagrant driver:
-
-    $ bundle install
-
-Open up the `.kitchen.yml` file created in the root of your
-repository.
+To review the configuration, open up the `.kitchen.yml` file created in
+the root of your repository.
 
 Now, it is time to get testing. Use the `--parallel` option to run
 your tests in parallel. Trust us, it's faster!
 
-    $ bundle exec kitchen test
+    $ kitchen test
 
 ### Helpful Switches
 
@@ -69,24 +57,37 @@ your tests in parallel. Trust us, it's faster!
 
 ## The Kitchen YAML format
 
-Test-Kitchen reads its configuration from the .kitchen.yml
-configuration file at the root of your cookbook. It closely resembles
-the format of .travis.yml which is intentional.
+Test-Kitchen reads its configuration from the `.kitchen.yml`
+configuration file at the root of your cookbook or module. It closely resembles
+the format of `.travis.yml` which is intentional.
 
-There are 4 stanzas in .kitchen.yml, driver_plugin, driver_config,
-platforms, and suites. driver_plugin, platforms, and suites are
-currently required. driver_config can optionally be used to set values
-for all platforms defined.
+There are 5 stanzas in `.kitchen.yml`:
 
-The driver_plugin stanza is only one line long and defines which
-driver is used by test-kitchen.
+* `driver_plugin`
+* `provisioner`
+* `driver_config`
+* `platforms`
+* `suites`
 
-The platforms stanza defines individual virtual machines. Additional
-driver_config, node attributes, and run_list can be defined in this stanza
+The `driver_plugin`, `platforms`, and `suites` stanzas are currently all
+required. The `driver_config` stanza can optionally be used to set
+values for all platforms defined.
 
-The suites stanza defines sets of tests that you intend to be run on
-each platform. A run_list and node attributes can be defined for each
-suite. The run_list and node attributes will be merged with that of
+The `driver_plugin` stanza is only one line long and defines which
+driver is used by Test-Kitchen.
+
+The `provisioner` stanza is only one line long and defines which
+configuration management tool a driver should use. It defines a
+configuration value passed to the driver of `provisioner`. When
+Test-Kitchen is initialized it detects if it is in a Chef cookbook or a
+Puppet module and sets itself accordingly. Otherwise, it defaults to `chef`.
+
+The `platforms` stanza defines individual virtual machines. Additional
+`driver_config`, node attributes, and `run_list` can be defined in this stanza
+
+The `suites` stanza defines sets of tests that you intend to be run on
+each platform. A `run_list` and node attributes can be defined for each
+suite. The `run_list` and node attributes will be merged with that of
 each platform. In case of the conflict, the attributes defined on the
 suite will triumph.
 
@@ -94,6 +95,7 @@ suite will triumph.
 
 ---
 driver_plugin: vagrant
+provisioner: chef
 
 platforms:
 - name: ubuntu-12.04

--- a/lib/kitchen/config.rb
+++ b/lib/kitchen/config.rb
@@ -30,6 +30,7 @@ module Kitchen
     attr_accessor :kitchen_root
     attr_accessor :test_base_path
     attr_accessor :log_level
+    attr_writer :provisioner
     attr_writer :supervised
     attr_writer :platforms
     attr_writer :suites
@@ -90,6 +91,11 @@ module Kitchen
       @supervised.nil? ? @supervised = true : @supervised
     end
 
+    def provisioner
+      provisioner = data[:provisioner].nil? ? 'chef' : data[:provisioner]
+      @provisioner ||= provisioner
+    end
+
     private
 
     def new_suite(hash)
@@ -108,6 +114,7 @@ module Kitchen
     def new_driver(hash)
       hash[:driver_config] ||= Hash.new
       hash[:driver_config][:kitchen_root] = kitchen_root
+      hash[:driver_config][:provisioner] = provisioner
 
       Driver.for_plugin(hash[:driver_plugin], hash[:driver_config])
     end

--- a/spec/kitchen/config_spec.rb
+++ b/spec/kitchen/config_spec.rb
@@ -160,6 +160,15 @@ describe Kitchen::Config do
       config.instances.first.driver.must_be_instance_of Kitchen::Driver::Dummy
     end
 
+    it "returns an instance containing a driver instance with a provisioner" do
+      config.provisioner = 'foo'
+      stub_data!({
+        :platforms => [{ :name => 'platform', :driver_plugin => 'dummy' }],
+        :suites => [{ :name => 'suite', :run_list => [] }]
+      })
+      config.instances.first.driver[:provisioner].must_equal "foo"
+    end
+
     it "returns an instance with a driver initialized with kitchen_root" do
       config.kitchen_root = "/tmp"
       stub_data!({
@@ -191,6 +200,18 @@ describe Kitchen::Config do
     it "returns an overridden log_level" do
       config.log_level = :error
       config.log_level.must_equal :error
+    end
+  end
+
+  describe "provisioner" do
+
+    it "returns a default provisioner of chef" do
+      config.provisioner.must_equal 'chef'
+    end
+
+    it "returns an overriden provisioner" do
+      config.provisioner = 'foo'
+      config.provisioner.must_equal 'foo'
     end
   end
 

--- a/templates/init/chef_kitchen.yml.erb
+++ b/templates/init/chef_kitchen.yml.erb
@@ -1,5 +1,6 @@
 ---
 driver_plugin: <%= config[:driver_plugin] %>
+provisioner: <%= config[:provisioner] %>
 
 platforms:
 - name: ubuntu-12.04

--- a/templates/init/puppet_kitchen.yml.erb
+++ b/templates/init/puppet_kitchen.yml.erb
@@ -1,0 +1,25 @@
+---
+driver_plugin: <%= config[:driver_plugin] %>
+provisioner: <%= config[:provisioner] %>
+
+platforms:
+- name: ubuntu-12.04
+  driver_config:
+    box: puppetlabs-ubuntu-12.04
+    box_url: http://puppet-vagrant-boxes.puppetlabs.com/ubuntu-server-12042-x64-vbox4210.box
+- name: ubuntu-10.04
+  driver_config:
+    box: puppetlabs-ubuntu-10.04
+    box_url: http://puppet-vagrant-boxes.puppetlabs.com/ubuntu-server-10044-x64-vbox4210.box
+- name: centos-6.4
+  driver_config:
+    box: puppetlabs-centos-6.4
+    box_url: http://puppet-vagrant-boxes.puppetlabs.com/centos-64-x64-vbox4210.box
+- name: centos-5.9
+  driver_config:
+    box: puppetlabs-centos-5.9
+    box_url: http://puppet-vagrant-boxes.puppetlabs.com/centos-59-x64-vbox4210.box
+
+suites:
+- name: <%= config[:klass] %>
+  run_list: []

--- a/templates/init/puppet_manifest.pp.erb
+++ b/templates/init/puppet_manifest.pp.erb
@@ -1,0 +1,1 @@
+class { "<%= config[:klass] %>": }


### PR DESCRIPTION
1. Expose provisioner in driver configuration.

Exposes a new config file option: provisioner. Passed to the driver as
the `provisioner` configuration item.
1. Refactor kitchen init to detect Puppet modules

Detects if it is being init'ed in a Module or a Cookbook and defaults to
the right provisioner. For Puppet modules it also creates a template
manifest in `test/manifests` that loads the default module class.

Includes updates to docs and tests.
