### PR TITLE
Fix where instance filter failed if matched with more than one item by regex

### DIFF
--- a/lib/kitchen/command.rb
+++ b/lib/kitchen/command.rb
@@ -68,7 +68,8 @@ module Kitchen
             "you may need to single quote the argument. " +
             "Please try again or consult http://rubular.com/ (#{e.message})"
         end
-        result = Array(result[result.index(regex)]) if result.include?(regexp)
+        result = Array(result)
+        result = result[result.index(regex)] if result.include?(regexp)
 
         if result.empty?
           die "No instances for regex `#{regexp}', try running `kitchen list'"


### PR DESCRIPTION
```
$ kitchen list
Instance                      Driver   Provisioner  Last Action
gdb01-master-ubuntu-1204      Vagrant  ChefSolo     Created
logdb01-master-ubuntu-1204    Vagrant  ChefSolo     Created

$ kitchen login gdb01-master-ubuntu-1204
>>>>>>
Argument `gdb01-master-ubuntu-1204' returned multiple results:
  * gdb01-master-ubuntu-1204
  * logdb01-master-ubuntu-1204

```
