### PR TITLE
gem_src: Add gem_source configuration option.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Added gem_source busser processing that updates the gem source used to install busser.  Working with test-kitchen without internet access but with a gem mirror requires some way of specifying the gem source for the busser gem that is installed for verify.  Add "  gem_source: <gem server url>" under busser: in .kitchen.yml to set the gem mirror location.
+
 ## 1.2.1 / 2014-02-12
 
 ### Bug fixes

--- a/lib/kitchen/busser.rb
+++ b/lib/kitchen/busser.rb
@@ -53,6 +53,7 @@ module Kitchen
       @config[:root_path] = opts.fetch(:root_path, DEFAULT_ROOT_PATH)
       @config[:version] = opts.fetch(:version, "busser")
       @config[:busser_bin] = opts.fetch(:busser_bin, File.join(@config[:root_path], "bin/busser"))
+      @config[:gem_source] = opts.fetch(:gem_source, nil)
     end
 
     # Returns the name of this busser, suitable for display in a CLI.
@@ -244,6 +245,7 @@ module Kitchen
       args = gem
       args += " --version #{version}" if version
       args += " --no-rdoc --no-ri"
+      args += " --source #{config[:gem_source]}" if config[:gem_source]
       args
     end
   end


### PR DESCRIPTION
Allow a gem server to be specified for the busser gem install.

When running test-kitchen in an environment without access to rubygems.org I need to be able to specify the gem mirror where busser and related gems may be found. This request adds a gem_source option to the busier config in .kitchen.yml so that the source may be specified.  The config option is appended to the busser gem install command as "--source <gem source>.

Thanks,
  Mark
