### PR TITLE
Allow configuration for cookbooks and site-cookbooks paths (array of cookbook paths)

### DIFF
--- a/lib/kitchen/data_munger.rb
+++ b/lib/kitchen/data_munger.rb
@@ -86,7 +86,7 @@ module Kitchen
     def convert_legacy_chef_paths_format!
       data.fetch(:suites, []).each do |suite|
         %w{data data_bags encrypted_data_bag_secret_key
-          environments nodes roles}.each do |key|
+          environments nodes roles cookbooks site_cookbooks}.each do |key|
             move_chef_data_to_provisioner_at!(suite, "#{key}_path".to_sym)
         end
       end

--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -310,11 +310,19 @@ module Kitchen
       end
 
       def cookbooks_dir
-        config[:cookbooks_path]
+        if config[:cookbooks_path]
+          File.expand_path(config[:cookbooks_path])
+        else
+          File.join(config[:kitchen_root], "cookbooks")
+        end
       end
 
       def site_cookbooks_dir
-        config[:site_cookbooks_path]
+        if config[:site_cookbooks_path]
+          File.expand_path(config[:site_cookbooks_path])
+        else
+          File.join(config[:kitchen_root], "site-cookbooks")
+        end
       end
 
       def data_bags

--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -310,11 +310,11 @@ module Kitchen
       end
 
       def cookbooks_dir
-        config[:cookbooks]
+        config[:cookbooks_path]
       end
 
       def site_cookbooks_dir
-        config[:site_cookbooks]
+        config[:site_cookbooks_path]
       end
 
       def data_bags

--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -76,6 +76,16 @@ module Kitchen
       end
       expand_path_for :encrypted_data_bag_secret_key_path
 
+      default_config :cookbooks_path do |provisioner|
+        provisioner.calculate_path("cookbooks")
+      end
+      expand_path_for :cookbooks_path
+
+      default_config :site_cookbooks_path do |provisioner|
+        provisioner.calculate_path("site-cookbooks")
+      end
+      expand_path_for :site_cookbooks_path
+
       def install_command
         return unless config[:require_chef_omnibus]
 
@@ -300,11 +310,11 @@ module Kitchen
       end
 
       def cookbooks_dir
-        File.join(config[:kitchen_root], "cookbooks")
+        config[:cookbooks]
       end
 
       def site_cookbooks_dir
-        File.join(config[:kitchen_root], "site-cookbooks")
+        config[:site_cookbooks]
       end
 
       def data_bags

--- a/spec/kitchen/data_munger_spec.rb
+++ b/spec/kitchen/data_munger_spec.rb
@@ -1260,7 +1260,8 @@ module Kitchen
     describe "legacy chef paths from suite" do
 
       LEGACY_CHEF_PATHS = [:data_path, :data_bags_path, :environments_path,
-        :nodes_path, :roles_path, :encrypted_data_bag_secret_key_path]
+        :nodes_path, :roles_path, :encrypted_data_bag_secret_key_path,
+        :cookbooks_path, :site_cookbooks_path]
 
       LEGACY_CHEF_PATHS.each do |key|
 


### PR DESCRIPTION
In our chef-repo we want to be able to keep all our cookbooks under `site-cookbooks/` and have one `Cheffile` to populate the `cookbooks` directory, but have a separate test-kitchen setup for each cookbook. Allowing the cookbooks and site-cookbooks path allows us to achieve this.

For example, my configuration would look something like this:

```
# cookbooks/something/.kitchen.yml
provisioner:
  ...
  cookbooks_path: <%= File.join(ENV['CHEF_REPO'], 'cookbooks') %>
  site_cookbooks_path: <%= File.join(ENV['CHEF_REPO'], 'site-cookbooks') %>
```
