### PR TITLE
Allow files in subdirectories in "helpers" directory

### DIFF
--- a/lib/kitchen/busser.rb
+++ b/lib/kitchen/busser.rb
@@ -193,7 +193,7 @@ module Kitchen
     end
 
     def helper_files
-      Dir.glob(File.join(config[:test_base_path], "helpers", "*/**/*"))
+      Dir.glob(File.join(config[:test_base_path], "helpers", "*/**/*")).reject { |f| File.directory?(f) }
     end
 
     def remote_file(file, dir)


### PR DESCRIPTION
This makes it possible to have, for example, a `support` directory in the "helpers" directory.

Closes #312
