### PR TITLE
Fixing error when using more than one helper

### DIFF
--- a/lib/kitchen/busser.rb
+++ b/lib/kitchen/busser.rb
@@ -128,7 +128,7 @@ module Kitchen
         sync_cmd << busser_setup_env
         sync_cmd << "#{sudo}#{config[:busser_bin]} suite cleanup"
         sync_cmd << "#{local_suite_files.map { |f| stream_file(f, remote_file(f, config[:suite_name])) }.join("; ")}"
-        sync_cmd << "#{helper_files.map { |f| stream_file(f, remote_file(f, "helpers")) }.join}"
+        sync_cmd << "#{helper_files.map { |f| stream_file(f, remote_file(f, "helpers")) }.join("; ")}"
 
         # use Bourne (/bin/sh) as Bash does not exist on all Unix flavors
         "sh -c '#{sync_cmd.join('; ')}'"


### PR DESCRIPTION
When placing more than one helper in the test/integration/helpers
directory I was receiving the following error:

```
/tmp/busser/gems/gems/busser-0.6.0/lib/busser/command/deserialize.rb:46:in `Integer': invalid value for Integer(): "0664echo" (ArgumentError)
        from
/tmp/busser/gems/gems/busser-0.6.0/lib/busser/command/deserialize.rb:46:in `perform'
        from /tmp/busser/gems/gems/thor-0.18.1/lib/thor/command.rb:27:in `run'
        from
/tmp/busser/gems/gems/thor-0.18.1/lib/thor/invocation.rb:120:in `invoke_command'
        from
/tmp/busser/gems/gems/thor-0.18.1/lib/thor/invocation.rb:127:in `block in invoke_all'
        from
/tmp/busser/gems/gems/thor-0.18.1/lib/thor/invocation.rb:127:in `each'
        from
/tmp/busser/gems/gems/thor-0.18.1/lib/thor/invocation.rb:127:in `map'
        from
/tmp/busser/gems/gems/thor-0.18.1/lib/thor/invocation.rb:127:in `invoke_all'
        from /tmp/busser/gems/gems/thor-0.18.1/lib/thor/group.rb:233:in `dispatch'
        from
/tmp/busser/gems/gems/thor-0.18.1/lib/thor/invocation.rb:109:in `invoke'
        from /tmp/busser/gems/gems/thor-0.18.1/lib/thor.rb:43:in `block in register'
        from /tmp/busser/gems/gems/thor-0.18.1/lib/thor/command.rb:27:in `run'
        from
/tmp/busser/gems/gems/thor-0.18.1/lib/thor/invocation.rb:120:in `invoke_command'
        from /tmp/busser/gems/gems/thor-0.18.1/lib/thor.rb:363:in `dispatch'
        from /tmp/busser/gems/gems/thor-0.18.1/lib/thor/base.rb:439:in `start'
        from /tmp/busser/gems/gems/busser-0.6.0/bin/busser:8:in `<top (required)>'
        from /tmp/busser/gems/bin/busser:23:in `load'
        from /tmp/busser/gems/bin/busser:23:in `<main>'
```

When I add the semicolon to helperfiles line I can use multiple helpers without an error.

I was only able to test again 1.0.0, but when I did it seemed to work.
