### PR TITLE
SSH ENV as hash

### DIFF
--- a/lib/kitchen/driver/ssh_base.rb
+++ b/lib/kitchen/driver/ssh_base.rb
@@ -96,18 +96,17 @@ module Kitchen
         [combined[:hostname], combined[:username], opts]
       end
 
-      def env_cmd(cmd)
-        env = "env"
-        env << " http_proxy=#{config[:http_proxy]}"   if config[:http_proxy]
-        env << " https_proxy=#{config[:https_proxy]}" if config[:https_proxy]
-
-        env == "env" ? cmd : "#{env} #{cmd}"
+      def env
+        [:http_proxy, :https_proxy].reduce(Hash.new) do |env, key|
+          env[key] = config[key] if config[key]
+          env
+        end
       end
 
       def run_remote(command, connection)
         return if command.nil?
 
-        connection.exec(env_cmd(command))
+        connection.exec(command, env)
       rescue SSHFailed, Net::SSH::Exception => ex
         raise ActionFailed, ex.message
       end

--- a/lib/kitchen/ssh.rb
+++ b/lib/kitchen/ssh.rb
@@ -147,17 +147,16 @@ module Kitchen
         channel.request_pty
 
         # NOTE net/ssh warns:
-        #  If you are connecting to an OpenSSH server, you will
-        #  need to update the AcceptEnv setting in the sshd_config to include the
-        #  environment variables you want to send.
-        env.each do |key, value|
-          channel.env(key, value) do |ch, success|
-            logger.debug("Setting remote env #{key}=#{value}")
-            logger.error("Failed to set remote env #{key}=#{value}") unless success
-          end
-        end
+        # If you are connecting to an OpenSSH server, you will
+        # need to update the AcceptEnv setting in the sshd_config to include the
+        # environment variables you want to send.
+        #
+        # This means that we can't use channel#env.
+        # Instead we have to stringify the environment and prepend it to the command
 
         env_string = env.map { |k,v| [k,v].join("=") }.join(" ")
+        debug("Command environment: '#{env_string}'")
+
         env_with_cmd = [env_string, cmd].join(" ")
 
         channel.exec(env_with_cmd) do |ch, success|

--- a/lib/kitchen/ssh.rb
+++ b/lib/kitchen/ssh.rb
@@ -152,12 +152,15 @@ module Kitchen
         #  environment variables you want to send.
         env.each do |key, value|
           channel.env(key, value) do |ch, success|
-            logger.debug("Setting remote env #{key}=#{val}")
-            logger.error("Failed to set remote env #{key}=#{val}") unless success
+            logger.debug("Setting remote env #{key}=#{value}")
+            logger.error("Failed to set remote env #{key}=#{value}") unless success
           end
         end
 
-        channel.exec(cmd) do |ch, success|
+        env_string = env.map { |k,v| [k,v].join("=") }.join(" ")
+        env_with_cmd = [env_string, cmd].join(" ")
+
+        channel.exec(env_with_cmd) do |ch, success|
 
           channel.on_data do |ch, data|
             logger << data


### PR DESCRIPTION
This is the lowest impact way I see to get a better way for managing the remote env.

Sadly, openssh won't let us set the env in the channel like net/ssh warns, so we do have to prepend the variable to the command.

To me, passing env vars prepended as a string is an implementation detail, and having the interface of taking a hash seems nicer. This way, people could even do crazy thing like pass `ENV` from ruby to the remote.

[Here is how I tested this](https://gist.github.com/ChrisLundquist/8051513)

As you can see, setting the env in channel produces our error messages.

The variables are still there though, because we join and prepend the hash in front of the command.

I left the broken ssh variable in channel method there for now mostly as a reminder for people of why we have to prepend it. We can remove it, but I didn't want any one else to waste time duplicated the failed experiment.