### PR TITLE
Fix failing minitest test on Windows

### DIFF
--- a/spec/kitchen/loader/yaml_spec.rb
+++ b/spec/kitchen/loader/yaml_spec.rb
@@ -52,7 +52,7 @@ describe Kitchen::Loader::YAML do
     it "sets config_file from parameter, if given" do
       loader = Kitchen::Loader::YAML.new('/tmp/crazyfunkytown.file')
 
-      loader.config_file.must_equal '/tmp/crazyfunkytown.file'
+      loader.config_file.must_match %r{/tmp/crazyfunkytown.file$}
     end
   end
 


### PR DESCRIPTION
The "sets config_file from parameter, if given" test in spec/loader/yaml_spec.rb tests for '/tmp/crazyfunkytown.file'. This fails on Windows because it gets changed to 'C:/tmp/crazyfunkytown.file'.

This PR changes the must_equal to a must_match to make this test pass on Windows.

With this changed all minitest tests pass on Windows :)
