### PR TITLE
Global (aka 'all') suite support

### DIFF
--- a/lib/kitchen/busser.rb
+++ b/lib/kitchen/busser.rb
@@ -95,7 +95,7 @@ module Kitchen
     # @return [String] a command string to setup the test suite, or nil if no
     #   work needs to be performed
     def setup_cmd
-      @setup_cmd ||= if local_suite_files.empty?
+      @setup_cmd ||= if local_suite_files.empty? && all_suite_files.empty?
         nil
       else
         setup_cmd  = []


### PR DESCRIPTION
This adds a special directory -- `test/integration/all` -- that operates as a suite that is the base for all other suites. This allows cookbooks to have specialized suites for recipes and still normalize shared functionality between suites by putting your busser tests and helpers in the `test/integration/all` path just like you would any other suite.

When `test/integration/all` is found, the files are copied from there before copying from anywhere else. This way, a suite may override the given test with a more useful test for that suite, as it will be copied in later. Think class inheritance.

I have also added a few (small) support methods to make some of the more gory bits of path concatenation simpler.

https://github.com/gollector/chef-gollector/tree/master/test/integration is an example of how the tree looks after exploiting this patch. Note that there are no backwards compat problems that I have noticed.

There are no tests AFAICT for the busser functionality touched, or documentation best I can tell. Please inform me if there is a necessity for either.

Thanks!