### PR TITLE
Fix install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ In your `Gemfile`, add `test-kitchen` as a
 dependency:
 
 ```ruby
-gem 'test-kitchen', git: 'git://github.com/opscode/test-kitchen.git', branch: '1.0'
+gem 'test-kitchen', git: 'git://github.com/opscode/test-kitchen.git', branch: 'master'
 ```
 
 and run the `bundle` command to install:


### PR DESCRIPTION
Installing the 1.0 branch with bundler is no longer possible. It should be master now.
