### PR TITLE
Set compression flag for SSH session.

### DIFF
--- a/lib/kitchen/driver/ssh_base.rb
+++ b/lib/kitchen/driver/ssh_base.rb
@@ -98,6 +98,7 @@ module Kitchen
         opts[:port] = combined[:port] if combined[:port]
         opts[:keys] = Array(combined[:ssh_key]) if combined[:ssh_key]
         opts[:logger] = logger
+        opts[:compression] = true
 
         [combined[:hostname], combined[:username], opts]
       end


### PR DESCRIPTION
Now, compression flag of SSH is dependent on the user configuration such as ssh_config.
It may take some time to transfer the file.


Example: About 100MB file transfer.

```
# case compression=true
real	0m16.905s
user	0m7.740s
sys	0m0.505s

# case compression=false
real	0m46.755s
user	0m3.001s
sys	0m0.401s
```
