### PR TITLE
KITCHEN-75 - support cross suite helpers.

### DIFF
--- a/lib/kitchen/busser.rb
+++ b/lib/kitchen/busser.rb
@@ -80,7 +80,8 @@ module Kitchen
         <<-INSTALL_CMD.gsub(/^ {10}/, '')
           bash -c '
           #{sudo}#{busser_bin} suite cleanup
-          #{local_suite_files.map { |f| stream_file(f, remote_file(f)) }.join}'
+          #{local_suite_files.map { |f| stream_file(f, remote_file(f, @suite_name)) }.join}
+          #{helper_files.map { |f| stream_file(f, remote_file(f, "helpers")) }.join}'
         INSTALL_CMD
       end
     end
@@ -104,6 +105,7 @@ module Kitchen
 
     def validate_options(suite_name)
       raise ClientError, "Busser#new requires a suite_name" if suite_name.nil?
+      raise UserError, "Suite name invalid: 'helper' is a reserved directory name." if suite_name == 'helper'
     end
 
     def plugins
@@ -118,8 +120,12 @@ module Kitchen
       end
     end
 
-    def remote_file(file)
-      local_prefix = File.join(test_root, @suite_name)
+    def helper_files
+      Dir.glob(File.join(test_root, "helpers", "*/**/*"))
+    end
+
+    def remote_file(file, dir)
+      local_prefix = File.join(test_root, dir)
       "$(#{sudo}#{busser_bin} suite path)/".concat(file.sub(%r{^#{local_prefix}/}, ''))
     end
 


### PR DESCRIPTION
- If there is a test/integration/helpers directory then copy the contents of the test framework specific sub folder
  to the remote suite dir.

For example,

  test/integration/helpers/serverspec/spec_helper.rb

would be copied to /opt/busser/suites/serverspec/spec_helper.rb

This allows common files used across suites (such as spec_helper) to live in one place.
