### PR TITLE
chef-provisioner: add support for site-cookbooks when using Librarian

### DIFF
--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -269,6 +269,7 @@ module Kitchen
           resolve_with_berkshelf
         elsif File.exist?(cheffile)
           resolve_with_librarian
+          cp_site_cookbooks if File.directory?(site_cookbooks_dir)
         elsif File.directory?(cookbooks_dir)
           cp_cookbooks
         elsif File.exist?(metadata_rb)


### PR DESCRIPTION
Please consider this patch for merge. Should this also be implemented for Berkshelf?
