### PR TITLE
added config option 'chef_path' for chef_solo provisioner to be independ...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,6 @@ tmp
 .rvmrc
 .rbenv-version
 .ruby-version
+.ruby-gemset
 .project
+.idea

--- a/lib/kitchen/logger.rb
+++ b/lib/kitchen/logger.rb
@@ -301,7 +301,15 @@ module Kitchen
       #
       # @param msg [String] a message
       def <<(msg)
-        msg =~ /\n/ ? msg.split("\n").each { |l| format_line(l) } : super
+        @buffer ||= ""
+        lines, _, remainder = msg.rpartition("\n")
+        if lines.empty?
+          @buffer << remainder
+        else
+          lines.insert(0, @buffer)
+          lines.split("\n").each { |l| format_line(l.chomp) }
+          @buffer = ""
+        end
       end
 
       # Log a banner message.

--- a/lib/kitchen/provisioner/chef_solo.rb
+++ b/lib/kitchen/provisioner/chef_solo.rb
@@ -28,6 +28,7 @@ module Kitchen
     class ChefSolo < ChefBase
 
       default_config :solo_rb, {}
+      default_config :chef_path, nil
 
       # (see Base#create_sandbox)
       def create_sandbox
@@ -37,10 +38,17 @@ module Kitchen
 
       # (see Base#run_command)
       def run_command
-        cmd = sudo("chef-solo")
+        level = config[:log_level] == :info ? :auto : config[:log_level]
+
+        cmd = sudo("chef-solo");
+        unless config[:chef_path].nil?
+          cmd = sudo("#{config[:chef_path].gsub(/\/$/,'')}/chef-solo")
+        end
         args = [
           "--config #{config[:root_path]}/solo.rb",
-          "--log_level #{config[:log_level]}",
+          "--log_level #{level}",
+          "--force-formatter",
+          "--no-color",
           "--json-attributes #{config[:root_path]}/dna.json"
         ]
         args << "--logfile #{config[:log_file]}" if config[:log_file]

--- a/lib/kitchen/provisioner/chef_zero.rb
+++ b/lib/kitchen/provisioner/chef_zero.rb
@@ -62,10 +62,14 @@ module Kitchen
 
       # (see Base#run_command)
       def run_command
+        level = config[:log_level] == :info ? :auto : config[:log_level]
+
         cmd = modern? ? "#{sudo("chef-client")} --local-mode" : shim_command
         args = [
           "--config #{config[:root_path]}/client.rb",
-          "--log_level #{config[:log_level]}"
+          "--log_level #{level}",
+          "--force-formatter",
+          "--no-color"
         ]
         if config[:chef_zero_port]
           args <<  "--chef-zero-port #{config[:chef_zero_port]}"

--- a/spec/kitchen/logger_spec.rb
+++ b/spec/kitchen/logger_spec.rb
@@ -193,6 +193,41 @@ describe Kitchen::Logger do
           colorize("       vanilla", opts[:color]) + "\n"
         )
       end
+
+      it "message with line that is not newline terminated will be buffered" do
+        logger << [
+          "-----> banner",
+          "       info",
+          "partial"
+        ].join("\n")
+
+        stdout.string.must_equal(
+          colorize("-----> banner", opts[:color]) + "\n" +
+          colorize("       info", opts[:color]) + "\n"
+        )
+      end
+
+      it "logger with buffered data will flush on next message with newline" do
+        logger << "partial"
+        logger << "ly\nokay\n"
+
+        stdout.string.must_equal(
+          colorize("       partially", opts[:color]) + "\n" +
+          colorize("       okay", opts[:color]) + "\n"
+        )
+      end
+
+      it "logger chomps carriage return characters" do
+        logger << [
+          "-----> banner\r",
+          "vanilla\r"
+        ].join("\n").concat("\n")
+
+        stdout.string.must_equal(
+          colorize("-----> banner", opts[:color]) + "\n" +
+          colorize("       vanilla", opts[:color]) + "\n"
+        )
+      end
     end
   end
 

--- a/spec/kitchen/provisioner/chef_zero_spec.rb
+++ b/spec/kitchen/provisioner/chef_zero_spec.rb
@@ -401,14 +401,22 @@ describe Kitchen::Provisioner::ChefZero do
         cmd.must_match regexify(" --config /a/b/client.rb", :partial_line)
       end
 
-      it "sets log level flag on chef-client" do
-        cmd.must_match regexify(" --log_level info", :partial_line)
+      it "sets log level flag on chef-client to auto by default" do
+        cmd.must_match regexify(" --log_level auto", :partial_line)
       end
 
       it "set log level flag for custom level" do
         config[:log_level] = :extreme
 
         cmd.must_match regexify(" --log_level extreme", :partial_line)
