### PR TITLE
Fix malformed logger call.

### DIFF
--- a/lib/kitchen/ssh.rb
+++ b/lib/kitchen/ssh.rb
@@ -86,7 +86,7 @@ module Kitchen
     end
 
     def wait
-      logger.log("Waiting for #{hostname}:#{port}...") until test_ssh
+      logger.info("Waiting for #{hostname}:#{port}...") until test_ssh
     end
 
     def login_command


### PR DESCRIPTION
logger.log(level, msg), so this crashes currently. Guess that info is the right level.
