### PR TITLE
moved the Thor version to rely on '~> 0.19'

### DIFF
--- a/test-kitchen.gemspec
+++ b/test-kitchen.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'net-scp',         '~> 1.1'
   gem.add_dependency 'net-ssh',         '~> 2.7'
   gem.add_dependency 'safe_yaml',       '~> 1.0'
-  gem.add_dependency 'thor',            '~> 0.18'
+  gem.add_dependency 'thor',            '~> 0.19'
 
   gem.add_development_dependency 'bundler',   '~> 1.3'
   gem.add_development_dependency 'rake'


### PR DESCRIPTION
0.18 is now a year old. Moving on to 0.19 should probably be done now. 
