### PR TITLE
Add SSH ProxyCommand functionality

### DIFF
--- a/lib/kitchen/driver/ssh_base.rb
+++ b/lib/kitchen/driver/ssh_base.rb
@@ -230,7 +230,7 @@ module Kitchen
         opts[:keys_only] = true if combined[:ssh_key]
         opts[:password] = combined[:password] if combined[:password]
         opts[:forward_agent] = combined[:forward_agent] if combined.key? :forward_agent
-        opts[:proxy_command] = combined[:proxy_command] if combined[:proxy_command]
+        opts[:proxy_command] = combined[:proxy_command] if combined.key? :proxy_command
         opts[:port] = combined[:port] if combined[:port]
         opts[:keys] = Array(combined[:ssh_key]) if combined[:ssh_key]
         opts[:logger] = logger

--- a/lib/kitchen/driver/ssh_base.rb
+++ b/lib/kitchen/driver/ssh_base.rb
@@ -230,6 +230,7 @@ module Kitchen
         opts[:keys_only] = true if combined[:ssh_key]
         opts[:password] = combined[:password] if combined[:password]
         opts[:forward_agent] = combined[:forward_agent] if combined.key? :forward_agent
+        opts[:proxy_command] = combined[:proxy_command] if combined[:proxy_command]
         opts[:port] = combined[:port] if combined[:port]
         opts[:keys] = Array(combined[:ssh_key]) if combined[:ssh_key]
         opts[:logger] = logger

--- a/lib/kitchen/ssh.rb
+++ b/lib/kitchen/ssh.rb
@@ -16,11 +16,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'logger'
-require 'net/ssh'
-require 'net/scp'
-require 'net/ssh/proxy/command'
-require 'socket'
+require "logger"
+require "net/ssh"
+require "net/scp"
+require "net/ssh/proxy/command"
+require "socket"
 
 require "kitchen/errors"
 require "kitchen/login_command"


### PR DESCRIPTION
Similar to vagrant's `ssh_info[:proxy_command]`, this adds a `:proxy_command` argument for SSH where an SSH proxy is required for a driver to communicate with remote instance(s).

I have tested (and am currently using) this with vagrant driver and vagrant-libvirt plugin where hypervisor is remote and instances live on hypervisor's internal private network.  Another (vagrant-specific) use-case is when `config.ssh.proxy_command` is placed in a user's Vagrantfile (or custom Vagrantfile ERB in kitchen-vagrant's case) to access remote instances when policy or network configuration requires it.
