### PR TITLE
Support computed default values for Driver authors.

### DIFF
--- a/lib/kitchen/driver/base.rb
+++ b/lib/kitchen/driver/base.rb
@@ -30,7 +30,7 @@ module Kitchen
       include ShellOut
       include Logging
 
-      attr_writer :instance
+      attr_accessor :instance
 
       class << self
         attr_reader :serial_actions
@@ -58,7 +58,9 @@ module Kitchen
       # @param attr [Object] configuration key
       # @return [Object] value at configuration key
       def [](attr)
-        config[attr]
+        proc_or_val = config[attr]
+
+        proc_or_val.respond_to?(:call) ? proc_or_val.call(self) : proc_or_val
       end
 
       # Creates an instance.
@@ -112,7 +114,7 @@ module Kitchen
 
       protected
 
-      attr_reader :config, :instance
+      attr_reader :config
 
       ACTION_METHODS = %w{create converge setup verify destroy}.
         map(&:to_sym).freeze
@@ -171,8 +173,8 @@ module Kitchen
         end
       end
 
-      def self.default_config(attr, value)
-        defaults[attr] = value
+      def self.default_config(attr, value = nil, &block)
+        defaults[attr] = block_given? ? block : value
       end
 
       def self.validations

--- a/spec/kitchen/driver/base_spec.rb
+++ b/spec/kitchen/driver/base_spec.rb
@@ -1,0 +1,123 @@
+# -*- encoding: utf-8 -*-
+#
+# Author:: Fletcher Nichol (<fnichol@nichol.ca>)
+#
+# Copyright (C) 2012, Fletcher Nichol
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative '../../spec_helper'
+require 'logger'
+require 'stringio'
+
+require 'kitchen'
+
+module Kitchen
+
+  module Driver
+
+    class StaticDefaults < Base
+
+      default_config :beans, "kidney"
+      default_config :tunables, { 'flimflam' => 'positate' }
+    end
+
+    class ComputedDefaults < Base
+
+      default_config :beans, "kidney"
+      default_config :fetch_command, "curl"
+      default_config :beans_url do |driver|
+        "http://gim.me/#{driver[:beans]}"
+      end
+      default_config :command do |driver|
+        "#{driver[:fetch_command]} #{driver[:beans_url]}"
+      end
+      default_config :fetch_url do |driver|
+        "http://gim.me/beans-for/#{driver.instance.name}"
+      end
+    end
+  end
+end
+
+describe Kitchen::Driver::Base do
+
+  let(:logged_output) { StringIO.new }
+  let(:logger)        { Logger.new(logged_output) }
+  let(:config)        { Hash.new }
+  let(:state)         { Hash.new }
+
+  let(:instance) do
+    stub(:name => "coolbeans", :logger => logger, :to_str => "instance")
+  end
+
+  describe "user config" do
+
+    let(:driver) do
+      d = Kitchen::Driver::Base.new(config)
+      d.instance = instance
+      d
+    end
+
+    it "injects config into driver" do
+      config[:fruit] = %w{apples oranges}
+      config[:cool_enough] = true
+
+      driver[:fruit].must_equal ['apples', 'oranges']
+      driver[:cool_enough].must_equal true
+    end
+  end
+
+  describe "static default config" do
+
+    let(:driver) do
+      d = Kitchen::Driver::StaticDefaults.new(config)
+      d.instance = instance
+      d
+    end
+
+    it "uses default config" do
+      driver[:beans].must_equal "kidney"
+      driver[:tunables]['flimflam'].must_equal 'positate'
+    end
+
+    it "uses user config over default config" do
+      config[:beans] = "pinto"
+
+      driver[:beans].must_equal "pinto"
+    end
+  end
+
+  describe "computed default config" do
+
+    let(:driver) do
+      d = Kitchen::Driver::ComputedDefaults.new(config)
+      d.instance = instance
+      d
+    end
+
+    it "uses computed config" do
+      driver[:beans_url].must_equal "http://gim.me/kidney"
+      driver[:command].must_equal "curl http://gim.me/kidney"
+    end
+
+    it "has access to instance object" do
+      driver[:fetch_url].must_equal "http://gim.me/beans-for/coolbeans"
+    end
+
+    it "uses user config over default config" do
+      config[:command] = "echo listentome"
+
+      driver[:command].must_equal "echo listentome"
+    end
+  end
+end


### PR DESCRIPTION
This feature augments the `default_config` method provided to Driver
authors by allowing a block to be passed which provides a way to
delay or compute a default value using another default (or provided
value).

For example, a driver author can now write `default_config` values such
as:

``` ruby
class Kitchen::Driver::BelAirCloud < Kitchen::Driver::Base

  default_config :region, "west-philadelphia"

  default_config :endpoint_url do |driver|
    "http://#{driver[:region]}.belair-cloud.com/api"
  end
end
```

In the above example `driver[:endpoint_url]` will be computed when
called using the current driver object for context. Driver authors will
have access to the underlying config Hash (using `driver[:my_key]`) and
the associated instance object (using `driver.instance` for access to
data such as `instance.name`).

Note that any config data that is provided via the Kitchen YAML will
override any `default_config` values or blocks.
