### PR TITLE
Include VERSION file when copying cookbooks

### DIFF
--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -176,7 +176,7 @@ module Kitchen
       end
 
       def cookbook_files_glob
-        files = %w{README.* metadata.{json,rb}
+        files = %w{README.* VERSION metadata.{json,rb}
           attributes/**/* definitions/**/* files/**/* libraries/**/*
           providers/**/* recipes/**/* resources/**/* templates/**/*
         }
@@ -238,7 +238,7 @@ module Kitchen
             " Please add: `name '<cookbook_name>'` to metadata.rb and retry")
 
         cb_path = File.join(tmpbooks_dir, cb_name)
-        glob = Dir.glob("#{kitchen_root}/{metadata.rb,README.*,definitions," +
+        glob = Dir.glob("#{kitchen_root}/{metadata.rb,README.*,VERSION,definitions," +
           "attributes,files,libraries,providers,recipes,resources,templates}")
 
         FileUtils.mkdir_p(cb_path)


### PR DESCRIPTION
"The Berkshelf way" defines cookbook versions in a VERSION file.
This makes the metadata.rb file contain:

```
IO.read(File.join(File.dirname(__FILE__), 'VERSION'))
```

By default, Berkshelf adds a "rescue '0.1.0'", but this feels wrong
and also makes it impossible to do any kind of "version checking".
