### PR TITLE
Set the default ssh port.

### DIFF
--- a/lib/kitchen/driver/ssh_base.rb
+++ b/lib/kitchen/driver/ssh_base.rb
@@ -31,6 +31,8 @@ module Kitchen
     # @author Fletcher Nichol <fnichol@nichol.ca>
     class SSHBase < Base
 
+      default_config :port, 22
+
       def create(state)
         raise ClientError, "#{self.class}#create must be implemented"
       end


### PR DESCRIPTION
The sshd check just loops forever if the driver doesn't set the port.

This sets the default port to 22.
