### PR TITLE
Absolute Paths for Suite Data Bags, Roles, and Nodes are Set to Nil

### DIFF
--- a/lib/kitchen/config.rb
+++ b/lib/kitchen/config.rb
@@ -179,22 +179,15 @@ module Kitchen
     end
 
     def calculate_path(path, suite_name, local_path)
-      custom_path     = File.join(kitchen_root, local_path) if local_path
-      suite_path      = File.join(test_base_path, suite_name, path)
-      common_path     = File.join(test_base_path, path)
-      top_level_path  = File.join(Dir.pwd, path)
+      possibles = [].tap do |a|
+        a.push(local_path) if local_path
+        a.push(File.join(kitchen_root, local_path)) if local_path
+        a.push(File.join(test_base_path, suite_name, path))
+        a.push(File.join(test_base_path, path))
+        a.push(File.join(Dir.pwd, path))
+      end.compact
 
-      if custom_path and File.directory?(custom_path)
-        custom_path
-      elsif File.directory?(suite_path)
-        suite_path
-      elsif File.directory?(common_path)
-        common_path
-      elsif File.directory?(top_level_path)
-        top_level_path
-      else
-        nil
-      end
+      possibles.find { |path| File.directory?(path) }
     end
 
     def default_driver_hash

--- a/spec/kitchen/config_spec.rb
+++ b/spec/kitchen/config_spec.rb
@@ -130,6 +130,17 @@ describe Kitchen::Config do
         must_equal "/tmp/base/shared/data_bags"
     end
 
+    it "returns a suite with an absolute data_bags_path set" do
+      stub_data!({ :suites => [{ :name => 'one', :run_list => [],
+        :data_bags_path => '/shared/data_bags' }] })
+      config.kitchen_root = "/tmp/base"
+      FileUtils.mkdir_p "/shared/data_bags"
+      FileUtils.mkdir_p "/tmp/base/shared/data_bags"
+
+      cheflike_suite(config.suites.first).data_bags_path.
+        must_equal "/shared/data_bags"
+    end
+
     it "returns a suite with nil for roles_path by default" do
       stub_data!({ :suites => [{ :name => 'one', :run_list => [] }] })
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,17 +16,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# require 'simplecov'
-# SimpleCov.adapters.define 'gem' do
-#   command_name 'Specs'
+require 'simplecov'
+SimpleCov.adapters.define 'gem' do
+  command_name 'Specs'
 
-#   add_filter '.gem/'
-#   add_filter '/spec/'
-#   add_filter '/lib/vendor/'
+  add_filter '.gem/'
+  add_filter '/spec/'
+  add_filter '/lib/vendor/'
 
-#   add_group 'Libraries', '/lib/'
-# end
-# SimpleCov.start 'gem'
+  add_group 'Libraries', '/lib/'
+end
+SimpleCov.start 'gem'
 
 require 'fakefs/safe'
 require 'minitest/autorun'


### PR DESCRIPTION
I've found that when I place an absolute path for data bags, roles, or nodes in my .kitchen.yml file, it ends up being blank by the time the chef solo provisioner is run.  I've done hacked my local copy of test-kitchen and figured out that that it's getting set to nil the new_suite method at config.rb:77.  Commenting out the relevant entries in the path_hash is my current workaround but this is less than ideal.

Here is an example suite that shows the problem.

```
suites:
- name: default
  run_list: ["recipe[cookbook]"]
  data_bags_path: "/code/chef-data/data_bags"
  attributes: {}
```
