### PR TITLE
Use single quotes in Rake/Thorfile templates

### DIFF
--- a/features/kitchen_init_command.feature
+++ b/features/kitchen_init_command.feature
@@ -164,10 +164,10 @@ Feature: Add Test Kitchen support to an existing project
     Then the file "Rakefile" should contain:
     """
     begin
-      require "kitchen/rake_tasks"
+      require 'kitchen/rake_tasks'
       Kitchen::RakeTasks.new
     rescue LoadError
-      puts ">>>>> Kitchen gem not loaded, omitting tasks" unless ENV["CI"]
+      puts '>>>>> Kitchen gem not loaded, omitting tasks' unless ENV['CI']
     end
     """
 
@@ -183,10 +183,10 @@ Feature: Add Test Kitchen support to an existing project
     Then the file "Thorfile" should contain:
     """
     begin
-      require "kitchen/thor_tasks"
+      require 'kitchen/thor_tasks'
       Kitchen::ThorTasks.new
     rescue LoadError
-      puts ">>>>> Kitchen gem not loaded, omitting tasks" unless ENV["CI"]
+      puts '>>>>> Kitchen gem not loaded, omitting tasks' unless ENV['CI']
     end
     """
 

--- a/lib/kitchen/generator/init.rb
+++ b/lib/kitchen/generator/init.rb
@@ -135,10 +135,10 @@ module Kitchen
         rakedoc = <<-RAKE.gsub(/^ {10}/, "")
 
           begin
-            require "kitchen/rake_tasks"
+            require 'kitchen/rake_tasks'
             Kitchen::RakeTasks.new
           rescue LoadError
-            puts ">>>>> Kitchen gem not loaded, omitting tasks" unless ENV["CI"]
+            puts '>>>>> Kitchen gem not loaded, omitting tasks' unless ENV['CI']
           end
         RAKE
         append_to_file(File.join(destination_root, "Rakefile"), rakedoc)
@@ -153,10 +153,10 @@ module Kitchen
         thordoc = <<-THOR.gsub(/^ {10}/, "")
 
           begin
-            require "kitchen/thor_tasks"
+            require 'kitchen/thor_tasks'
             Kitchen::ThorTasks.new
           rescue LoadError
-            puts ">>>>> Kitchen gem not loaded, omitting tasks" unless ENV["CI"]
+            puts '>>>>> Kitchen gem not loaded, omitting tasks' unless ENV['CI']
           end
         THOR
         append_to_file(File.join(destination_root, "Thorfile"), thordoc)


### PR DESCRIPTION
This fixes issues when running rubocop. See https://github.com/berkshelf/berkshelf/pull/1301