### PR TITLE
Gem runner install driver

### DIFF
--- a/lib/kitchen/generator/init.rb
+++ b/lib/kitchen/generator/init.rb
@@ -183,6 +183,10 @@ module Kitchen
       end
 
       def install_gem(driver_gem)
+        # Temporarily disable safe yaml so installed driver gem matches the expected
+        # gem specification output. This disabling can be removed when TK SafeYAML.load
+        # to avoid YAML monkeypath in safe_yaml by requriring 'safe_yaml/load' in
+        # lib/kitchen/command/driver_discover.rb
         SafeYAML::OPTIONS[:default_mode] = :unsafe
         unbundlerize do
           Gem::GemRunner.new.run(["install", driver_gem])


### PR DESCRIPTION
Fixes https://github.com/opscode/chef-dk/issues/20. Makes driver gems install to the same ruby/gem installation as test-kitchen.
