### PR TITLE
Allow chef-solo to use remote_file and other resources through proxy

### DIFF
--- a/lib/kitchen/provisioner/chef_solo.rb
+++ b/lib/kitchen/provisioner/chef_solo.rb
@@ -52,14 +52,16 @@ module Kitchen
         solo << %{file_cache_path "#{home_path}/cache"}
         solo << %{cookbook_path "#{home_path}/cookbooks"}
         solo << %{role_path "#{home_path}/roles"}
-        if config[:chef_http_proxy]
-          solo << %{http_proxy "#{config[:chef_http_proxy]}"}
-        end
-        if config[:chef_https_proxy]
-          solo << %{https_proxy "#{config[:chef_https_proxy]}"}
-        end
-        if config[:chef_no_proxy]
-          solo << %{no_proxy "#{config[:chef_no_proxy]}"}
+        if config[:chef]
+          if config[:chef][:http_proxy]
+            solo << %{http_proxy "#{config[:chef][:http_proxy]}"}
+          end
+          if config[:chef][:https_proxy]
+            solo << %{https_proxy "#{config[:chef][:https_proxy]}"}
+          end
+          if config[:chef][:no_proxy]
+            solo << %{no_proxy "#{config[:chef][:no_proxy]}"}
+          end
         end
         if instance.suite.data_bags_path
           solo << %{data_bag_path "#{home_path}/data_bags"}


### PR DESCRIPTION
Allows passing of http_proxy, https_proxy, and no_proxy variables to the chef-solo solo.rb file by adding the following variables to .kitchen.yml:
    chef_http_proxy: http://myproxy.com:8000
    chef_https_proxy: http://myproxy.com:8000
    chef_no_proxy: "_.internal.corp,10._"
