### PR TITLE
Check for zero byte state files.

### DIFF
--- a/lib/kitchen/state_file.rb
+++ b/lib/kitchen/state_file.rb
@@ -49,7 +49,7 @@ module Kitchen
     # @raise [StateFileLoadError] if there is a problem loading the state file
     #   from disk and loading it into a Hash
     def read
-      if File.exists?(file_name)
+      if File.exists?(file_name) and not File.zero?(file_name)
         Util.symbolized_hash(deserialize_string(read_file))
       else
         Hash.new

--- a/spec/kitchen/state_file_spec.rb
+++ b/spec/kitchen/state_file_spec.rb
@@ -47,6 +47,12 @@ describe Kitchen::StateFile do
       state_file.read.must_equal(Hash.new)
     end
 
+    it "returns and empty hash if the file is zero length" do
+      stub_state_file!('')
+
+      state_file.read.must_equal(Hash.new)
+    end
+
     it "returns a Hash with symbolized keys from the state file" do
       stub_state_file!
 
@@ -72,6 +78,7 @@ describe Kitchen::StateFile do
 
       proc { state_file.read }.must_raise Kitchen::StateFileLoadError
     end
+
   end
 
   describe "#write" do


### PR DESCRIPTION
The read method did not handle zero byte files and would attempt to read the file. This now will overwrite the values should the file be empty. Fixes issue #430.
