### PR TITLE
Add config parameter to use a local web proxy (with health checking)

### DIFF
--- a/lib/kitchen/driver/ssh_base.rb
+++ b/lib/kitchen/driver/ssh_base.rb
@@ -16,6 +16,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "net/https"
+require "net/http"
+require "socket"
+require "uri"
+
+PROXY_TIMEOUT = 2
+
 module Kitchen
 
   module Driver
@@ -98,7 +105,95 @@ module Kitchen
         [combined[:hostname], combined[:username], opts]
       end
 
+      def get_local_web_proxy_address
+        port_to_use = 8123 # polipo default... other options are squid default 3128
+        port_to_use = config[:local_web_proxy_port] if config[:local_web_proxy_port]
+
+        # TODO: perhaps return a tuple (i.e. don't format as string)?
+        return "#{local_ip()}:#{port_to_use}"
+      end
+
+      # from http://coderrr.wordpress.com/2008/05/28/get-your-local-ip-address/
+      # returns the host's non-private network IP address
+      def local_ip
+        # turn off reverse DNS resolution temporarily
+        orig = Socket.do_not_reverse_lookup
+        Socket.do_not_reverse_lookup = true
+
+        UDPSocket.open do |s|
+          # ip is for Google
+          s.connect '64.233.187.99', 1
+          s.addr.last
+        end
+      ensure
+        # restore previous setting
+        Socket.do_not_reverse_lookup = orig
+      end
+
+      def web_proxy_health_check(proxy_host, proxy_port, uri)
+        proxy = Net::HTTP::Proxy(proxy_host, proxy_port)
+
+        use_ssl = false
+        verify_mode = nil
+        if uri.scheme == 'https'
+          use_ssl = true
+          verify_mode = OpenSSL::SSL::VERIFY_PEER
+        end
+
+        begin
+          http = proxy.start(
+            uri.host,
+            :use_ssl => use_ssl,
+            :verify_mode => verify_mode)
+          http.open_timeout = PROXY_TIMEOUT
+          http.read_timeout = PROXY_TIMEOUT
+          http_resp = http.get(uri.path)
+        rescue Errno::ECONNREFUSED => e
+          return false
+        rescue Timeout::Error
+          return false
+        end
+
+        if http_resp.code == '200'
+          return true
+        end
+        return false
+      end
+
+      # tests http and https, assumes same server and port
+      def http_and_https_proxy_working?(proxy_address)
+        http_uri = URI('http://www.google.com/')
+        https_uri = URI('https://www.google.com/')
+
+        split_arr = proxy_address.split(':')
+        proxy_host = split_arr[0]
+        proxy_port = split_arr[1]
+
+        puts "in http_and_https_proxy_working:"
+        puts http_success = web_proxy_health_check(proxy_host, proxy_port, http_uri)
+        puts https_success = web_proxy_health_check(proxy_host, proxy_port, https_uri)
+
+        if http_success && https_success
+          return true
+        end
+        return false
+      end
+
       def env_cmd(cmd)
+        if config[:use_local_web_proxy]
+          puts "use_local_web_proxy: option is enabled."
+          proxy_address = get_local_web_proxy_address()
+          if http_and_https_proxy_working?(proxy_address)
+            puts "use_local_web_proxy: proxy is healthy. using it."
+            # TODO: hmm, bad to stomp on this config param?
+            # - not clear that use_local_web_proxy will mess with http/https_proxy?
+            config[:http_proxy] = "http://#{proxy_address}"
+            config[:https_proxy] = "https://#{proxy_address}"
+          else
+            puts "use_local_web_proxy: proxy is not healthy. not using."
+          end
+        end
+
         env = "env"
         env << " http_proxy=#{config[:http_proxy]}"   if config[:http_proxy]
         env << " https_proxy=#{config[:https_proxy]}" if config[:https_proxy]


### PR DESCRIPTION
Adds support for the following new config parameters:

``` text
:use_local_web_proxy (defaults to false)
:local_web_proxy_port (defaults to 8123, polipo default)
```

If :use_local_web_proxy is enabled, the code will attempt to connect to that proxy and verify that it's working. The external address IP address of the host computer is determined by inspecting the default gateway. If it is working it will be used, if it's not working it will be disabled.

http_proxy and https_proxy work well for organizations that run a centralized cache, but don't serve use cases where the developer runs a local cache.

Maximum speed gains are realized by rewriting the urls in the install.sh from https to http to enable caching (proxies that work with SSL content only allow it to pass -- they cannot cache it). See my master branch (aerickson/test-kitchen) for that modification. Ideally the install.sh would just be changed to http links (the advantages of using HTTPS aren't clear).

---

``` yaml
driver_plugin: vagrant
driver_config:
  use_local_web_proxy: true
  # local_web_proxy_port: 3128 # squid default port
```
