### PR TITLE
Add support for busser-plugins with versions in config file

### DIFF
--- a/lib/kitchen/busser.rb
+++ b/lib/kitchen/busser.rb
@@ -209,12 +209,11 @@ module Kitchen
     #   config file.
     # @api private
     def plugin_version(plugin_name)
-      version = ''
+      version = ""
       config[:plugins].each do |plugin|
-        p = plugin.split('@')
-        if p[0] == plugin_name && p.length > 1
-          version += "@#{p[1]}"
-        end
+        p = plugin.split("@")
+        next unless p[0] == plugin_name && p.length > 1
+        version += "@#{p[1]}"
       end
       version
     end

--- a/lib/kitchen/busser.rb
+++ b/lib/kitchen/busser.rb
@@ -52,6 +52,7 @@ module Kitchen
       @config[:ruby_bindir] = opts.fetch(:ruby_bindir, DEFAULT_RUBY_BINDIR)
       @config[:root_path] = opts.fetch(:root_path, DEFAULT_ROOT_PATH)
       @config[:version] = opts.fetch(:version, "busser")
+      @config[:plugins] = opts.fetch(:plugins, [])
       @config[:busser_bin] = opts.fetch(:busser_bin, File.join(@config[:root_path], "bin/busser"))
     end
 
@@ -198,7 +199,24 @@ module Kitchen
       glob = File.join(config[:test_base_path], config[:suite_name], "*")
       Dir.glob(glob).reject { |d|
         !File.directory?(d) || non_suite_dirs.include?(File.basename(d))
-      }.map { |d| "busser-#{File.basename(d)}" }.sort.uniq
+      }.map { |d| "busser-#{File.basename(d)}#{plugin_version(File.basename(d))}" }.sort.uniq
+    end
+
+    # Returns a version string for a plugin that will be installed by Busser
+    #
+    # @param plugin_name [String] name of the plugin
+    # @return [String] @version or empty string if no version was set in the
+    #   config file.
+    # @api private
+    def plugin_version(plugin_name)
+      version = ''
+      config[:plugins].each do |plugin|
+        p = plugin.split('@')
+        if p[0] == plugin_name && p.length > 1
+          version += "@#{p[1]}"
+        end
+      end
+      version
     end
 
     # Returns an Array of test suite filenames for the related suite currently

--- a/spec/kitchen/busser_spec.rb
+++ b/spec/kitchen/busser_spec.rb
@@ -52,7 +52,7 @@ describe Kitchen::Busser do
 
   it "#config_keys returns an array of config key names" do
     busser.config_keys.sort.must_equal [
-      :busser_bin, :kitchen_root, :root_path, :ruby_bindir, :sudo,
+      :busser_bin, :kitchen_root, :plugins, :root_path, :ruby_bindir, :sudo,
       :suite_name, :test_base_path, :version
     ]
   end
@@ -92,13 +92,17 @@ describe Kitchen::Busser do
 
       busser[:busser_bin].must_equal "/beep/bin/busser"
     end
+
+    it ":plugins defaults to an empty array" do
+      busser[:plugins].must_equal []
+    end
   end
 
   describe "#diagnose" do
 
     it "returns a hash with sorted keys" do
       busser.diagnose.keys.must_equal [
-        :busser_bin, :kitchen_root, :root_path, :ruby_bindir, :sudo,
+        :busser_bin, :kitchen_root, :plugins, :root_path, :ruby_bindir, :sudo,
         :suite_name, :test_base_path, :version
       ]
     end
@@ -227,6 +231,14 @@ describe Kitchen::Busser do
         cmd.must_match regexify(
           %{sudo -E /b/b plugin install } +
             %{busser-abba busser-minispec busser-mondospec},
+          :partial_line)
+      end
+
+      it "runs busser plugin install with config[:plugins]" do
+        config[:plugins] = ["minispec@1.2.3"]
+
+        cmd.must_match regexify(
+          %{busser-abba busser-minispec@1.2.3 busser-mondospec},
           :partial_line)
       end
     end


### PR DESCRIPTION
Issue reference test-kitchen/test-kitchen#515

Locking busser-plugin versions would reduce failure because of busser-plugin bugs when updated.

```
busser:
  plugins:
    - serverspec@0.2.0
    - rspec@0.7.4
    - minitest
```