### PR TITLE
Clarify comments in configuration loader

### DIFF
--- a/lib/kitchen/loader/yaml.rb
+++ b/lib/kitchen/loader/yaml.rb
@@ -115,8 +115,9 @@ module Kitchen
       # 2. local config
       # 3. project config
       #
-      # The merge order is 3 -> 2 -> 1, meaning that the highest number in the
-      # above list has merge precedence over any lower numbered source.
+      # The merge order is project -> local -> global, meaning that elements at
+      # the top of the above list will be merged last, and have greater
+      # precedence than elements at the bottom of the list.
       #
       # @return [Hash] a new merged Hash
       # @api private


### PR DESCRIPTION
The original comment used words like "higher" to mean "physically above another element" and "lower" to mean "physically below another element" but the list was numbered in increasing order, so item 3 was 'lower' than item 2 (isn't that confusing when 3 is lower than 2, but 3 is greater than 2
numerically). This is extremely counterintuitive for people who assume "higher" means "numerically larger/greater", and "lower" means "numerically smaller/less."

This PR changes the comment to use "top" and "bottom" of the list, and avoid descriptions that contrast physical list layout with numerical ordering.
