### PR TITLE
relax the celluloid dep by one version

### DIFF
--- a/test-kitchen.gemspec
+++ b/test-kitchen.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 1.9.1'
 
-  gem.add_dependency 'celluloid',       '~> 0.15'
+  gem.add_dependency 'celluloid',       '~> 0.14'
   gem.add_dependency 'mixlib-shellout', '~> 1.2'
   gem.add_dependency 'net-scp',         '~> 1.1'
   gem.add_dependency 'net-ssh',         '~> 2.7'


### PR DESCRIPTION
- berkshelf pulls in ridley which pulls in an overly aggressive
  sperm operator on celluloid:  celluloid (~> 0.14.0)
- since that is incompatible with the celluloid ~> 0.15 constraint
  that creates issues in bundling gems for test setups with
  test-kitchen.
- relaxing the ridley dep is probably the right thing to do, but
  as SV didn't pin TK at ~> 0.15 because 0.14.x was broken, backing
  it off by one should work (and the depsolver must have been using
  this anyway for everyone using TK+berkshelf together)
