### PR TITLE
Allow SSH authentication agent to be forwarded to the remote machine

### DIFF
--- a/lib/kitchen/driver/ssh_base.rb
+++ b/lib/kitchen/driver/ssh_base.rb
@@ -91,6 +91,7 @@ module Kitchen
         opts[:user_known_hosts_file] = "/dev/null"
         opts[:paranoid] = false
         opts[:password] = combined[:password] if combined[:password]
+        opts[:forward_agent] = combined[:forward_agent] if combined.key? :forward_agent
         opts[:port] = combined[:port] if combined[:port]
         opts[:keys] = Array(combined[:ssh_key]) if combined[:ssh_key]
         opts[:logger] = logger

--- a/lib/kitchen/ssh.rb
+++ b/lib/kitchen/ssh.rb
@@ -93,6 +93,7 @@ module Kitchen
       args  = %W{ -o UserKnownHostsFile=/dev/null }
       args += %W{ -o StrictHostKeyChecking=no }
       args += %W{ -o LogLevel=#{logger.debug? ? "VERBOSE" : "ERROR"} }
+      args += %W{ -o ForwardAgent=#{options[:forward_agent] ? "yes" : "no"} } if options.key? :forward_agent
       Array(options[:keys]).each { |ssh_key| args += %W{ -i #{ssh_key}} }
       args += %W{ -p #{port}}
       args += %W{ #{username}@#{hostname}}


### PR DESCRIPTION
Optionally adds the "forward agent" flag to either the Net::SSH connection or login-ssh-command.
