### PR TITLE
show hostname and ssh_port at list.

### DIFF
--- a/lib/kitchen/command/list.rb
+++ b/lib/kitchen/command/list.rb
@@ -62,7 +62,8 @@ module Kitchen
           color_pad(instance.name),
           color_pad(instance.driver.name),
           color_pad(instance.provisioner.name),
-          format_last_action(instance.last_action)
+          format_last_action(instance.last_action),
+          *format_connection(instance)
         ]
       end
 
@@ -82,6 +83,21 @@ module Kitchen
         end
       end
 
+      # Format connect infomation the given instance.
+      #
+      # @param [String] instance
+      # @return [Array] hostname and ssh_port
+      def format_connection(instance)
+        if instance.hostname
+          [
+            colorize(instance.hostname, :white),
+            colorize(instance.port || "<Unknown>", :white)
+          ]
+        else
+          [colorize("<Unknown>", :white), colorize("<Unknown>", :white)]
+        end
+      end
+
       # Constructs a list display table and output it to the screen.
       #
       # @param result [Array<Instance>] an array of instances
@@ -90,7 +106,8 @@ module Kitchen
         table = [
           [
             colorize("Instance", :green), colorize("Driver", :green),
-            colorize("Provisioner", :green), colorize("Last Action", :green)
+            colorize("Provisioner", :green), colorize("Last Action", :green),
+            colorize("Hostname", :green), colorize("SSHPort", :green)
           ]
         ]
         table += Array(result).map { |i| display_instance(i) }

--- a/lib/kitchen/instance.rb
+++ b/lib/kitchen/instance.rb
@@ -230,6 +230,14 @@ module Kitchen
       state_file.read[:last_action]
     end
 
+    def hostname
+      state_file.read[:hostname]
+    end
+
+    def port
+      state_file.read[:port]
+    end
+
     private
 
     # @return [StateFile] a state file object that can be read from or written


### PR DESCRIPTION
`kitchen list` shows Hostname and SSHPort if exists.

```
$ kitchen list
Instance             Driver   Provisioner  Last Action  Hostname   SSHPort
default-ubuntu-1204  Vagrant  ChefSolo     Created      <Unknown>  <Unknown>
default-centos-64    Vagrant  ChefSolo     Created      <Unknown>  <Unknown>
```

```
$ kitchen list
Instance             Driver   Provisioner  Last Action  Hostname   SSHPort
default-ubuntu-1204  Vagrant  ChefSolo     Created      127.0.0.1  2201
default-centos-64    Vagrant  ChefSolo     Created      127.0.0.1  2202
```

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/test-kitchen/test-kitchen/519)
<!-- Reviewable:end -->
