### PR TITLE
Propagate errors from prepare with Berkshelf and Libraries

### DIFF
--- a/lib/kitchen/chef_data_uploader.rb
+++ b/lib/kitchen/chef_data_uploader.rb
@@ -72,7 +72,7 @@ module Kitchen
       cookbooks_dir = local_cookbooks
       upload_path(scp, cookbooks_dir, "cookbooks")
     ensure
-      FileUtils.rmtree(cookbooks_dir)
+      FileUtils.rmtree(cookbooks_dir) unless cookbooks_dir.nil?
     end
 
     def upload_data_bags(scp)


### PR DESCRIPTION
Propagate errors from prepare with Berkshelf and Libraries to be able to see them in the error log, before the only error was [can't convert nil into String]
