### PR TITLE
Add ability to specify custom config template for kitchen init

### DIFF
--- a/lib/kitchen/generator/init.rb
+++ b/lib/kitchen/generator/init.rb
@@ -51,7 +51,8 @@ module Kitchen
         D
 
       def init
-        self.class.source_root(Kitchen.source_root.join("templates", "init"))
+        source_root = find_existing_template_dir || Kitchen.source_root.join("templates", "init")
+        self.class.source_root(source_root)
 
         create_kitchen_yaml
         prepare_rakefile if init_rakefile?
@@ -70,6 +71,15 @@ module Kitchen
       end
 
       private
+      def find_existing_template_dir
+	config_dir = nil
+        Pathname.new(Dir.pwd).ascend do |path|
+	  if File.exists?(File.expand_path('kitchen.yml.erb', path))
+	    config_dir = path
+	  end
+	end
+        config_dir
+      end
 
       def create_kitchen_yaml
         cookbook_name = if File.exists?(File.expand_path('metadata.rb'))

--- a/lib/kitchen/generator/init.rb
+++ b/lib/kitchen/generator/init.rb
@@ -72,12 +72,12 @@ module Kitchen
 
       private
       def find_existing_template_dir
-	config_dir = nil
+        config_dir = nil
         Pathname.new(Dir.pwd).ascend do |path|
-	  if File.exists?(File.expand_path('kitchen.yml.erb', path))
-	    config_dir = path
-	  end
-	end
+          if File.exists?(File.expand_path('kitchen.yml.erb', path))
+            config_dir = path
+          end
+        end
         config_dir
       end
 


### PR DESCRIPTION
This allows you to state configurations in `kitchen.yml.erb` to be used in the templates for `kitchen init`.

I wanted to introduce testing to many different cookbooks without having to edit the `.kitchen.yml` file each time to change the box, box url, or provider type.

The code will ascend the file path until it finds `kitchen.yml.erb` and uses it as the template for creating the `.kitchen.yml` file.