### PR TITLE
Use SafeYAML.load to avoid YAML monkeypatch in safe_yaml.

### DIFF
--- a/lib/kitchen/loader/yaml.rb
+++ b/lib/kitchen/loader/yaml.rb
@@ -24,7 +24,7 @@ if RUBY_VERSION <= "1.9.3"
   require 'yaml'
   YAML::ENGINE.yamler = 'psych'
 end
-require 'safe_yaml'
+require 'safe_yaml/load'
 
 module Kitchen
 
@@ -188,7 +188,7 @@ module Kitchen
       def parse_yaml_string(string, file_name)
         return Hash.new if string.nil? || string.empty?
 
-        result = ::YAML.safe_load(string) || Hash.new
+        result = SafeYAML.load(string) || Hash.new
         unless result.is_a?(Hash)
           raise UserError, "Error parsing #{file_name} as YAML " +
             "(Result of parse was not a Hash, but was a #{result.class}).\n" +

--- a/lib/kitchen/state_file.rb
+++ b/lib/kitchen/state_file.rb
@@ -21,7 +21,7 @@ if RUBY_VERSION <= "1.9.3"
   require 'yaml'
   YAML::ENGINE.yamler = 'psych'
 end
-require 'safe_yaml'
+require 'safe_yaml/load'
 
 module Kitchen
 
@@ -91,7 +91,7 @@ module Kitchen
     end
 
     def deserialize_string(string)
-      ::YAML.safe_load(string)
+      SafeYAML.load(string)
     rescue SyntaxError, Psych::SyntaxError => ex
       raise StateFileLoadError, "Error parsing #{file_name} (#{ex.message})"
     end

--- a/spec/kitchen/loader/yaml_spec.rb
+++ b/spec/kitchen/loader/yaml_spec.rb
@@ -340,14 +340,11 @@ describe Kitchen::Loader::YAML do
         "Error parsing /tmp/.kitchen.yml"))
     end
 
-    it "raises a UserError if kitchen.yml is a commented out YAML document" do
+    it "handles a kitchen.yml if it is a commented out YAML document" do
       FileUtils.mkdir_p "/tmp"
-      # this is not technically valid YAML and worse yet returns a Psych::Paser
       File.open("/tmp/.kitchen.yml", "wb") { |f| f.write '#---\n' }
 
-      err = proc { loader.read }.must_raise Kitchen::UserError
-      err.message.must_match Regexp.new(Regexp.escape(
-        "Error parsing /tmp/.kitchen.yml"))
+      loader.read.must_equal(Hash.new)
     end
 
     it "raises a UserError if kitchen.local.yml cannot be parsed" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,18 +35,6 @@ require 'minitest/autorun'
 require 'mocha/setup'
 require 'tempfile'
 
-# enable yaml symbol parsing if code is executing under guard
-if ENV['GUARD_NOTIFY']
-  if RUBY_VERSION <= "1.9.3"
-    # ensure that Psych and not Syck is used for Ruby 1.9.2
-    require 'yaml'
-    YAML::ENGINE.yamler = 'psych'
-  end
-  require 'safe_yaml'
-  YAML.enable_symbol_parsing!
-  SafeYAML::OPTIONS[:suppress_warnings] = true
-end
-
 # Nasty hack to redefine IO.read in terms of File#read for fakefs
 class IO
   def self.read(*args)

--- a/test-kitchen.gemspec
+++ b/test-kitchen.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'mixlib-shellout', '~> 1.2'
   gem.add_dependency 'net-scp',         '~> 1.1'
   gem.add_dependency 'net-ssh',         '~> 2.7'
-  gem.add_dependency 'safe_yaml',       '~> 0.9'
+  gem.add_dependency 'safe_yaml',       '~> 1.0.0rc2'
   gem.add_dependency 'thor',            '~> 0.18'
 
   gem.add_development_dependency 'bundler',   '~> 1.3'


### PR DESCRIPTION
This will leave YAML loading in Test Kitchen as implementation detail
and avoid polluting other Ruby objects.
