### PR TITLE
Add option to run a stanza on a fixed set of platforms

### DIFF
--- a/lib/kitchen/config.rb
+++ b/lib/kitchen/config.rb
@@ -102,14 +102,21 @@ module Kitchen
     end
 
     def build_instances
-      results = []
-      filtered_instances = suites.product(platforms).delete_if do |arr|
-        arr[0].excludes.include?(arr[1].name)
+      filtered = suites.product(platforms).select do |suite, platform|
+        if !suite.includes.empty?
+          suite.includes.include?(platform.name)
+        elsif !suite.excludes.empty?
+          !suite.excludes.include?(platform.name)
+        else
+          true
+        end
       end
-      filtered_instances.each_with_index do |arr, index|
-        results << new_instance(arr[0], arr[1], index)
+
+      instances = filtered.map.with_index do |(suite, platform), index|
+        new_instance(suite, platform, index)
       end
-      Collection.new(results)
+
+      Collection.new(instances)
     end
 
     def new_instance(suite, platform, index)

--- a/lib/kitchen/suite.rb
+++ b/lib/kitchen/suite.rb
@@ -30,6 +30,9 @@ module Kitchen
     # @return [Array] Array of names of excluded platforms
     attr_reader :excludes
 
+    # @return [Array] Array of names of only included platforms
+    attr_reader :includes
+
     # @return [Hash] suite specific driver_config hash
     attr_reader :driver_config
 
@@ -38,12 +41,15 @@ module Kitchen
     # @param [Hash] options configuration for a new suite
     # @option options [String] :name logical name of this suit (**Required**)
     # @option options [String] :excludes Array of names of excluded platforms
+    # @option options [String] :includes Array of names of only included
+    #   platforms
     def initialize(options = {})
       options = options.dup
       validate_options(options)
 
       @name = options.delete(:name)
       @excludes = Array(options[:excludes])
+      @includes = Array(options[:includes])
       @driver_config = options.delete(:driver_config) || {}
       @data = options
     end

--- a/spec/kitchen/suite_spec.rb
+++ b/spec/kitchen/suite_spec.rb
@@ -43,6 +43,10 @@ describe Kitchen::Suite do
       suite.excludes.must_equal Array.new
     end
 
+    it "returns an empty Array given no includes" do
+      suite.includes.must_equal Array.new
+    end
+
     it "returns nil given no data_bags_path" do
       suite.data_bags_path.must_be_nil
     end


### PR DESCRIPTION
The inverse of the existing `excludes` list, for tests that are specifically for a set of platforms.
