### PR TITLE
Support proxy configurations in Chef provisioners

### DIFF
--- a/lib/kitchen/configurable.rb
+++ b/lib/kitchen/configurable.rb
@@ -299,32 +299,11 @@ module Kitchen
     # rubocop:disable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
     def wrap_shell_code(code)
       env = []
-      if config[:http_proxy]
-        env << shell_env_var("http_proxy", config[:http_proxy])
-        env << shell_env_var("HTTP_PROXY", config[:http_proxy])
-      else
-        export_proxy(env, "http")
-      end
-      if config[:https_proxy]
-        env << shell_env_var("https_proxy", config[:https_proxy])
-        env << shell_env_var("HTTPS_PROXY", config[:https_proxy])
-      else
-        export_proxy(env, "https")
-      end
-      if config[:ftp_proxy]
-        env << shell_env_var("ftp_proxy", config[:ftp_proxy])
-        env << shell_env_var("FTP_PROXY", config[:ftp_proxy])
-      else
-        export_proxy(env, "ftp")
-      end
-      # if http_proxy was set from environment variable or https_proxy was set
-      # from environment variable, or ftp_proxy was set from environment
-      # variable, include no_proxy environment variable, if set.
-      if (!config[:http_proxy] && (ENV["http_proxy"] || ENV["HTTP_PROXY"])) ||
-          (!config[:https_proxy] && (ENV["https_proxy"] || ENV["HTTPS_PROXY"])) ||
-          (!config[:ftp_proxy] && (ENV["ftp_proxy"] || ENV["FTP_PROXY"]))
-        env << shell_env_var("no_proxy", ENV["no_proxy"]) if ENV["no_proxy"]
-        env << shell_env_var("NO_PROXY", ENV["NO_PROXY"]) if ENV["NO_PROXY"]
+      %i(http_proxy https_proxy no_proxy ftp_proxy).each do |type|
+        if config[type]
+          env << shell_env_var(type.to_str, config[type])
+          env << shell_env_var(type.to_str.upcase, config[type])
+        end
       end
       if powershell_shell?
         env.join("\n").concat("\n").concat(code)

--- a/lib/kitchen/driver/ssh_base.rb
+++ b/lib/kitchen/driver/ssh_base.rb
@@ -242,24 +242,12 @@ module Kitchen
       # rubocop:disable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity, Metrics/AbcSize
       def env_cmd(cmd)
         return if cmd.nil?
-        env = "env"
-        http_proxy = config[:http_proxy] || ENV["http_proxy"] ||
-          ENV["HTTP_PROXY"]
-        https_proxy = config[:https_proxy] || ENV["https_proxy"] ||
-          ENV["HTTPS_PROXY"]
-        ftp_proxy = config[:ftp_proxy] || ENV["ftp_proxy"] ||
-          ENV["FTP_PROXY"]
-        no_proxy = if (!config[:http_proxy] && http_proxy) ||
-            (!config[:https_proxy] && https_proxy) ||
-            (!config[:ftp_proxy] && ftp_proxy)
-          ENV["no_proxy"] || ENV["NO_PROXY"]
-        end
-        env << " http_proxy=#{http_proxy}"   if http_proxy
-        env << " https_proxy=#{https_proxy}" if https_proxy
-        env << " ftp_proxy=#{ftp_proxy}"     if ftp_proxy
-        env << " no_proxy=#{no_proxy}"       if no_proxy
-
-        env == "env" ? cmd : "#{env} #{cmd}"
+        env = 'env'
+        env << " http_proxy=#{config[:http_proxy]}"   if config[:http_proxy]
+        env << " https_proxy=#{config[:https_proxy]}" if config[:https_proxy]
+        env << " no_proxy=#{config[:no_proxy]}"       if config[:no_proxy]
+        env << " ftp_proxy=#{config[:ftp_proxy]}"     if config[:ftp_proxy]
+        env == 'env' ? cmd : "#{env} #{cmd}"
       end
 
       # Executes a remote command over SSH.

