### PR TITLE
Aggressively filter "non-cookbook" files before uploading to instances.

### DIFF
--- a/lib/kitchen/chef_data_uploader.rb
+++ b/lib/kitchen/chef_data_uploader.rb
@@ -151,7 +151,8 @@ module Kitchen
     def cookbook_files_glob
       files = %w{README.* metadata.{json,rb}
         attributes/**/* definitions/**/* files/**/* libraries/**/*
-        providers/**/* recipes/**/* resources/**/* templates/**/*}
+        providers/**/* recipes/**/* resources/**/* templates/**/*
+      }
 
       "*/{#{files.join(',')}}"
     end


### PR DESCRIPTION
In order to minimize the amount of extra files in a cookbook project
that must be uploaded to an instance, the prepared directory of
cookbooks is processed to eliminate "non-cookbook" files. The following
files are considered production cookbook files:
- `README.*`
- `metadata.{json,rb}`
- `attributes/**/*`
- `definitions/**/*`
- `files/**/*`
- `libraries/**/*`
- `providers/**/*`
- `recipes/**/*`
- `resources/**/*`
- `templates/**/*`

References #35
