### PR TITLE
Added configurable 'berksfile_path' and 'cheffile_path' options

### DIFF
--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -46,6 +46,16 @@ module Kitchen
       end
       expand_path_for :data_path
 
+      default_config :berksfile_path do |provisioner|
+        provisioner.calculate_path("berksfile")
+      end
+      expand_path_for :berksfile_path
+
+      default_config :cheffile_path do |provisioner|
+        provisioner.calculate_path("cheffile")
+      end
+      expand_path_for :cheffile_path
+
       default_config :data_bags_path do |provisioner|
         provisioner.calculate_path("data_bags")
       end
@@ -278,11 +288,19 @@ module Kitchen
       end
 
       def berksfile
-        File.join(config[:kitchen_root], "Berksfile")
+        if config[:berksfile_path]
+          File.expand_path(config[:berksfile_path])
+        else
+          File.join(config[:kitchen_root], "Berksfile")
+        end
       end
 
       def cheffile
-        File.join(config[:kitchen_root], "Cheffile")
+        if config[:cheffile_path]
+          File.expand_path(config[:cheffile_path])
+        else
+          File.join(config[:kitchen_root], "Cheffile")
+        end
       end
 
       def metadata_rb


### PR DESCRIPTION
Allows users to specify which berksfile/cheffile to use for test kitchen.  Defaults to original values.  This has been helpful when using a chef-repo and each cookbook has its own .kitchen.yml.