### PR TITLE
Read CLI options from kitchen.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,18 @@ your tests in parallel. Trust us, it's faster!
    - `always`: Regardless of the success or failure of the build,
      destroy the machine.
  - `--log-level=debug|info|warn|error|fatal` - Set the log-level of
-     the entire stack, including the chef-solo run. 
+     the entire stack, including the chef-solo run.
+
+You can also specify these switches in the `settings` has in your YAML:
+
+```yaml
+settings:
+  parallel: true
+  destroy: never
+```
+
+Options specified via the CLI still take precedence over options specified
+in the config.
 
 ## The Kitchen YAML format
 

--- a/lib/kitchen/cli.rb
+++ b/lib/kitchen/cli.rb
@@ -103,11 +103,11 @@ module Kitchen
       logger.debug "Starting Kitchen (v#{Kitchen::VERSION})"
       elapsed = Benchmark.measure do
         ensure_initialized
-        destroy_mode = options[:destroy].to_sym
+        destroy_mode = value_for(options[:destroy]).to_sym
         @task = :test
         results = parse_subcommand(args.join('|'))
 
-        if options[:parallel]
+        if value_for(:parallel)
           run_parallel(results, destroy_mode)
         else
           run_serial(results, destroy_mode)
@@ -405,6 +405,16 @@ module Kitchen
           ].join
         },
       ]
+    end
+
+    # Try finding the value for a given option by searching the CLI options,
+    # then the global config.
+    def value_for(key)
+      if options.has_key?(key)
+        options[key]
+      else
+        @config.settings[key]
+      end
     end
   end
 end

--- a/lib/kitchen/config.rb
+++ b/lib/kitchen/config.rb
@@ -72,6 +72,11 @@ module Kitchen
       @instances ||= build_instances
     end
 
+    # Constant/global settings defined in the YAML
+    def settings
+      data[:settings] || {}
+    end
+
     private
 
     def new_suite(hash)


### PR DESCRIPTION
Apologies if this feature is already covered.  If so, it isn't documented in the master README.

I would like the ability to specify the test kitchen CLI options from kitchen.yml.  See [lines 4-5](https://gist.github.com/atomic-penguin/5629656#file-kitchen-yml-L4) in this gist for an example.  In a nutshell, I would prefer not to have to specify `--destroy=never` or `--parallel` on the command line each time.
