### PR TITLE
Fix Cucumber tests on Windows

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -4,7 +4,9 @@ guard 'minitest' do
   watch(%r|^spec/spec_helper\.rb|)    { "spec" }
 end
 
-guard 'cucumber' do
+cucumber_cli = '--no-profile --color --format progress --strict'
+cucumber_cli += ' --tags ~@spawn' if RUBY_PLATFORM =~ /mswin|mingw|windows/
+guard 'cucumber', cli: cucumber_cli do
   watch(%r{^features/.+\.feature$})
   watch(%r{^features/support/.+$})          { 'features' }
   watch(%r{^features/step_definitions/(.+)_steps\.rb$}) { |m| Dir[File.join("**/#{m[1]}.feature")][0] || 'features' }

--- a/features/kitchen_command.feature
+++ b/features/kitchen_command.feature
@@ -3,6 +3,7 @@ Feature: A command line interface for Test Kitchen
   As a Test Kitchen user
   I want a command line interface that has sane defaults and built in help
 
+  @spawn
   Scenario: Displaying help
     When I run `kitchen help`
     Then the exit status should be 0

--- a/features/kitchen_driver_create_command.feature
+++ b/features/kitchen_driver_create_command.feature
@@ -3,6 +3,7 @@ Feature: Create a new Test Kitchen Driver project
   As a user of Test Kitchen
   I want a command to run that will give me a driver gem project scaffold
 
+  @spawn
   Scenario: Displaying help
     When I run `kitchen help driver create`
     Then the output should contain:

--- a/features/kitchen_driver_discover_command.feature
+++ b/features/kitchen_driver_discover_command.feature
@@ -3,6 +3,7 @@ Feature: Search RubyGems to discover new Test Kitchen Driver gems
   As a Test Kitchen user
   I want to run a command which returns candidate Kitchen drivers
 
+  @spawn
   Scenario: Displaying help
     When I run `kitchen help driver discover`
     Then the output should contain:

--- a/features/kitchen_init_command.feature
+++ b/features/kitchen_init_command.feature
@@ -3,6 +3,7 @@ Feature: Add Test Kitchen support to an existing project
   As an operator
   I want to run a command to initialize my project
 
+  @spawn
   Scenario: Displaying help
     When I run `kitchen help init`
     Then the output should contain:
@@ -12,6 +13,7 @@ Feature: Add Test Kitchen support to an existing project
     """
     And the exit status should be 0
 
+  @spawn
   Scenario: Running init with default values
     Given a sandboxed GEM_HOME directory named "kitchen-init"
     And I have a git repository

--- a/features/kitchen_list_command.feature
+++ b/features/kitchen_list_command.feature
@@ -51,11 +51,13 @@ Feature: Listing Test Kitchen instances
 
     """
 
+  @spawn
   Scenario: Listing instances with a regular expression yielding no results
     When I run `kitchen list freebsd --bare`
     Then the exit status should not be 0
     And the output should contain "No instances for regex `freebsd', try running `kitchen list'"
 
+  @spawn
   Scenario: Listing instances with a bad regular expression
     When I run `kitchen list *centos* --bare`
     Then the exit status should not be 0

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,10 +1,35 @@
 # Set up the environment for testing
 require 'aruba/cucumber'
+require 'aruba/in_process'
+require 'aruba/spawn_process'
 require 'kitchen'
+require 'kitchen/cli'
+
+class ArubaHelper
+  def initialize(argv, stdin=STDIN, stdout=STDOUT, stderr=STDERR, kernel=Kernel)
+    @argv, @stdin, @stdout, @stderr, @kernel = argv, stdin, stdout, stderr, kernel
+  end
+
+  def execute!
+    $stdout = @stdout
+    $stdin = @stdin
+
+    kitchen_cli = Kitchen::CLI
+    kitchen_cli.start(@argv)
+    @kernel.exit(0)
+  end
+end
 
 Before do
   @aruba_timeout_seconds = 15
   @cleanup_dirs = []
+
+  Aruba::InProcess.main_class = ArubaHelper
+  Aruba.process = Aruba::InProcess
+end
+
+Before('@spawn') do
+  Aruba.process = Aruba::SpawnProcess
 end
 
 After do |s|


### PR DESCRIPTION
This PR works around an issue with Aruba on Windows. ChildProcess, one of Aruba's dependencies, has some issues with running batch files on Windows. Ruby executables are wrapped in a batch file so just running the 'kitchen' command in an Aruba run fails.

The workaround I chose is to switch to Aruba::InProcess. This way the CLI get run in the same process as Aruba itself skipping the whole ChildProcess issue. A positive side effect of this is that testing goes a bit faster because it doesn't spawn a process for every test. 

The negative side effect of this is that becauseThor uses $0 as a basename command gets changed to 'cucumber' instead of 'kitchen' in help output. So I've tagged the tests that check for 'kitchen' in the output with @spawn. Another test that installs the kitchen-vagrant plugin also failed with InProcess so I tagged that as well. The @spawn tag uses Aruba::SpawnProcess for the tagged test.
