### PR TITLE
Allow chef client testing by installing dev version locally

### DIFF
--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -425,9 +425,9 @@ module Kitchen
           echo "------ Installing gcc so we can build native gems"
           if [ -f /etc/redhat-release -o -f /etc/fedora-release -o -f /etc/system-release ]; then
             #{sudo("yum")} install -y gcc
-          elif [ -f /etc/debian_version ]; then 
+          elif [ -f /etc/debian_version ]; then
             #{sudo("apt-get")} install -y gcc
-          else 
+          else
             echo "Platform not supported, sorry for the inconvenience."
           fi
 


### PR DESCRIPTION
The purpose of this is to create a kind of test harness where you can install a development (not released) version of the chef client from a github location.

It requires an omnibus chef install (for ruby and other dependencies), installs gcc for native extension building, builds a gem from the chef test code and installs this gem into the chef installation.

Example .kitchen.yml snippet config that enables it:

```
provisioner:
  name: chef_solo
  chef_git_hash: 6b463773ffc91056146a59c7e69f14e563821604
  chef_git_url: "github.com/opscode/chef"
```

If the chef_git_hash and chef_git_url entries are NOT there, it will not attempt to install and the existing code will work as before.

Should work with any chef based provisioners, tested with zero and solo. Currently only supports ubuntu and redhat/el based vagrant boxes.