+      end
+
+      it "sets force formatter flag on chef-solo" do
+        cmd.must_match regexify(" --force-formatter", :partial_line)
+      end
+
+      it "sets no color flag on chef-solo" do
+        cmd.must_match regexify(" --no-color", :partial_line)
       end
 
       it "sets chef zero port flag on chef-client" do
@@ -501,14 +509,22 @@ describe Kitchen::Provisioner::ChefZero do
         cmd.must_match regexify(" --config /a/b/client.rb", :partial_line)
       end
 
-      it "sets log level flag on chef-client" do
-        cmd.must_match regexify(" --log_level info", :partial_line)
+      it "sets log level flag on chef-client to auto by default" do
+        cmd.must_match regexify(" --log_level auto", :partial_line)
       end
 
       it "set log level flag for custom level" do
         config[:log_level] = :extreme
 
         cmd.must_match regexify(" --log_level extreme", :partial_line)
+      end
+
+      it "sets force formatter flag on chef-solo" do
+        cmd.must_match regexify(" --force-formatter", :partial_line)
+      end
+
+      it "sets no color flag on chef-solo" do
+        cmd.must_match regexify(" --no-color", :partial_line)
       end
 
       it "sets json attributes flag on chef-client" do

--- a/spec/kitchen/ssh_spec.rb
+++ b/spec/kitchen/ssh_spec.rb
@@ -318,7 +318,7 @@ describe Kitchen::SSH do
     end
 
     before do
-      expect_scp_session("-t /tmp/remote") do |channel|
+      expect_scp_session("-t #{Dir.tmpdir}/remote") do |channel|
         channel.gets_data("\0")
         channel.sends_data("C0755 1234 #{File.basename(src.path)}\n")
         channel.gets_data("\0")
@@ -334,13 +334,13 @@ describe Kitchen::SSH do
 
     it "uploads a file to remote over scp" do
       assert_scripted do
-        ssh.upload!(src.path, "/tmp/remote")
+        ssh.upload!(src.path, "#{Dir.tmpdir}/remote")
       end
     end
 
     it "logs upload progress to debug" do
       assert_scripted do
-        ssh.upload!(src.path, "/tmp/remote")
+        ssh.upload!(src.path, "#{Dir.tmpdir}/remote")
       end
 
       logged_output.string.must_match debug_line(
@@ -366,7 +366,7 @@ describe Kitchen::SSH do
       File.open("#{@dir}/zulu", "wb") { |f| f.write("zulu-contents\n") }
       FileUtils.chmod(0444, "#{@dir}/zulu")
 
-      expect_scp_session("-t -r /tmp/remote") do |channel|
+      expect_scp_session("-t -r #{Dir.tmpdir}/remote") do |channel|
         channel.gets_data("\0")
         channel.sends_data("D0700 0 #{File.basename(@dir)}\n")
         channel.gets_data("\0")
@@ -400,15 +400,15 @@ describe Kitchen::SSH do
 
     it "uploads a file to remote over scp" do
       with_sorted_dir_entries do
-        assert_scripted { ssh.upload_path!(@dir, "/tmp/remote") }
+        assert_scripted { ssh.upload_path!(@dir, "#{Dir.tmpdir}/remote") }
       end
     end
 
     it "logs upload progress to debug" do
-      remote_base = "/tmp/#{File.basename(@dir)}"
+      remote_base = "#{Dir.tmpdir}/#{File.basename(@dir)}"
 
       with_sorted_dir_entries do
-        assert_scripted { ssh.upload_path!(@dir, "/tmp/remote") }
+        assert_scripted { ssh.upload_path!(@dir, "#{Dir.tmpdir}/remote") }
       end
 
       logged_output.string.must_match debug_line(


### PR DESCRIPTION
...ent of target systems $PATH settings.

I had the problem of being forced to use company AMIs for the automation of our chef-server cookbook testbuilds. These AMIs were built with a preinstalled chef 10 into /usr/local/bin. Unfortunately the images cannot be upgraded to chef 11 as there is a vast number of legacy chef-solo scripts that are used by another departement and migration is not an option atm for them.

I Added the config option 'chef_path' for chef_solo provisioner to be independent of target systems $PATH settings. If 2 different chef versions are installed you can now point testkitchen to the binary directory you actually want to use. E.g. chef_path: '/opt/chef/bin' to use omnibus chef-solo instead of the one in /usr/local/bin

Perhaps this can be helpful to others too.
