### PR TITLE
Include dotfiles in the list of all sandbox files.

### DIFF
--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -167,7 +167,7 @@ module Kitchen
       def filter_only_cookbook_files
         info("Removing non-cookbook files in sandbox")
 
-        all_files = Dir.glob(File.join(tmpbooks_dir, "**/*")).
+        all_files = Dir.glob(File.join(tmpbooks_dir, "**/*"), File::FNM_DOTMATCH).
           select { |fn| File.file?(fn) }
         cookbook_files = Dir.glob(File.join(tmpbooks_dir, cookbook_files_glob)).
           select { |fn| File.file?(fn) }


### PR DESCRIPTION
I'm using librarian-chef with a fairly large set of cookbooks, many of which come from individual git repositories. This means there are lots of .git directories embedded in my cookbooks directory.

Copying the sandbox directory up to the VM with scp takes a while, not least because we're uselessly copying all the git repos.

This change includes dotfiles in the list of all files in the sandbox, so that we clean up git repos (and any other stray dotfiles) before copying everything up to the VM. 
