### PR TITLE
Cascade up the filesystem hierarchy looking for .kitchen.yml files, and then use that as the root.

### DIFF
--- a/lib/kitchen.rb
+++ b/lib/kitchen.rb
@@ -90,6 +90,8 @@ module Kitchen
   DEFAULT_TEST_DIR = "test/integration".freeze
 
   DEFAULT_LOG_DIR = ".kitchen/logs".freeze
+
+  DEFAULT_CONFIG_FILE_NAME = ".kitchen.yml".freeze
 end
 
 # Initialize the base logger

--- a/lib/kitchen/config.rb
+++ b/lib/kitchen/config.rb
@@ -40,7 +40,7 @@ module Kitchen
     # @option options [Symbol] :log_level
     def initialize(options = {})
       @loader         = options.fetch(:loader) { Kitchen::Loader::YAML.new }
-      @kitchen_root   = options.fetch(:kitchen_root) { Dir.pwd }
+      @kitchen_root   = options.fetch(:kitchen_root) { @loader.config_root }
       @log_level      = options.fetch(:log_level) { Kitchen::DEFAULT_LOG_LEVEL }
       @log_root       = options.fetch(:log_root) { default_log_root }
       @test_base_path = options.fetch(:test_base_path) { default_test_base_path }

--- a/lib/kitchen/loader/yaml.rb
+++ b/lib/kitchen/loader/yaml.rb
@@ -55,6 +55,7 @@ module Kitchen
       def initialize(options = {})
         @config_file =
           File.expand_path(options[:project_config] || default_config_file)
+        @config_root = File.dirname(@config_file)
         @local_config_file =
           File.expand_path(options[:local_config] || default_local_config_file)
         @global_config_file =
@@ -92,12 +93,20 @@ module Kitchen
         result
       end
 
+      attr_reader :config_file, :config_root, :local_config_file, :global_config_file
+
       protected
 
-      attr_reader :config_file, :local_config_file, :global_config_file
-
       def default_config_file
-        File.join(Dir.pwd, '.kitchen.yml')
+        pwd = orig_path = Dir.pwd
+
+        while pwd != "/" do
+          qual_path = File.join(pwd, Kitchen::DEFAULT_CONFIG_FILE_NAME)
+          return qual_path if File.exist?(qual_path)
+          pwd = File.dirname(pwd)
+        end
+
+        return File.join(orig_path, Kitchen::DEFAULT_CONFIG_FILE_NAME)
       end
 
       def combined_hash

--- a/spec/kitchen/config_spec.rb
+++ b/spec/kitchen/config_spec.rb
@@ -32,6 +32,9 @@ require 'kitchen/util'
 module Kitchen
 
   class DummyLoader
+    def config_root
+      Dir.pwd
+    end
 
     def read
       @data || Hash.new


### PR DESCRIPTION
Hoping this patch can get in -- if we need to tweak it a little or a lot, I'm happy to make those changes.

The patch allows you to work similar to how bundler works anywhere in the project tree. So, you can be in the `test/` directory, type `bundle exec kitchen converge all -c`, and it just works.

Right now the current solution is to exit with a user error, I think this is a good UI win for a CLI tool.

I might throw some more patches in here surrounding how the `.kitchen` dir gets created (it gets done too early), but please, please open a discussion on how this patch can be made better.

Thanks!
