### PR TITLE
add puppet to the list of ignored names to allow for a per suite puppet ...

### DIFF
--- a/lib/kitchen/busser.rb
+++ b/lib/kitchen/busser.rb
@@ -224,7 +224,7 @@ module Kitchen
     end
 
     def non_suite_dirs
-      %w{data data_bags environments nodes roles}
+      %w{data data_bags environments nodes roles puppet}
     end
 
     def busser_setup_env


### PR DESCRIPTION
...test configuration

otherwise it fails with at the busser install step:

```
sudo -E ${gem_bindir}/busser setup; sudo -E /tmp/busser/bin/busser plugin install busser-puppet busser-serverspec']
```

I created a workaround with a fake gem https://rubygems.org/gems/busser-puppet
And I think this should be somehow configurable, but can't think of how ...