### PR TITLE
get [cannot copy directory to itself] error when following the getting s...

### DIFF
--- a/lib/kitchen/provisioner/base.rb
+++ b/lib/kitchen/provisioner/base.rb
@@ -115,7 +115,7 @@ module Kitchen
       #     end
       #   end
       def create_sandbox
-        @sandbox_path = Dir.mktmpdir("#{instance.name}-sandbox-")
+        @sandbox_path = Dir.mktmpdir("#{instance.name}-sandbox-", "/tmp")
         File.chmod(0755, sandbox_path)
         info("Preparing files for transfer")
         debug("Creating local sandbox in #{sandbox_path}")


### PR DESCRIPTION
`get [cannot copy directory to itself]` error when following the getting started guide, this fixes it.  It was also addressed in the following issue:

https://github.com/test-kitchen/kitchen-openstack/issues/43

Here is the error I got before the fix:

``` text
MacBook-Pro:git-cookbook someone$ kitchen converge -l debug default-centos-64
-----> Starting Kitchen (v1.2.1)
D      [kitchen::driver::vagrant command] BEGIN (vagrant --version)
D      [kitchen::driver::vagrant command] END (0m0.20s)
-----> Converging <default-centos-64>...
D      Creating Vagrantfile for <default-centos-64> (/Users/someone/repos/git-cookbook/.kitchen/kitchen-vagrant/default-centos-64/Vagrantfile)
D      ------------
D      Vagrant.configure("2") do |c|
D        c.vm.box = "opscode-centos-6.4"
D        c.vm.box_url = "https://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-6.4_chef-provisionerless.box"
D        c.vm.hostname = "default-centos-64.vagrantup.com"
D        c.vm.synced_folder ".", "/vagrant", disabled: true
D        c.vm.provider :virtualbox do |p|
D        end
D      end
D      ------------
       Preparing files for transfer
D      Creating local sandbox in /Users/someone/repos/git-cookbook/default-centos-64-sandbox-20140809-97523-qhd3qz
       Preparing current project directory as a cookbook
D      Using metadata.rb from /Users/someone/repos/git-cookbook/metadata.rb
D      Cleaning up local sandbox in /Users/someone/repos/git-cookbook/default-centos-64-sandbox-20140809-97523-qhd3qz
>>>>>> ------Exception-------
>>>>>> Class: Kitchen::ActionFailed
>>>>>> Message: Failed to complete #converge action: [cannot copy directory /Users/someone/repos/git-cookbook/default-centos-64-sandbox-20140809-97523-qhd3qz to itself /Users/someone/repos/git-cookbook/default-centos-64-sandbox-20140809-97523-qhd3qz/cookbooks/git/default-centos-64-sandbox-20140809-97523-qhd3qz]
>>>>>> ----------------------
>>>>>> Please see .kitchen/logs/kitchen.log for more details
>>>>>> Also try running `kitchen diagnose --all` for configuration

D      ------Exception-------
D      Class: Kitchen::ActionFailed
D      Message: Failed to complete #converge action: [cannot copy directory /Users/someone/repos/git-cookbook/default-centos-64-sandbox-20140809-97523-qhd3qz to itself /Users/someone/repos/git-cookbook/default-centos-64-sandbox-20140809-97523-qhd3qz/cookbooks/git/default-centos-64-sandbox-20140809-97523-qhd3qz]
D      ---Nested Exception---
D      Class: ArgumentError
D      Message: cannot copy directory /Users/someone/repos/git-cookbook/default-centos-64-sandbox-20140809-97523-qhd3qz to itself /Users/someone/repos/git-cookbook/default-centos-64-sandbox-20140809-97523-qhd3qz/cookbooks/git/default-centos-64-sandbox-20140809-97523-qhd3qz
D      ------Backtrace-------
D      /Users/someone/.rvm/rubies/ruby-2.0.0-p247/lib/ruby/2.0.0/fileutils.rb:1344:in `copy'
D      /Users/someone/.rvm/rubies/ruby-2.0.0-p247/lib/ruby/2.0.0/fileutils.rb:463:in `block in copy_entry'
D      /Users/someone/.rvm/rubies/ruby-2.0.0-p247/lib/ruby/2.0.0/fileutils.rb:1478:in `call'
D      /Users/someone/.rvm/rubies/ruby-2.0.0-p247/lib/ruby/2.0.0/fileutils.rb:1478:in `wrap_traverse'
D      /Users/someone/.rvm/rubies/ruby-2.0.0-p247/lib/ruby/2.0.0/fileutils.rb:460:in `copy_entry'
D      /Users/someone/.rvm/rubies/ruby-2.0.0-p247/lib/ruby/2.0.0/fileutils.rb:435:in `block in cp_r'
D      /Users/someone/.rvm/rubies/ruby-2.0.0-p247/lib/ruby/2.0.0/fileutils.rb:1551:in `block in fu_each_src_dest'
D      /Users/someone/.rvm/rubies/ruby-2.0.0-p247/lib/ruby/2.0.0/fileutils.rb:1560:in `block in fu_each_src_dest0'
D      /Users/someone/.rvm/rubies/ruby-2.0.0-p247/lib/ruby/2.0.0/fileutils.rb:1558:in `each'
D      /Users/someone/.rvm/rubies/ruby-2.0.0-p247/lib/ruby/2.0.0/fileutils.rb:1558:in `fu_each_src_dest0'
D      /Users/someone/.rvm/rubies/ruby-2.0.0-p247/lib/ruby/2.0.0/fileutils.rb:1549:in `fu_each_src_dest'
D      /Users/someone/.rvm/rubies/ruby-2.0.0-p247/lib/ruby/2.0.0/fileutils.rb:434:in `cp_r'
D      /Users/someone/.rvm/gems/ruby-2.0.0-p247/gems/test-kitchen-1.2.1/lib/kitchen/provisioner/chef_base.rb:378:in `cp_this_cookbook'
D      /Users/someone/.rvm/gems/ruby-2.0.0-p247/gems/test-kitchen-1.2.1/lib/kitchen/provisioner/chef_base.rb:265:in `prepare_cookbooks'
D      /Users/someone/.rvm/gems/ruby-2.0.0-p247/gems/test-kitchen-1.2.1/lib/kitchen/provisioner/chef_base.rb:120:in `create_sandbox'
D      /Users/someone/.rvm/gems/ruby-2.0.0-p247/gems/test-kitchen-1.2.1/lib/kitchen/provisioner/chef_solo.rb:33:in `create_sandbox'
D      /Users/someone/.rvm/gems/ruby-2.0.0-p247/gems/test-kitchen-1.2.1/lib/kitchen/driver/ssh_base.rb:40:in `converge'
D      /Users/someone/.rvm/gems/ruby-2.0.0-p247/gems/kitchen-vagrant-0.15.0/lib/kitchen/driver/vagrant.rb:75:in `converge'
D      /Users/someone/.rvm/gems/ruby-2.0.0-p247/gems/test-kitchen-1.2.1/lib/kitchen/instance.rb:273:in `public_send'
D      /Users/someone/.rvm/gems/ruby-2.0.0-p247/gems/test-kitchen-1.2.1/lib/kitchen/instance.rb:273:in `block in perform_action'
D      /Users/someone/.rvm/gems/ruby-2.0.0-p247/gems/test-kitchen-1.2.1/lib/kitchen/instance.rb:308:in `call'
D      /Users/someone/.rvm/gems/ruby-2.0.0-p247/gems/test-kitchen-1.2.1/lib/kitchen/instance.rb:308:in `synchronize_or_call'
D      /Users/someone/.rvm/gems/ruby-2.0.0-p247/gems/test-kitchen-1.2.1/lib/kitchen/instance.rb:283:in `block in action'
D      /Users/someone/.rvm/rubies/ruby-2.0.0-p247/lib/ruby/2.0.0/benchmark.rb:281:in `measure'
D      /Users/someone/.rvm/gems/ruby-2.0.0-p247/gems/test-kitchen-1.2.1/lib/kitchen/instance.rb:282:in `action'
D      /Users/someone/.rvm/gems/ruby-2.0.0-p247/gems/test-kitchen-1.2.1/lib/kitchen/instance.rb:273:in `perform_action'
D      /Users/someone/.rvm/gems/ruby-2.0.0-p247/gems/test-kitchen-1.2.1/lib/kitchen/instance.rb:256:in `converge_action'
D      /Users/someone/.rvm/gems/ruby-2.0.0-p247/gems/test-kitchen-1.2.1/lib/kitchen/instance.rb:246:in `block in transition_to'
D      /Users/someone/.rvm/gems/ruby-2.0.0-p247/gems/test-kitchen-1.2.1/lib/kitchen/instance.rb:245:in `each'
D      /Users/someone/.rvm/gems/ruby-2.0.0-p247/gems/test-kitchen-1.2.1/lib/kitchen/instance.rb:245:in `transition_to'
D      /Users/someone/.rvm/gems/ruby-2.0.0-p247/gems/test-kitchen-1.2.1/lib/kitchen/instance.rb:119:in `converge'
D      /Users/someone/.rvm/gems/ruby-2.0.0-p247/gems/test-kitchen-1.2.1/lib/kitchen/command.rb:109:in `public_send'
D      /Users/someone/.rvm/gems/ruby-2.0.0-p247/gems/test-kitchen-1.2.1/lib/kitchen/command.rb:109:in `block (2 levels) in run_action'
D      ----------------------
```
