### PR TITLE
Issue 212: Stop filtering "non-cookbook" files.

### DIFF
--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -160,28 +160,6 @@ module Kitchen
             " must exist in #{kitchen_root}")
           raise UserError, "Cookbooks could not be found"
         end
-
-        filter_only_cookbook_files
-      end
-
-      def filter_only_cookbook_files
-        info("Removing non-cookbook files in sandbox")
-
-        all_files = Dir.glob(File.join(tmpbooks_dir, "**/*")).
-          select { |fn| File.file?(fn) }
-        cookbook_files = Dir.glob(File.join(tmpbooks_dir, cookbook_files_glob)).
-          select { |fn| File.file?(fn) }
-
-        FileUtils.rm(all_files - cookbook_files)
-      end
-
-      def cookbook_files_glob
-        files = %w{README.* metadata.{json,rb}
-          attributes/**/* definitions/**/* files/**/* libraries/**/*
-          providers/**/* recipes/**/* resources/**/* templates/**/*
-        }
-
-        "*/{#{files.join(',')}}"
       end
 
       def berksfile


### PR DESCRIPTION
Fix for issue #212.  Was originally planning on ignoring the chefignore but after further thought decided that it would be easier to just copy all the things.
