### PR TITLE
Make a nicer error on regexp failure

### DIFF
--- a/features/kitchen_list_command.feature
+++ b/features/kitchen_list_command.feature
@@ -55,3 +55,8 @@ Feature: Listing Test Kitchen instances
     When I run `kitchen list freebsd --bare`
     Then the exit status should not be 0
     And the output should contain "No instances for regex `freebsd', try running `kitchen list'"
+
+  Scenario: Listing instances with a bad regular expression
+    When I run `kitchen list *centos* --bare`
+    Then the exit status should not be 0
+    And the output should contain "Invalid Ruby regular expression"

--- a/lib/kitchen/cli.rb
+++ b/lib/kitchen/cli.rb
@@ -308,7 +308,13 @@ module Kitchen
     end
 
     def get_filtered_instances(regexp)
-      result = @config.instances.get_all(/#{regexp}/)
+      result = begin
+        @config.instances.get_all(/#{regexp}/)
+      rescue RegexpError => e
+        die task, "Invalid Ruby regular expression, " +
+          "you may need to single quote the argument. " +
+          "Please try again or consult http://rubular.com/ (#{e.message})"
+      end
 
       if result.empty?
         die task, "No instances for regex `#{regexp}', try running `kitchen list'"


### PR DESCRIPTION
Yes, I had a brain fart where I forgot how to write a regexp... but maybe catch RegexpError and just print "Invalid regex" instead of some weird stacktrack like this:

``` ruby
borkbork ~/devel/gh/juliandunn/chef-client (master *)$ kitchen test *centos*
-----> Starting Kitchen (v1.0.0.rc.1)
/Users/juliandunn/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/test-kitchen-1.0.0.rc.1/lib/kitchen/cli.rb:311:in `get_filtered_instances': target of repeat operator is not specified: /*centos*/ (RegexpError)
    from /Users/juliandunn/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/test-kitchen-1.0.0.rc.1/lib/kitchen/cli.rb:297:in `parse_subcommand'
    from /Users/juliandunn/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/test-kitchen-1.0.0.rc.1/lib/kitchen/cli.rb:111:in `block in test'
    from /Users/juliandunn/.rbenv/versions/1.9.3-p448/lib/ruby/1.9.1/benchmark.rb:280:in `measure'
    from /Users/juliandunn/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/test-kitchen-1.0.0.rc.1/lib/kitchen/cli.rb:107:in `test'
    from /Users/juliandunn/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/thor-0.18.1/lib/thor/command.rb:27:in `run'
    from /Users/juliandunn/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/thor-0.18.1/lib/thor/invocation.rb:120:in `invoke_command'
    from /Users/juliandunn/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/test-kitchen-1.0.0.rc.1/lib/kitchen/cli.rb:258:in `invoke_task'
    from /Users/juliandunn/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/thor-0.18.1/lib/thor.rb:363:in `dispatch'
    from /Users/juliandunn/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/thor-0.18.1/lib/thor/base.rb:439:in `start'
    from /Users/juliandunn/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/test-kitchen-1.0.0.rc.1/bin/kitchen:13:in `block in <top (required)>'
    from /Users/juliandunn/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/test-kitchen-1.0.0.rc.1/lib/kitchen/errors.rb:81:in `with_friendly_errors'
    from /Users/juliandunn/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/test-kitchen-1.0.0.rc.1/bin/kitchen:13:in `<top (required)>'
    from /Users/juliandunn/.rbenv/versions/1.9.3-p448/bin/kitchen:19:in `load'
    from /Users/juliandunn/.rbenv/versions/1.9.3-p448/bin/kitchen:19:in `<main>'
    from /Users/juliandunn/.rbenv/versions/1.9.3-p448/bin/ruby_noexec_wrapper:14:in `eval'
    from /Users/juliandunn/.rbenv/versions/1.9.3-p448/bin/ruby_noexec_wrapper:14:in `<main>'
```
