### PR TITLE
Add cmd_prefix ssh driver option to allow windows-via-ssh to work

### DIFF
--- a/lib/kitchen/driver/ssh_base.rb
+++ b/lib/kitchen/driver/ssh_base.rb
@@ -147,6 +147,7 @@ module Kitchen
       def run_remote(command, connection)
         return if command.nil?
 
+        command = "#{config[:cmd_prefix]} #{command}" if config[:cmd_prefix]
         connection.exec(env_cmd(command))
       rescue SSHFailed, Net::SSH::Exception => ex
         raise ActionFailed, ex.message

--- a/spec/kitchen/driver/ssh_base_spec.rb
+++ b/spec/kitchen/driver/ssh_base_spec.rb
@@ -357,6 +357,14 @@ describe Kitchen::Driver::SSHBase do
       cmd
     end
 
+    it "invokes the #install_command with :cmd_prefix set" do
+      config[:cmd_prefix] = "my_shell"
+      Kitchen::SSH.stubs(:new).yields(connection)
+      connection.expects(:exec).with("my_shell install")
+
+      cmd
+    end
+
     describe "transferring files" do
 
       before do


### PR DESCRIPTION
A slightly less hacky form of the workaround at http://aespinosa.github.io/blog/2014-05-08-workarounds-to-converge-test-kitchen-on-windows.html, to allow SSH control of windows guests