### PR TITLE
Use recursive delete instead of massive file list to filter cookbook directories (also, include dotfiles)

### DIFF
--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -170,10 +170,17 @@ module Kitchen
         # Find all files and hidden files but not 'current directory' or
         # parent directory.
 
-        all_files = Dir.glob(File.join(tmpbooks_dir, "*", "*"), File::FNM_DOTMATCH).reject{|f| f =~ /(\/\.\.|\/\.\/|\/\.$)/}
-        cookbook_files = Dir.glob(File.join(tmpbooks_dir, "*", cookbook_files_glob), File::FNM_DOTMATCH).reject{|f| f =~ /(\/\.\.|\/\.\/|\/\.$)/}
+        all_files = Dir.glob(File.join(tmpbooks_dir, "*", "*"), File::FNM_DOTMATCH).reject { |f|
+          f =~ /(\/\.\.|\/\.\/|\/\.$)/
+        }
 
-        (all_files - cookbook_files).each{|f| debug("Removing: " + f) }
+        cookbook_files = Dir.glob(File.join(tmpbooks_dir, "*", cookbook_files_glob), File::FNM_DOTMATCH).reject { |f|
+          f =~ /(\/\.\.|\/\.\/|\/\.$)/
+        }
+
+        (all_files - cookbook_files).each { |f|
+          debug("Removing: " + f)
+        }
 
         FileUtils.rm_r(all_files - cookbook_files)
       end


### PR DESCRIPTION
Currently the code builds an array of all files in each cookbook directory, subtracts all "legitimate" files, and uploads the difference.  In cases where bundle install is being used (such as is often the case with artifact cookbooks), this array can be quite large as it will include the entire vender gems directory.  Also, hidden files and directories are not included, resulting in fatal upload errors if there are symlinks pointing to any files inside hidden directories.

Instead of all this chicanery, this pull request switches to using only auditing the top level directory (including hidden "dot" files), and then doing an rm_r on anything that isn't on the list.
