### PR TITLE
Allow chef omnibus install.sh url to be configurable

### DIFF
--- a/lib/kitchen/driver/ssh_base.rb
+++ b/lib/kitchen/driver/ssh_base.rb
@@ -101,7 +101,7 @@ module Kitchen
       end
 
       def install_omnibus(ssh_args)
-        url = "https://www.opscode.com/chef/install.sh"
+        url = config[:chef_omnibus_url] || "https://www.opscode.com/chef/install.sh"
         flag = config[:require_chef_omnibus]
         version = if flag.is_a?(String) && flag != "latest"
           "-s -- -v #{flag.downcase}"


### PR DESCRIPTION
Inside ssh_base.rb, the url for the chef omnibus install.sh is currently hardcoded to https://www.opscode.com/chef/install.sh. This should be configurable to support custom variations that might be needed (such as in a corporate network, etc). This will also allow the possibility of removing an external dependency on opscode.com.

This pull request allows the url to be configured in the .kitchen.yml (example below)

```
driver config:
  require_chef_omnibus: true
  chef_omnibus_url: "https://example.com/chef/install.sh"
```
