### PR TITLE
avoid wiping the cache every run

### DIFF
--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -63,7 +63,6 @@ module Kitchen
       end
 
       def init_command
-        "#{sudo('rm')} -rf #{home_path}"
       end
 
       def cleanup_sandbox


### PR DESCRIPTION
preserve home_dir/cache so that downloaded files are still present
for the second time through kitchen converge.
