### PR TITLE
Added KITCHEN_DIR environ var for shell provider

### DIFF
--- a/lib/kitchen/provisioner/shell.rb
+++ b/lib/kitchen/provisioner/shell.rb
@@ -49,7 +49,7 @@ module Kitchen
       end
 
       def run_command
-        sudo(File.join(config[:root_path], File.basename(config[:script])))
+        "KITCHEN_DIR=#{config[:root_path]} #{sudo(File.join(config[:root_path], File.basename(config[:script])))}"
       end
 
       protected


### PR DESCRIPTION
Added a KITCHEN_DIR variable, instead of hardcoding /tmp/kitchen in bootstrap.sh scripts. Related issue: https://github.com/test-kitchen/test-kitchen/issues/349
