### PR TITLE
expend version constraint on mixlib-shellout

### DIFF
--- a/test-kitchen.gemspec
+++ b/test-kitchen.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 1.9.1"
 
-  gem.add_dependency "mixlib-shellout", ">= 1.2", "<= 3.0"
+  gem.add_dependency "mixlib-shellout", ">= 1.2", "< 3.0"
   gem.add_dependency "net-scp",         "~> 1.1"
   gem.add_dependency "net-ssh",         "~> 2.7"
   gem.add_dependency "safe_yaml",       "~> 1.0"


### PR DESCRIPTION
the change for mixlib-shellout 2.0 drops the forcing of LC_ALL=C
which breaks UTF-8 encoding, so this is probably a good thing for
test-kitchen, but in the absense of any bug reports about encoding
problems with test-kitchen the mixlib-shellout 1.x branch still
works fine for most users so there's no need to raise the floor.
