### PR TITLE
Fixes bundler ref for 1.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ In your `Gemfile`, add `test-kitchen` as a
 dependency:
 
 ```ruby
-gem 'test-kitchen', git: 'git://github.com/opscode/test-kitchen.git', branch: '1.0'
+gem 'test-kitchen', '~> 1.0.0.alpha'
 ```
 
 and run the `bundle` command to install:


### PR DESCRIPTION
Not ideal to restrict to `alpha`, but pretty sure that's the only liberal way to refer to prereleases in the `Gemfile` without locking to a specific prerelease: http://gembundler.com/v1.3/gemfile.html
