### PR TITLE
add asterisk to  wait_for_sshd argument

### DIFF
--- a/lib/kitchen/driver/ssh_base.rb
+++ b/lib/kitchen/driver/ssh_base.rb
@@ -122,7 +122,7 @@ module Kitchen
         raise ActionFailed, ex.message
       end
 
-      def wait_for_sshd(ssh_args)
+      def wait_for_sshd(*ssh_args)
         SSH.new(*ssh_args).wait
       end
     end


### PR DESCRIPTION
Hi, I fix argument of `wait_for_sshd(ssh_args)` method since I encountered error about this. 

Thanks.
