### PR TITLE
Add ability to download and install chef from GitHub.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,7 @@
 Style/FileName:
   Exclude:
     - 'support/**/*'
+
+Style/ClassLength:
+  Exclude:
+    - 'lib/kitchen/provisioner/chef_base.rb'

--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -148,17 +148,17 @@ module Kitchen
       def chef_install_function
         install_command = install_chef_omnibus
 
-        if config[:git] || config[:github] || config[:branch]
+        if config[:github] || config[:branch]
           chef_src_dir = "/tmp/src/chef"
           chef_install_dir = "/opt/chef"
 
-          git = config[:git] || "github.com/#{config[:github] || 'opscode/chef'}"
+          git = "github.com/#{config[:github] || "opscode/chef"}"
           git = git[0..-5] if git.end_with?(".git")
-          branch = config[:branch] || 'master'
+          branch = config[:branch] || "master"
           url = "https://#{git}/tarball/#{branch}"
 
           install_command << download_chef_from_github(url, chef_src_dir)
-          install_command << get_build_tools
+          install_command << install_build_tools
           install_command << build_and_install_chef_gem(chef_src_dir, chef_install_dir)
         end
 
@@ -184,7 +184,7 @@ module Kitchen
                          end
         install_flags = %w[latest true].include?(version) ? "" : "-v #{version}"
 
-        return <<-INSTALL.gsub(/^ {10}/, "")
+        <<-INSTALL.gsub(/^ {10}/, "")
           if should_update_chef "/opt/chef" "#{version}" ; then
             echo "-----> Installing Chef Omnibus (#{pretty_version})"
             do_download #{config[:chef_omnibus_url]} /tmp/install.sh
@@ -200,7 +200,7 @@ module Kitchen
       # @return [String] shell code
       # @api private
       def download_chef_from_github(url, chef_src_dir)
-        <<-TARBALL.gsub(/^ {10}/, '')
+        <<-TARBALL.gsub(/^ {10}/, "")
           echo "------ Downloading Chef Client source code from GitHub"
           if [ -e /tmp/chef_src.tar.gz ]; then
             #{sudo("rm")} /tmp/chef_src.tar.gz
@@ -229,8 +229,8 @@ module Kitchen
       #
       # @return [String] shell code
       # @api private
-      def get_build_tools
-        <<-BUILDTOOLS.gsub(/^ {10}/, '')
+      def install_build_tools
+        <<-BUILDTOOLS.gsub(/^ {10}/, "")
           echo "------ Installing build tools (gcc, make) to build native gems"
           if exists yum; then
             echo "trying yum..."
@@ -254,7 +254,7 @@ module Kitchen
       # @return [String] shell code
       # @api private
       def build_and_install_chef_gem(chef_src_dir, chef_install_dir)
-        <<-CHEFGEM.gsub(/^ {10}/, '')
+        <<-CHEFGEM.gsub(/^ {10}/, "")
           export chef_bin=/opt/chef/embedded/bin
           export PATH=$chef_bin:$PATH
           #{sudo("chown -R")} $USER #{chef_src_dir}

--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -151,14 +151,7 @@ module Kitchen
         if repo = config[:github]
           chef_src_dir = "/tmp/src/chef"
           chef_install_dir = "/opt/chef"
-
-          unless branch = config[:branch]
-            raise(UserError,
-              "The #{ENV['KITCHEN_YAML'] || '.kitchen.yml'} defines a 'github' key" \
-              " but does not define a 'branch' key." \
-              " Please add: `branch <git_sha>` OR `branch <branch_name>`" \
-              " to your provisioner in #{ENV['KITCHEN_YAML'] || '.kitchen.yml'} and retry.")
-          end
+          branch = config[:branch] || 'master'
 
           install_command << download_chef_from_github(repo, branch, chef_src_dir)
           install_command << get_build_tools

--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -223,6 +223,7 @@ module Kitchen
       # the chef gem from local chef client source code. These tools are:
       # - gcc
       # - make
+      # - git
       #
       # @return [String] shell code
       # @api private
@@ -233,11 +234,13 @@ module Kitchen
             echo "trying yum..."
             #{sudo("yum")} install -qy gcc
             #{sudo("yum")} install -qy make
+            #{sudo("yum")} install -qy git
           elif exists apt-get; then
             echo "trying apt-get..."
             #{sudo("apt-get")} update
             #{sudo("apt-get")} install -qy gcc
             #{sudo("apt-get")} install -qy make
+            #{sudo("apt-get")} install -qy git
           else
             echo ">>>>>> apt-get, yum not found on this instance"
           fi


### PR DESCRIPTION
This replaces https://github.com/test-kitchen/test-kitchen/pull/473, with some minor changes:

* Uses the tag `:github`, instead of `:chef_git_url`, and set `:github "<user>/<repo>"`
* Requires `:branch` key if `:github` key is used. `:branch` can be set to a branch name or commit sha.
* Overrides `:require_chef_omnibus` to `true` when downloading GitHub source code, if set to `false` or `nil`
* Will fail immediately if the source code cannot be downloaded from the generated url or if the chef gem cannot be built.

Works on Ubuntu 12.04 on both vagrant/virtualbox and ec2. Works on CentOS on vagrant/virtualbox and I'm pretty sure ec2, too.

@fnichol, @sethvargo, @sersut, @lamont-granquist, @adamedx, @danielsdeleo

<!---
@huboard:{"order":484.0,"milestone_order":484,"custom_state":""}
-->
