### PR TITLE
Busser Fixes for Greybeard UNIX

### DIFF
--- a/lib/kitchen/busser.rb
+++ b/lib/kitchen/busser.rb
@@ -37,7 +37,7 @@ module Kitchen
     # @option opts [String] :instance_ruby_bindir path to the directory
     #   containing the Ruby binary on the remote instance
     # @option opts [TrueClass, FalseClass] :sudo whether or not to invoke
-    #   sudo before commands requiring root access (default: `true`)
+    #   sudo before commands requiring root access (default: `false`)
     def initialize(suite_name, opts = {})
       validate_options(suite_name)
 
@@ -48,7 +48,7 @@ module Kitchen
       @config[:kitchen_root] = kitchen_root
       @config[:test_base_path] = File.expand_path(test_base_path, kitchen_root)
       @config[:suite_name] = suite_name
-      @config[:sudo] = opts.fetch(:sudo, true)
+      @config[:sudo] = opts.fetch(:sudo, false)
       @config[:ruby_bindir] = opts.fetch(:ruby_bindir, DEFAULT_RUBY_BINDIR)
       @config[:root_path] = opts.fetch(:root_path, DEFAULT_ROOT_PATH)
       @config[:version] = opts.fetch(:version, "busser")


### PR DESCRIPTION
A number of fixes for `Kitchen::Busser` I wound while testing `1.0.0.rc.1` against a network switch which runs a stripped down version of FreeBSD.

Fixes include:
- Busser config key name is `sudo` not `use_sudo`
- Ensure `busser/ruby_bindir` config value is respected
- Ensure `busser/busser_bin` config value is respected
- Remove all newline characters from remote Busser commands (see commit message for in depth explanation).

Here is the `.kitchen.yml` I used in my testing:
https://gist.github.com/schisamo/0b1eb8da5034f85199f0
