### PR TITLE
Sleep before retrying SSH#establish_connection.

### DIFF
--- a/lib/kitchen/ssh.rb
+++ b/lib/kitchen/ssh.rb
@@ -124,6 +124,7 @@ module Kitchen
       rescue *rescue_exceptions => e
         if (retries -= 1) > 0
           logger.info("[SSH] connection failed, retrying (#{e.inspect})")
+          sleep 1
           retry
         else
           logger.warn("[SSH] connection failed, terminating (#{e.inspect})")


### PR DESCRIPTION
This addresses a race condition where the remote instance might be
restarting its sshd process and is therefore unavailable for a second or
two.
