### PR TITLE
Setting :on_black when your default terminal text color is black results in unreadable (black on black) text.

### DIFF
--- a/lib/kitchen/cli.rb
+++ b/lib/kitchen/cli.rb
@@ -328,7 +328,7 @@ module Kitchen
       when nil then set_color("<Not Created>", :red)
       else set_color("<Unknown>", :white)
       end
-      [set_color(instance.name, :on_black), action]
+      [set_color(instance.name, :white, :on_black), action]
     end
 
     def update_config!


### PR DESCRIPTION
This fix for #154 comes from @tarrall (who hasn't signed the Opscode contributor agreement yet).