--- a/lib/kitchen/provisioner/base.rb
+++ b/lib/kitchen/provisioner/base.rb
@@ -31,6 +31,7 @@ module Kitchen
       default_config :http_proxy, nil
       default_config :https_proxy, nil
       default_config :ftp_proxy, nil
+      default_config :no_proxy, nil
 
       default_config :root_path do |provisioner|
         provisioner.windows_os? ? "$env:TEMP\\kitchen" : "/tmp/kitchen"

--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -161,6 +161,7 @@ module Kitchen
           opts[:root] = config[:chef_omnibus_root] if config.key? :chef_omnibus_root
           opts[:http_proxy] = config[:http_proxy] if config.key? :http_proxy
           opts[:https_proxy] = config[:https_proxy] if config.key? :https_proxy
+          opts[:no_proxy] = config[:no_proxy] if config.key? :no_proxy
         end
       end
 
@@ -176,6 +177,21 @@ module Kitchen
       # @api private
       def cheffile
         File.join(config[:kitchen_root], "Cheffile")
+      end
+
+      # Generates a Hash with inherited values from the kitchen.yml configuration.
+      # These are for system options such as proxies, SSL, etc.
+      #
+      # @return [Hash] a configuration hash
+      # @api private
+      def inherited_config_rb
+        Hash.new.tap do |h|
+          h[:http_proxy] = config[:http_proxy] if config[:http_proxy]
+          h[:https_proxy] = config[:https_proxy] if config[:https_proxy]
+          h[:no_proxy] = config[:no_proxy] if config[:no_proxy]
+          h[:ftp_proxy] = config[:ftp_proxy] if config[:ftp_proxy]
+          h[:ssl_verify_mode] = config[:ssl_verify_mode].to_sym if config[:ssl_verify_mode]
+        end
       end
 
       # Generates a Hash with default values for a solo.rb or client.rb Chef
@@ -207,7 +223,7 @@ module Kitchen
           :encrypted_data_bag_secret => remote_path_join(
             root, "encrypted_data_bag_secret"
           )
-        }
+        }.merge(inherited_config_rb)
       end
 
       # Generates a rendered client.rb/solo.rb/knife.rb formatted file as a

--- a/spec/kitchen/driver/ssh_base_spec.rb
+++ b/spec/kitchen/driver/ssh_base_spec.rb
@@ -15,7 +15,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 require_relative "../../spec_helper"
 
 require "kitchen"
@@ -736,7 +735,6 @@ describe Kitchen::Driver::SSHBase do
       connection = mock
       transport.expects(:connection).returns(connection)
       connection.expects(:wait_until_ready)
-
       cmd
     end
   end
@@ -1110,6 +1108,37 @@ describe Kitchen::Driver::SSHBase do
 
         proc { cmd }.must_raise Kitchen::ActionFailed
       end
+    end
+  end
+
+  describe "when setting environment variable for proxies" do
+    let(:config) do
+      {
+        :http_proxy => "proxy.opscode.com:80",
+        :ftp_proxy => "proxy.opscode.com:81",
+        :https_proxy => "proxy.opscode.com:82",
+        :no_proxy => "localhost,127.0.0.1"
+      }
+    end
+
+    let(:driver) do
+      Kitchen::Driver::SSHBase.new(config).finalize_config!(instance)
+    end
+
+    it "driver[:http_proxy] is correct" do
+      driver[:http_proxy].must_equal "proxy.opscode.com:80"
+    end
+
+    it "driver[:ftp_proxy] is correct" do
+      driver[:ftp_proxy].must_equal "proxy.opscode.com:81"
+    end
+
+    it "driver[:https_proxy] is correct" do
+      driver[:https_proxy].must_equal "proxy.opscode.com:82"
+    end
+
+    it "driver[:http_proxy] is correct" do
+      driver[:no_proxy].must_equal "localhost,127.0.0.1"
     end
   end
 end


### PR DESCRIPTION
This patch supports writing out the proxies to the client.rb file (default configuration) for any of the Chef provisioners. It also adds support for the `no_proxy` environment variable. 
