### PR TITLE
Add SOCKS support to test_ssh

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,13 @@ subcommands and their usage:
 $ kitchen help test
 ```
 
+## Using Test Kitchen from behind a SOCKS proxy
+
+You can specify the following parameters to use Test Kitchen with remote hosts (e.g. EC2) from behind a firewall:
+socks_version = The SOCKS version supported by the server (either 4 or 5)
+socks_server  = The DNS name or IP of the SOCKS server
+socks_port    = The port of the SOCKS server
+
 ## Documentation
 
 Documentation is being added on the Test Kitchen [website][website]. Please

--- a/lib/kitchen/ssh.rb
+++ b/lib/kitchen/ssh.rb
@@ -167,6 +167,25 @@ module Kitchen
     end
 
     def test_ssh
+       # Check to see if we're supposed to proxy the connection to the host
+      if options[:socks_version]
+        require 'socksify'
+
+        unless options[:socks_server]
+          raise ClientError, "Option socks_server must be set when socks_version is set!"
+        end
+
+        unless options[:socks_port]
+          raise ClientError, "Option socks_port must be set when socks_version is set!"
+        end 
+        
+        logger.debug("Using SOCKS proxy (#{options[:socks_server]}:#{options[:socks_port]})")
+
+        TCPSocket::socks_server = options[:socks_server]
+        TCPSocket::socks_port = options[:socks_port]
+        TCPSocket::socks_version = options[:socks_version]
+      end
+      
       socket = TCPSocket.new(hostname, port)
       IO.select([socket], nil, nil, 5)
     rescue SocketError, Errno::ECONNREFUSED,

--- a/test-kitchen.gemspec
+++ b/test-kitchen.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'net-ssh',         '~> 2.7'
   gem.add_dependency 'safe_yaml',       '~> 1.0'
   gem.add_dependency 'thor',            '~> 0.18'
+  gem.add_dependency 'socksify',        '~> 1.5'
 
   gem.add_development_dependency 'bundler',   '~> 1.3'
   gem.add_development_dependency 'rake'


### PR DESCRIPTION
This pull request adds SOCKS support to Test Kitchen, so that you can spin up EC2 instances from behind a firewall.

This is only a 'partial' pull request, it'll need Pull Request #426 to be included, which adds the ability to add a ProxyCommand argument to the SSH command. That pull request won't work with EC2, unless the changes in this pull request are included as well.

This does introduce a dependency on 'socksify'.

Please let me know if this is a viable pull request. We, along with many others in big enterprise land live behind firewalls. Without this, Test Kitchen is not really all that usable to us.