### PR TITLE
Add `json_attributes: true` config option to ChefZero provisioner.

### DIFF
--- a/lib/kitchen/provisioner/chef_zero.rb
+++ b/lib/kitchen/provisioner/chef_zero.rb
@@ -29,6 +29,7 @@ module Kitchen
 
       default_config :client_rb, {}
       default_config :ruby_bindir, "/opt/chef/embedded/bin"
+      default_config :json_attributes, true
 
       def create_sandbox
         create_chef_sandbox do
@@ -62,9 +63,11 @@ module Kitchen
       def run_command
         args = [
           "--config #{config[:root_path]}/client.rb",
-          "--json-attributes #{config[:root_path]}/dna.json",
           "--log_level #{config[:log_level]}"
         ]
+        if config[:json_attributes]
+          args << "--json-attributes #{config[:root_path]}/dna.json"
+        end
 
         if local_mode_supported?
           ["#{sudo('chef-client')} -z"].concat(args).join(" ")


### PR DESCRIPTION
This option allows a user to invoke chef-client without passing the
generated JSON file in the `--json-attributes` option. That way if you
have a JSON definition of your node (including a run-list), the
chef-client run will depend entirely on what is on the "Chef Server".

For example, let's assume we want a node called "mynode" to be in the
"production" chef environment. Given a .kitchen.yml with the following:

```

---
driver:
  name: vagrant

provisioner:
  name: chef_zero
  json_attributes: false
  client_rb:
    node_name: mynode

platforms:
  - name: ubuntu-12.04

suites:
  - name: default
```

and an environment JSON description for our chef environment called
"production" in `test/integration/environments/production.json` that
looks like:

```
{
  "name": "production",
  "default_attributes": {
    "myenv_attr": "Good to be in prod"
  }
}
```

and a node JSON description for our node called "mynode" in
`test/integration/nodes/mynode.json` that looks like:

```
{
  "id": "mynode",
  "chef_environment": "production",
  "run_list": [
    "recipe[nginx]"
  ],
  "normal": {
    "some_attr": "hello"
  },
  "automatic": {
    "ipaddress": "192.168.77.77"
  }
}
```

then the instance will attempt to register with the Chef Zero server as
"mynode" (vs. "default-ubuntu-1204" in this case) and will receive a
run-list of `["recipe[nginx]"]` from the server. Additionally the
following node attributes will be setup:
- `node[:some_attr]` will be set to `"hello"`
- `node[:myenv_attr]` will be set to `"Good to be in prod"`
- `node[:ipaddress]` will be set to `"192.168.77.77"`

Note that the node JSON format assumes a Chef 11 serialized format which
Chef Zero will use under the hood. For more details, please read:

http://docs.opscode.com/essentials_node_object.html
