### PR TITLE
Use the full path to `chef-solo` and `chef-client`

### DIFF
--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -35,7 +35,7 @@ module Kitchen
 
       default_config :require_chef_omnibus, true
       default_config :chef_omnibus_url, "https://www.getchef.com/chef/install.sh"
-      default_config :chef_root, "/opt/chef"
+      default_config :chef_omnibus_root, "/opt/chef"
       default_config :run_list, []
       default_config :attributes, {}
       default_config :log_file, nil
@@ -157,7 +157,7 @@ module Kitchen
         install_flags = %w[latest true].include?(version) ? "" : "-v #{version}"
 
         <<-INSTALL.gsub(/^ {10}/, "")
-          if should_update_chef "#{chef_root}" "#{version}" ; then
+          if should_update_chef "#{config[:chef_omnibus_root]}" "#{version}" ; then
             echo "-----> Installing Chef Omnibus (#{pretty_version})"
             do_download #{config[:chef_omnibus_url]} /tmp/install.sh
             #{sudo("sh")} /tmp/install.sh #{install_flags}
@@ -358,11 +358,6 @@ module Kitchen
       # @api private
       def tmpsitebooks_dir
         File.join(sandbox_path, "cookbooks")
-      end
-
-      # @return [Pathname]
-      def chef_root
-        @chef_root ||= Pathname.new(config[:chef_root])
       end
 
       # Copies a cookbooks/ directory into the sandbox path.

--- a/lib/kitchen/provisioner/chef_solo.rb
+++ b/lib/kitchen/provisioner/chef_solo.rb
@@ -29,6 +29,10 @@ module Kitchen
 
       default_config :solo_rb, {}
 
+      default_config :chef_solo_path do |provisioner|
+        File.join(provisioner[:chef_omnibus_root], %w[bin chef-solo])
+      end
+
       # (see Base#create_sandbox)
       def create_sandbox
         super
@@ -39,7 +43,7 @@ module Kitchen
       def run_command
         level = config[:log_level] == :info ? :auto : config[:log_level]
 
-        cmd = sudo(chef_root.join("bin", "chef-solo"))
+        cmd = sudo(config[:chef_solo_path])
         args = [
           "--config #{config[:root_path]}/solo.rb",
           "--log_level #{level}",

--- a/lib/kitchen/provisioner/chef_zero.rb
+++ b/lib/kitchen/provisioner/chef_zero.rb
@@ -32,6 +32,10 @@ module Kitchen
       default_config :json_attributes, true
       default_config :chef_zero_port, 8889
 
+      default_config :chef_client_path do |provisioner|
+        File.join(provisioner[:chef_omnibus_root], %w[bin chef-client])
+      end
+
       # (see Base#create_sandbox)
       def create_sandbox
         super
@@ -64,9 +68,9 @@ module Kitchen
       # (see Base#run_command)
       def run_command
         level = config[:log_level] == :info ? :auto : config[:log_level]
-        chef_client_bin = chef_root.join("bin", "chef-client")
+        chef_client_bin = sudo(config[:chef_client_path])
 
-        cmd = modern? ? "#{sudo(chef_client_bin)} --local-mode" : shim_command
+        cmd = modern? ? "#{chef_client_bin} --local-mode" : shim_command
         args = [
           "--config #{config[:root_path]}/client.rb",
           "--log_level #{level}",

--- a/spec/kitchen/provisioner/chef_base_spec.rb
+++ b/spec/kitchen/provisioner/chef_base_spec.rb
@@ -57,6 +57,10 @@ describe Kitchen::Provisioner::ChefBase do
         must_equal "https://www.getchef.com/chef/install.sh"
     end
 
+    it ":chef_omnibus_root has a default" do
+      provisioner[:chef_omnibus_root].must_equal "/opt/chef"
+    end
+
     it ":run_list defaults to an empty array" do
       provisioner[:run_list].must_equal []
     end

--- a/spec/kitchen/provisioner/chef_solo_spec.rb
+++ b/spec/kitchen/provisioner/chef_solo_spec.rb
@@ -47,6 +47,12 @@ describe Kitchen::Provisioner::ChefSolo do
     it "sets :solo_rb to an empty Hash" do
       provisioner[:solo_rb].must_equal Hash.new
     end
+
+    it "sets :chef_solo_path to a path using :chef_omnibus_root" do
+      config[:chef_omnibus_root] = "/nice/place"
+
+      provisioner[:chef_solo_path].must_equal "/nice/place/bin/chef-solo"
+    end
   end
 
   describe "#create_sandbox" do
@@ -229,16 +235,18 @@ describe Kitchen::Provisioner::ChefSolo do
     end
 
     it "uses sudo for chef-solo when configured" do
+      config[:chef_omnibus_root] = "/c"
       config[:sudo] = true
 
-      cmd.must_match regexify("sudo -E /opt/chef/bin/chef-solo ", :partial_line)
+      cmd.must_match regexify("sudo -E /c/bin/chef-solo ", :partial_line)
     end
 
     it "does not use sudo for chef-solo when configured" do
+      config[:chef_omnibus_root] = "/c"
       config[:sudo] = false
 
       cmd.must_match regexify("chef-solo ", :partial_line)
-      cmd.wont_match regexify("sudo -E /opt/chef/bin/chef-solo ", :partial_line)
+      cmd.wont_match regexify("sudo -E /c/bin/chef-solo ", :partial_line)
     end
 
     it "sets config flag on chef-solo" do

--- a/spec/kitchen/provisioner/chef_zero_spec.rb
+++ b/spec/kitchen/provisioner/chef_zero_spec.rb
@@ -48,6 +48,12 @@ describe Kitchen::Provisioner::ChefZero do
       provisioner[:client_rb].must_equal Hash.new
     end
 
+    it "sets :chef_client_path to a path using :chef_omnibus_root" do
+      config[:chef_omnibus_root] = "/nice/place"
+
+      provisioner[:chef_client_path].must_equal "/nice/place/bin/chef-client"
+    end
+
     it "sets :ruby_bindir to use an Omnibus Ruby" do
       provisioner[:ruby_bindir].must_equal "/opt/chef/embedded/bin"
     end
@@ -374,16 +380,18 @@ describe Kitchen::Provisioner::ChefZero do
       end
 
       it "uses sudo for chef-client when configured" do
+        config[:chef_omnibus_root] = "/c"
         config[:sudo] = true
 
-        cmd.must_match regexify("sudo -E /opt/chef/bin/chef-client ", :partial_line)
+        cmd.must_match regexify("sudo -E /c/bin/chef-client ", :partial_line)
       end
 
       it "does not use sudo for chef-client when configured" do
+        config[:chef_omnibus_root] = "/c"
         config[:sudo] = false
 
-        cmd.must_match regexify("/opt/chef/bin/chef-client ", :partial_line)
-        cmd.wont_match regexify("sudo -E /opt/chef/bin/chef-client ", :partial_line)
+        cmd.must_match regexify("/c/bin/chef-client ", :partial_line)
+        cmd.wont_match regexify("sudo -E /c/bin/chef-client ", :partial_line)
       end
 
       it "sets local mode flag on chef-client" do


### PR DESCRIPTION
This fixes a bug where a cookbook (like rbenv, rvm, chruby) sets the default system Ruby. Chruby and RBenv specifically use $PATH munging, making those binaries unavailable on subsequent Test Kitchen runs.

Since other people can "touch" `/usr/local`, assuming the symlinks in `/usr/local/bin` will point to the correct places isn't a valid assumption. I bit myself with this locally when cooking up some magic. I think specifying the full path is the right thing to do.

/cc @schisamo @yzl
