### PR TITLE
Require the 'name' attribute is present in `metadata.rb`

### DIFF
--- a/lib/kitchen/chef_data_uploader.rb
+++ b/lib/kitchen/chef_data_uploader.rb
@@ -158,6 +158,9 @@ module Kitchen
     def cp_this_cookbook(tmpdir)
       metadata_rb = File.join(kitchen_root, "metadata.rb")
       cb_name = MetadataChopper.extract(metadata_rb).first
+
+      raise TestKitchen::Errors::MissingCookbookName.new(name) if cb_name.nil?
+
       cb_path = File.join(tmpdir, cb_name)
       glob = Dir.glob("#{kitchen_root}/{metadata.rb,README.*," +
         "attributes,files,libraries,providers,recipes,resources,templates}")

--- a/lib/kitchen/errors.rb
+++ b/lib/kitchen/errors.rb
@@ -74,6 +74,24 @@ module Kitchen
   # Exception class capturing what caused an instance to die.
   class InstanceFailure < TransientFailure ; end
 
+  # Exception class raised when a cookbook's metadata is missing the name
+  # attribute.
+  class MissingCookbookName  < StandardError
+    def initialize(name)
+      @name = name
+    end
+
+    def to_s
+      [
+        "The metadata.rb does not define the 'name' key. Please add:",
+        "",
+        "  name '#{@name}'",
+        "",
+        "to the metadata.rb for '#{@name}' and try again."
+      ].join("\n")
+    end
+  end
+
   def self.with_friendly_errors
     yield
   rescue Kitchen::InstanceFailure => e


### PR DESCRIPTION
@fnichol after tracing all day, I found this.

If there's no `name` attribute in the `metadata.rb`, TK fails to copy the cookbook, but it doesn't fail until later up the stack.

So I inserted a check... and it **still** doesn't fail until later up the stack, but the exception is definitely raised. I think we need to link the supervisor/actors together and listen for exceptions on the children?

Basically, I want to give the user a happy little error say "PUT A NAME ATTRIBUTE IF YOUR FREAKING COOKBOOK", but nicer :smile:. And instead I get "Message: Failed to complete #converge action: [can't convert nil into String]"

:warning: not ready for merge
