### PR TITLE
Multiple arguments to test (verify, converge, etc)

### DIFF
--- a/lib/kitchen/cli.rb
+++ b/lib/kitchen/cli.rb
@@ -105,7 +105,7 @@ module Kitchen
         ensure_initialized
         destroy_mode = options[:destroy].to_sym
         @task = :test
-        results = parse_subcommand(args.first)
+        results = parse_subcommand(args.join('|'))
 
         if options[:parallel]
           run_parallel(results, destroy_mode)


### PR DESCRIPTION
If I want to run kitchen against a couple of specific patterns in a given run, such as:

```
kitchen test test1-ubuntu-1204-chef-1144 test1-centos
```

My expected behavior is that kitchen would test the first one I specified, then any caught via pattern for `test1-centos`.

Apparently it only runs the first argument. Should it allow for multiple arguments?
