### PR TITLE
Disable color output when no TTY is present.

### DIFF
--- a/lib/kitchen.rb
+++ b/lib/kitchen.rb
@@ -82,6 +82,14 @@ module Kitchen
       Logger.new(:stdout => $stdout, :logdev => logfile, :level => env_log)
     end
 
+    # Returns whether or not standard output is associated with a terminal
+    # device (tty).
+    #
+    # @return [true,false] is there a tty?
+    def tty?
+      $stdout.tty?
+    end
+
     private
 
     # Determine the default log level from an environment variable, if it is

--- a/lib/kitchen/errors.rb
+++ b/lib/kitchen/errors.rb
@@ -188,8 +188,9 @@ module Kitchen
   # @param lines [Array<String>] an array of strings to log
   # @api private
   def self.stderr_log(lines)
-    Array(lines).each do |line|
-      $stderr.puts(Color.colorize(">>>>>> #{line}", :red))
+    Array(lines).map { |line| ">>>>>> #{line}" }.each do |line|
+      line = Color.colorize(line, :red) if Kitchen.tty?
+      $stderr.puts(line)
     end
   end
 

--- a/lib/kitchen/logger.rb
+++ b/lib/kitchen/logger.rb
@@ -260,8 +260,14 @@ module Kitchen
     # @api private
     def stdout_logger(stdout, color)
       logger = StdoutLogger.new(stdout)
-      logger.formatter = proc do |_severity, _datetime, _progname, msg|
-        Color.colorize("#{msg}", color).concat("\n")
+      if Kitchen.tty?
+        logger.formatter = proc do |_severity, _datetime, _progname, msg|
+          Color.colorize("#{msg}", color).concat("\n")
+        end
+      else
+        logger.formatter = proc do |_severity, _datetime, _progname, msg|
+          msg.concat("\n")
+        end
       end
       logger
     end

--- a/spec/kitchen/errors_spec.rb
+++ b/spec/kitchen/errors_spec.rb
@@ -138,6 +138,7 @@ describe Kitchen do
     let(:logger)    { Kitchen::Logger.new(:logdev => logger_io) }
 
     before do
+      Kitchen.stubs(:tty?).returns(true)
       @orig_stderr = $stderr
       $stderr = StringIO.new
       @orig_logger = Kitchen.logger
@@ -177,6 +178,23 @@ describe Kitchen do
           ">>>>>> Message: no stuff",
           ">>>>>> ----------------------"
         ].map { |l| Kitchen::Color.colorize(l, :red) }.join("\n").concat("\n")
+
+        begin
+          go_boom
+        rescue SystemExit
+          $stderr.string.must_equal output
+        end
+      end
+
+      it "prints a message on STDERR without color" do
+        Kitchen.stubs(:tty?).returns(false)
+        output = [
+          ">>>>>> cannot do that",
+          ">>>>>> ------Exception-------",
+          ">>>>>> Class: IOError",
+          ">>>>>> Message: no stuff",
+          ">>>>>> ----------------------"
+        ].join("\n").concat("\n")
 
         begin
           go_boom
@@ -233,6 +251,24 @@ describe Kitchen do
           ">>>>>> Please see .kitchen/logs/kitchen.log for more details",
           ">>>>>> Also try running `kitchen diagnose --all` for configuration\n"
         ].map { |l| Kitchen::Color.colorize(l, :red) }.join("\n").concat("\n")
+
+        begin
+          go_boom
+        rescue SystemExit
+          $stderr.string.must_equal output
+        end
+      end
+
+      it "prints a message on STDERR without color" do
+        Kitchen.stubs(:tty?).returns(false)
+        output = [
+          ">>>>>> ------Exception-------",
+          ">>>>>> Class: Kitchen::StandardError",
+          ">>>>>> Message: ah crap",
+          ">>>>>> ----------------------",
+          ">>>>>> Please see .kitchen/logs/kitchen.log for more details",
+          ">>>>>> Also try running `kitchen diagnose --all` for configuration"
+        ].join("\n").concat("\n")
 
         begin
           go_boom

--- a/spec/kitchen/logger_spec.rb
+++ b/spec/kitchen/logger_spec.rb
@@ -23,6 +23,7 @@ require "kitchen"
 describe Kitchen::Logger do
 
   before do
+    Kitchen.stubs(:tty?).returns(true)
     @orig_stdout = $stdout
     $stdout = StringIO.new
   end
@@ -108,10 +109,25 @@ describe Kitchen::Logger do
       $stdout.string.must_equal colorize("       hello", opts[:color]) + "\n"
     end
 
