### PR TITLE
add `skip_git` option to Init Generator

### DIFF
--- a/features/kitchen_init_command.feature
+++ b/features/kitchen_init_command.feature
@@ -14,6 +14,7 @@ Feature: Add Test Kitchen support to an existing project
 
   Scenario: Running init with default values
     Given a sandboxed GEM_HOME directory named "kitchen-init"
+    And I have a git repository
     When I run `kitchen init`
     Then the exit status should be 0
     And a directory named ".kitchen" should exist
@@ -72,6 +73,11 @@ Feature: Add Test Kitchen support to an existing project
       puts ">>>>> Kitchen gem not loaded, omitting tasks" unless ENV['CI']
     end
     """
+
+  Scenario: Running without git doesn't make a .gitignore
+    When I successfully run `kitchen init`
+    Then the exit status should be 0
+    And a file named ".gitignore" should not exist
 
   Scenario: Running with a Thorfile file appends Kitchen tasks
     Given an empty file named "Gemfile"

--- a/features/step_definitions/git_steps.rb
+++ b/features/step_definitions/git_steps.rb
@@ -1,0 +1,3 @@
+Given /I have a git repository/ do
+  create_dir('.git')
+end

--- a/lib/kitchen/generator/init.rb
+++ b/lib/kitchen/generator/init.rb
@@ -50,8 +50,10 @@ module Kitchen
         prepare_rakefile if init_rakefile?
         prepare_thorfile if init_thorfile?
         empty_directory "test/integration/default" if init_test_dir?
-        append_to_gitignore(".kitchen/")
-        append_to_gitignore(".kitchen.local.yml")
+        if init_git?
+          append_to_gitignore(".kitchen/")
+          append_to_gitignore(".kitchen.local.yml")
+        end
         prepare_gemfile if init_gemfile?
         add_drivers
 
@@ -94,6 +96,10 @@ module Kitchen
 
       def init_test_dir?
         Dir.glob("test/integration/*").select { |d| File.directory?(d) }.empty?
+      end
+
+      def init_git?
+        File.directory?(File.join(destination_root, '.git'))
       end
 
       def prepare_rakefile


### PR DESCRIPTION
It should be possible to skip manipulating a `.gitignore` file since some users may not be using Git
