### PR TITLE
Use Ruby 2.1 instead of 2.1.0 for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,5 +26,3 @@ matrix:
   exclude:
     - rvm: 2.0.0
       env: RUBYGEMS_VERSION=1.8.25
-    - rvm: 2.1.0-preview2
-      env: RUBYGEMS_VERSION=1.8.25


### PR DESCRIPTION
Ruby is now following semver starting with 2.1, and patch versions will use 2.1.1 instead of appending 2.1.0-p1
