### PR TITLE
Help update

### DIFF
--- a/lib/kitchen/cli.rb
+++ b/lib/kitchen/cli.rb
@@ -95,11 +95,23 @@ module Kitchen
       perform("diagnose", "diagnose", args, :loader => @loader)
     end
 
-    [:create, :converge, :setup, :verify, :destroy].each do |action|
+    {
+      create:   'Change instance state to create. Start one or more instances',
+      converge: 'Change instance state to converge. Use a provisioner to configure one or more instances',
+      setup:    'Change instance state to setup. Prepare to run automated tests. \
+        Install busser and related gems on one or more instances',
+      verify:   'Change instance state to verify. Run automated tests on one or more instances',
+      destroy:  'Change instance state to destroy. Delete all information for one or more instances'
+    }.each do |action, short_desc|
       desc(
         "#{action} [INSTANCE|REGEXP|all]",
-        "#{action.capitalize} one or more instances"
+        short_desc
       )
+      long_desc <<-DESC
+        The instance states are in order: destroy, create, converge, setup, verify, destroy.
+        Change one or more instances from the current state to the #{action} state. Actions for all
+        intermediate states will be executed. See http://kitchen.ci for further explanation.
+      DESC
       method_option :concurrency, :aliases => "-c",
         :type => :numeric, :lazy_default => MAX_CONCURRENCY,
         :desc => <<-DESC.gsub(/^\s+/, '').gsub(/\n/, ' ')
@@ -119,9 +131,13 @@ module Kitchen
       end
     end
 
-    desc "test [INSTANCE|REGEXP|all]", "Test one or more instances"
+    desc 'test [INSTANCE|REGEXP|all]',
+         'Test (destroy, create, converge, setup, verify and destroy) one or more instances'
     long_desc <<-DESC
-      Test one or more instances
+      The instance states are in order: destroy, create, converge, setup, verify, destroy.
+      Test changes the state of one or more instances to destroyed, then executes
+      the actions for each state up to destroy. At any sign of failure, executing the
+      actions stops and the instance is left in the last successful execution state.
 
       There are 3 post-verify modes for instance cleanup, triggered with
       the `--destroy' flag:


### PR DESCRIPTION
Modified the output of the kitchen help commands for create, converge, setup, verify, destroy and test.  The text in the messages is what I'm using to explain how test kitchen works to test-kitchen beginners.  This update may help cover some of the requests raised in issue #439.
