### PR TITLE
Use a configurable glob pattern to select Chef cookbook files.

### DIFF
--- a/test-kitchen.gemspec
+++ b/test-kitchen.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'net-ssh',         '~> 2.7'
   gem.add_dependency 'safe_yaml',       '~> 0.9'
   gem.add_dependency 'thor',            '~> 0.18'
-  gem.add_dependency 'buff-ignore',     '~> 1.1'
 
   gem.add_development_dependency 'bundler',   '~> 1.3'
   gem.add_development_dependency 'rake'


### PR DESCRIPTION
Performing no filtering of cookbooks files leads to very subpar
performance with Librarian-Chef due to its use of `./tmp/` for
calculating cookbook dependenices. Furthermore, if a cookbook was
referenced by `:path` using either Berkshelf or Librarian-Chef then all
dot files (including the `.git/` directory), testing artifacts, and even
the contents of `test/integration/data/` are uploaded to the server
without further work to reduce what is copied across.

Using blacklisting techniques such as a chefignore form opt-in behavior
which leads to slower Test Kitchen runs by default, despite the tool's
ability to determine what Chef repository files are required for
executing a Chef Solo or Client run. This becomes an additional source
of metadata for a new user to learn and manage as the file transfer size
increases over the course of developing new cookbooks and infrastructure
code.

Lastly, this solution can be implemented without an additional gem
dependency which has the potential to have version constraint conflicts
down the road with the larger tooling ecosystem.

There is configurable support for changing this file glob pattern by
adding a `cookbook_files_glob` key/value in a `provisioner` block. For
example, to effectively skip all filtering you could set
`cookbook_files_glob` to `"**/*"` to select all files:

```

---
driver: vagrant

provisioner:
  name: chef_solo
  cookbook_files_glob: "**/*"

platforms:
- name: centos-6.4
- name: ubuntu-10.04

suites:
- name: server
```

References  #211 and #212
