### PR TITLE
Add `start` action to start the instance VM.

### DIFF
--- a/lib/kitchen/cli.rb
+++ b/lib/kitchen/cli.rb
@@ -95,7 +95,7 @@ module Kitchen
       perform("diagnose", "diagnose", args, :loader => @loader)
     end
 
-    [:create, :converge, :setup, :verify, :destroy].each do |action|
+    [:create, :converge, :setup, :verify, :destroy, :start].each do |action|
       desc(
         "#{action} [INSTANCE|REGEXP|all]",
         "#{action.capitalize} one or more instances"

--- a/lib/kitchen/driver/base.rb
+++ b/lib/kitchen/driver/base.rb
@@ -103,6 +103,14 @@ module Kitchen
       # @raise [ActionFailed] if the action could not be completed
       def destroy(state) ; end
 
+      # Starts an instance.
+      #
+      # @param state [Hash] mutable instance and driver state
+      # @raise [ActionFailed] if the action could not be completed
+      def start(state)
+        raise NotImplementedError
+      end
+
       # Returns the shell command that will log into an instance.
       #
       # @param state [Hash] mutable instance and driver state

--- a/lib/kitchen/driver/dummy.rb
+++ b/lib/kitchen/driver/dummy.rb
@@ -52,6 +52,10 @@ module Kitchen
         state.delete(:my_id)
       end
 
+      def start(state)
+        report(:start, state)
+      end
+
       private
 
       def report(action, state)

--- a/lib/kitchen/instance.rb
+++ b/lib/kitchen/instance.rb
@@ -205,6 +205,10 @@ module Kitchen
       result
     end
 
+    def start
+      perform_action(:start, "Starting")
+    end
+
     def last_action
       state_file.read[:last_action]
     end
@@ -289,6 +293,10 @@ module Kitchen
       raise(InstanceFailure, failure_message(what) +
         "  Please see .kitchen/logs/#{self.name}.log for more details",
         e.backtrace)
+    rescue NotImplementedError => e
+      log_failure(what, e)
+      raise ActionFailed,
+        "#{driver.class.name} does not support '#{what}' action"
     rescue Exception => e
       log_failure(what, e)
       raise ActionFailed,

--- a/spec/kitchen/instance_spec.rb
+++ b/spec/kitchen/instance_spec.rb
@@ -720,6 +720,29 @@ describe Kitchen::Instance do
       end
     end
 
+    describe "#start" do
+
+      it "calls Driver#start" do
+        driver.expects(:start).with(Hash.new)
+
+        instance.start
+      end
+
+      it "logs the action start" do
+        instance.start
+
+        logger_io.string.must_match regex_for("Starting #{instance.to_str}")
+      end
+
+      it "logs the action finish" do
+        instance.start
+
+        logger_io.string.
+          must_match regex_for("Finished starting #{instance.to_str}")
+      end
+
+    end
+
     [:create, :converge, :setup, :verify, :test].each do |action|
 
       describe "#{action} on driver crash with ActionFailed" do


### PR DESCRIPTION
Hi, all.

I added `start` action to start the instance VM.
For example, after rebooting host machine, VM of the instance is halted.

```
$ kitchen login default
ssh: connect to host 127.0.0.1 port 2222: Connection refused
```

Because there is no way to start the VM, I added the new action.
You can start the VM like the following:

```
kitchen start default
-----> Starting Kitchen (v1.1.2.dev)
-----> Starting <default-ubuntu-1204>...
       Bringing machine 'default' up with 'virtualbox' provider...
       [default] Clearing any previously set forwarded ports...
       [Berkshelf] Skipping Berkshelf with --no-provision
       [default] Clearing any previously set network interfaces...
       [default] Preparing network interfaces based on configuration...
       [default] Forwarding ports...
       [default] -- 22 => 2222 (adapter 1)
       [default] Running 'pre-boot' VM customizations...
       [default] Booting VM...
       [default] Waiting for machine to boot. This may take a few minutes...
       [default] Machine booted and ready!
       [default] The guest additions on this VM do not match the installed version of
       VirtualBox! In most cases this is fine, but in rare cases it can
       cause things such as shared folders to not work properly. If you see
       shared folder errors, please make sure the guest additions within the
       virtual machine match the version of VirtualBox you have installed on
       your host and reload your VM.

       Guest Additions Version: 4.2.0
       VirtualBox Version: 4.3
       [default] Setting hostname...
       [default] VM already provisioned. Run `vagrant provision` or use `--provision` to force it
       Finished starting <default-ubuntu-1204> (0m15.03s).
-----> Kitchen is finished. (0m15.41s)
```

If the driver does not support `start` action, the user can get messages like the following:

```
$ kitchen start default
-----> Starting Kitchen (v1.1.2.dev)
-----> Starting <default-ubuntu-1204>...
>>>>>> ------Exception-------
>>>>>> Class: Kitchen::ActionFailed
>>>>>> Message: Kitchen::Driver::Vagrant does not support 'start' action
>>>>>> ----------------------
>>>>>> Please see .kitchen/logs/kitchen.log for more details
```

Also, I sent a pull request to `kitchen-vagrant` to support `start` action.
Please see also: test-kitchen/kitchen-vagrant#65