+    it "sets up a simple STDOUT logger by default with no color" do
+      Kitchen.stubs(:tty?).returns(false)
+      opts.delete(:stdout)
+      logger.info("hello")
+
+      $stdout.string.must_equal "       hello\n"
+    end
+
     it "accepts a :stdout option to redirect output" do
       logger.info("hello")
 
       stdout.string.must_equal colorize("       hello", opts[:color]) + "\n"
+    end
+
+    it "accepts a :stdout option to redirect output with no color" do
+      Kitchen.stubs(:tty?).returns(false)
+      logger.info("hello")
+
+      stdout.string.must_equal "       hello\n"
     end
 
     describe "for severity" do
@@ -124,10 +140,24 @@ describe Kitchen::Logger do
         stdout.string.must_equal colorize("-----> yo", opts[:color]) + "\n"
       end
 
+      it "logs to banner with no color" do
+        Kitchen.stubs(:tty?).returns(false)
+        logger.banner("yo")
+
+        stdout.string.must_equal "-----> yo\n"
+      end
+
       it "logs to debug" do
         logger.debug("yo")
 
         stdout.string.must_equal colorize("D      yo", opts[:color]) + "\n"
+      end
+
+      it "logs to debug with no color" do
+        Kitchen.stubs(:tty?).returns(false)
+        logger.debug("yo")
+
+        stdout.string.must_equal "D      yo\n"
       end
 
       it "logs to info" do
@@ -136,10 +166,24 @@ describe Kitchen::Logger do
         stdout.string.must_equal colorize("       yo", opts[:color]) + "\n"
       end
 
+      it "logs to info with no color" do
+        Kitchen.stubs(:tty?).returns(false)
+        logger.info("yo")
+
+        stdout.string.must_equal "       yo\n"
+      end
+
       it "logs to error" do
         logger.error("yo")
 
         stdout.string.must_equal colorize(">>>>>> yo", opts[:color]) + "\n"
+      end
+
+      it "logs to error with no color" do
+        Kitchen.stubs(:tty?).returns(false)
+        logger.error("yo")
+
+        stdout.string.must_equal ">>>>>> yo\n"
       end
 
       it "logs to warn" do
@@ -148,16 +192,37 @@ describe Kitchen::Logger do
         stdout.string.must_equal colorize("$$$$$$ yo", opts[:color]) + "\n"
       end
 
+      it "logs to warn with no color" do
+        Kitchen.stubs(:tty?).returns(false)
+        logger.warn("yo")
+
+        stdout.string.must_equal "$$$$$$ yo\n"
+      end
+
       it "logs to fatal" do
         logger.fatal("yo")
 
         stdout.string.must_equal colorize("!!!!!! yo", opts[:color]) + "\n"
       end
 
+      it "logs to fatal with no color" do
+        Kitchen.stubs(:tty?).returns(false)
+        logger.fatal("yo")
+
+        stdout.string.must_equal "!!!!!! yo\n"
+      end
+
       it "logs to unknown" do
         logger.unknown("yo")
 
         stdout.string.must_equal colorize("?????? yo", opts[:color]) + "\n"
+      end
+
+      it "logs to unknown with no color" do
+        Kitchen.stubs(:tty?).returns(false)
+        logger.unknown("yo")
+
+        stdout.string.must_equal "?????? yo\n"
       end
     end
 

--- a/spec/kitchen_spec.rb
+++ b/spec/kitchen_spec.rb
@@ -27,6 +27,7 @@ describe "Kitchen" do
   before do
     FakeFS.activate!
     FileUtils.mkdir_p(Dir.pwd)
+    stdout.stubs(:tty?).returns(true)
     @orig_stdout = $stdout
     $stdout = stdout
   end
@@ -52,6 +53,16 @@ describe "Kitchen" do
       Kitchen::DEFAULT_LOG_DIR.must_equal ".kitchen/logs"
       Kitchen::DEFAULT_LOG_DIR.frozen?.must_equal true
     end
+  end
+
+  it ".tty? returns true if $stdout.tty? is true" do
+    Kitchen.tty?.must_equal true
+  end
+
+  it ".tty? returns flse is $stdout.tty? is false" do
+    stdout.stubs(:tty?).returns(false)
+
+    Kitchen.tty?.must_equal false
   end
 
   it ".source_root returns the root path of the gem" do


### PR DESCRIPTION
This should help clean up kitchen output in CI environments, using
the kitchen command with unix pipes, etc.

In other words:

```
kitchen test | cat
```

Should _not_ output colors.

Currently, the only catch is that colors are still used inside the
instances for tools such as RSpec. This may require work in the Busser
component.

Closes #330
