### PR TITLE
[Breaking] Update signature of Driver.required_config block.

### DIFF
--- a/lib/kitchen/driver/base.rb
+++ b/lib/kitchen/driver/base.rb
@@ -45,7 +45,7 @@ module Kitchen
 
       def validate_config!
         Array(self.class.validations).each do |tuple|
-          tuple.last.call(tuple.first, config[tuple.first])
+          tuple.last.call(tuple.first, config[tuple.first], self)
         end
       end
 
@@ -186,9 +186,10 @@ module Kitchen
         @validations = [] if @validations.nil?
         if ! block_given?
           klass = self
-          block = lambda do |attr, value|
+          block = lambda do |attr, value, driver|
             if value.nil? || value.to_s.empty?
-              raise UserError, "#{klass}#config[:#{attr}] cannot be blank"
+              attribute = "#{klass}#{driver.instance.to_str}#config[:#{attr}]"
+              raise UserError, "#{attribute} cannot be blank"
             end
           end
         end


### PR DESCRIPTION
**Note:** this change does not appear to affect any drivers currently in the wild (using GitHub code search)

---

Now a reference to the driver object will be passed into the block which
helps generate a better default error message and allows for more
complex validation logic (using the new computed defaults).

Before this commit, a Driver author could have custom validation logic
for an attribute with the following:

``` ruby
class Kitchen::Driver::SharkCloud < Kitchen::Driver::SSHBase

  required_config :fonzie do |attribute, value|
    # custom logic...
  end
end
```

With this change you need to pass in one additional argument:

``` ruby
class Kitchen::Driver::SharkCloud < Kitchen::Driver::SSHBase

  required_config :fonzie do |attribute, value, driver|
    # custom logic...
  end
end
```
