### PR TITLE
Fix SSH 'Too many authentication failures' error.

### DIFF
--- a/lib/kitchen/driver/ssh_base.rb
+++ b/lib/kitchen/driver/ssh_base.rb
@@ -85,6 +85,7 @@ module Kitchen
         opts = Hash.new
         opts[:user_known_hosts_file] = "/dev/null"
         opts[:paranoid] = false
+        opts[:keys_only] = true if combined[:ssh_key]
         opts[:password] = combined[:password] if combined[:password]
         opts[:forward_agent] = combined[:forward_agent] if combined.key? :forward_agent
         opts[:port] = combined[:port] if combined[:port]

--- a/lib/kitchen/ssh.rb
+++ b/lib/kitchen/ssh.rb
@@ -92,6 +92,7 @@ module Kitchen
     def login_command
       args  = %W{ -o UserKnownHostsFile=/dev/null }
       args += %W{ -o StrictHostKeyChecking=no }
+      args += %W{ -o IdentitiesOnly=yes } if options[:keys]
       args += %W{ -o LogLevel=#{logger.debug? ? "VERBOSE" : "ERROR"} }
       args += %W{ -o ForwardAgent=#{options[:forward_agent] ? "yes" : "no"} } if options.key? :forward_agent
       Array(options[:keys]).each { |ssh_key| args += %W{ -i #{ssh_key}} }


### PR DESCRIPTION
When the system provides an SSH agent, which has many loaded keys, the
SSH client may attempt to use these for authentication before trying
the identity specified by the SSH config or invocation.

This can result in the guest system aborting the connection (due to
too many failed attempts) before the correct key is tried.
