### PR TITLE
Add chef_omnibus_package option

### DIFF
--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -35,6 +35,7 @@ module Kitchen
 
       default_config :require_chef_omnibus, true
       default_config :chef_omnibus_url, "https://www.getchef.com/chef/install.sh"
+      default_config :chef_omnibus_package, nil
       default_config :run_list, []
       default_config :attributes, {}
       default_config :log_file, nil
@@ -148,12 +149,16 @@ module Kitchen
       # @api private
       def chef_install_function
         version = config[:require_chef_omnibus].to_s.downcase
+        package = config[:chef_omnibus_package]
         pretty_version = case version
                          when "true" then "install only if missing"
                          when "latest" then "always install latest version"
                          else version
                          end
-        install_flags = %w[latest true].include?(version) ? "" : "-v #{version}"
+        flags = []
+        flags << "-v #{version}" unless %w[latest true].include?(version)
+        flags << "-P #{package}" unless package.nil?
+        install_flags = flags.join(' ')
 
         <<-INSTALL.gsub(/^ {10}/, "")
           if should_update_chef "/opt/chef" "#{version}" ; then

--- a/spec/kitchen/provisioner/chef_base_spec.rb
+++ b/spec/kitchen/provisioner/chef_base_spec.rb
@@ -57,6 +57,10 @@ describe Kitchen::Provisioner::ChefBase do
         must_equal "https://www.getchef.com/chef/install.sh"
     end
 
+    it ":chef_package defaults to nil" do
+      provision[:chef_omnibus_package].must_eql nil
+    end
+
     it ":run_list defaults to an empty array" do
       provisioner[:run_list].must_equal []
     end
@@ -181,6 +185,14 @@ describe Kitchen::Provisioner::ChefBase do
         "sudo -E sh /tmp/install.sh ")
       provisioner.install_command.must_match regexify(
         "Installing Chef Omnibus (install only if missing)", :partial_line)
+    end
+
+    it "will install a specific chef package, if specified" do
+      config[:require_chef_omnibus] = true
+      config[:chef_omnibus_package] = "angrychef"
+
+      provisioner.install_command.must_match regexify(
+        "sudo -E sh /tmp/install.sh -P angrychef")
     end
   end
 


### PR DESCRIPTION
Add ability for users to specify a specific Chef Omnibus package beyond the regular chef client. Supported values would be anything in the omnitruck API: https://github.com/opscode/opscode-omnitruck
