### PR TITLE
Include definitions directory when uploading the cookbooks

### DIFF
--- a/lib/kitchen/chef_data_uploader.rb
+++ b/lib/kitchen/chef_data_uploader.rb
@@ -178,7 +178,7 @@ module Kitchen
 
       cb_path = File.join(tmpdir, cb_name)
       glob = Dir.glob("#{kitchen_root}/{metadata.rb,README.*," +
-        "attributes,files,libraries,providers,recipes,resources,templates}")
+        "attributes,files,libraries,definitions,providers,recipes,resources,templates}")
 
       FileUtils.mkdir_p(cb_path)
       FileUtils.cp_r(glob, cb_path)


### PR DESCRIPTION
`kitchen converge` was not including the definitions directory when uploading my cookbooks into vagrant. This fixes that problem.

I tried to get `cp_this_cookbook` to use `cookbook_files_glob` to reduce redundancies but was unable to get it working right.
