### PR TITLE
Fix init generator to simplify YAML

### DIFF
--- a/features/kitchen_init_command.feature
+++ b/features/kitchen_init_command.feature
@@ -109,7 +109,10 @@ Feature: Add Test Kitchen support to an existing project
     Then the file ".kitchen.yml" should contain:
     """
     suites:
-    - name: default
-      run_list: ["recipe[ntp]"]
-      attributes: {}
+      - name: default
+        run_list:
+          - recipe[ntp::default]
+        attributes:
+          ntp:
+            config: value
     """

--- a/lib/kitchen/generator/init.rb
+++ b/lib/kitchen/generator/init.rb
@@ -70,10 +70,11 @@ module Kitchen
         else
           nil
         end
-        run_list = cookbook_name ? "recipe[#{cookbook_name}]" : nil
+        run_list = cookbook_name ? "recipe[#{cookbook_name}::default]" : nil
         driver_plugin = Array(options[:driver]).first || 'dummy'
 
         template("kitchen.yml.erb", ".kitchen.yml", {
+          :cookbook_name => cookbook_name,
           :driver_plugin => driver_plugin.sub(/^kitchen-/, ''),
           :run_list => Array(run_list)
         })

--- a/templates/init/kitchen.yml.erb
+++ b/templates/init/kitchen.yml.erb
@@ -1,27 +1,17 @@
----
 driver_plugin: <%= config[:driver_plugin] %>
 driver_config:
   require_chef_omnibus: true
 
 platforms:
-- name: ubuntu-12.04
-  driver_config:
-    box: opscode-ubuntu-12.04
-    box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/opscode_ubuntu-12.04_provisionerless.box
-- name: ubuntu-10.04
-  driver_config:
-    box: opscode-ubuntu-10.04
-    box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/opscode_ubuntu-10.04_provisionerless.box
-- name: centos-6.4
-  driver_config:
-    box: opscode-centos-6.4
-    box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/opscode_centos-6.4_provisionerless.box
-- name: centos-5.9
-  driver_config:
-    box: opscode-centos-5.9
-    box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/opscode_centos-5.9_provisionerless.box
+  - name: ubuntu-12.04
+  - name: centos-6.4
 
 suites:
-- name: default
-  run_list: <%= config[:run_list].inspect %>
-  attributes: {}
+  - name: default
+    run_list:
+<% config[:run_list].each do |recipe| -%>
+      - <%= recipe %>
+<% end -%>
+    attributes:
+      <%= config[:cookbook_name] %>:
+        config: value


### PR DESCRIPTION
This changes the YAML to use the "default" names and uses an array of recipe names by default:

``` yaml
driver_plugin: vagrant
driver_config:
  require_chef_omnibus: true

platforms:
  - name: ubuntu-12.04
  - name: centos-6.4

suites:
  - name: default
    run_list:
      - recipe[bacon::default]
    attributes:
      bacon:
        key: value
```
