### PR TITLE
Kernel.exec ~ expansion bug

### DIFF
--- a/lib/kitchen/instance.rb
+++ b/lib/kitchen/instance.rb
@@ -197,7 +197,7 @@ module Kitchen
     # @see Driver::Base#login_command
     def login
       login_command = driver.login_command(state_file.read)
-      *cmd = ['sh', '-c']
+      *cmd = ["sh", "-c"]
       *args = login_command.cmd_array
       options = login_command.options
 

--- a/lib/kitchen/instance.rb
+++ b/lib/kitchen/instance.rb
@@ -197,11 +197,12 @@ module Kitchen
     # @see Driver::Base#login_command
     def login
       login_command = driver.login_command(state_file.read)
-      cmd, *args = login_command.cmd_array
+      *cmd = ['sh', '-c']
+      *args = login_command.cmd_array
       options = login_command.options
 
-      debug(%{Login command: #{cmd} #{args.join(" ")} (Options: #{options})})
-      Kernel.exec(cmd, *args, options)
+      debug(%{Login command: #{cmd.join(" ")} #{args.join(" ")} (Options: #{options})})
+      Kernel.exec(*cmd, *args.join(" "), options)
     end
 
     # Executes an arbitrary command on this instance.

--- a/spec/kitchen/instance_spec.rb
+++ b/spec/kitchen/instance_spec.rb
@@ -250,7 +250,7 @@ describe Kitchen::Instance do
   it "#login executes the driver's login_command" do
     driver.stubs(:login_command).with(Hash.new).
       returns(Kitchen::LoginCommand.new(%w[echo hello], :purple => true))
-    Kernel.expects(:exec).with("echo", "hello", :purple => true)
+    Kernel.expects(:exec).with("sh", "-c", "echo hello", :purple => true)
 
     instance.login
   end


### PR DESCRIPTION
When setting an SSH key in .kitchen.yml with a path starting with a ~, Kernel.exec will not expand ~ to $HOME when passed as an element in an Array.
