### PR TITLE
Die on `kitchen login` if instance is not created.

### DIFF
--- a/features/kitchen_login_command.feature
+++ b/features/kitchen_login_command.feature
@@ -20,11 +20,21 @@ Feature: Logging into a Kitchen instance
       - name: default
       - name: full
     """
+    And I successfully run `kitchen create default-flebian`
 
   @spawn
   Scenario: Logging in to an instance
     When I run `kitchen login default-flebian`
     Then the output should contain "Remote login is not supported in this driver."
+    And the exit status should not be 0
+
+  @spawn
+  Scenario: Attempting to log into a non-created instance
+    When I run `kitchen login full-flebian`
+    Then the output should contain:
+    """
+    Instance <full-flebian> has not yet been created
+    """
     And the exit status should not be 0
 
   @spawn

--- a/lib/kitchen/instance.rb
+++ b/lib/kitchen/instance.rb
@@ -196,7 +196,12 @@ module Kitchen
     # @see Driver::LoginCommand
     # @see Driver::Base#login_command
     def login
-      login_command = driver.login_command(state_file.read)
+      state = state_file.read
+      if state[:last_action].nil?
+        raise UserError, "Instance #{to_str} has not yet been created"
+      end
+
+      login_command = driver.login_command(state)
       cmd, *args = login_command.cmd_array
       options = login_command.options
 

--- a/spec/kitchen/instance_spec.rb
+++ b/spec/kitchen/instance_spec.rb
@@ -248,11 +248,18 @@ describe Kitchen::Instance do
   end
 
   it "#login executes the driver's login_command" do
-    driver.stubs(:login_command).with(Hash.new).
+    state_file.write(:last_action => "create")
+    driver.stubs(:login_command).with(:last_action => "create").
       returns(Kitchen::LoginCommand.new(%w[echo hello], :purple => true))
     Kernel.expects(:exec).with("echo", "hello", :purple => true)
 
     instance.login
+  end
+
+  it "#login raises a UserError if the instance is not created" do
+    state_file.write({})
+
+    proc { instance.login }.must_raise Kitchen::UserError
   end
 
   describe "#diagnose" do


### PR DESCRIPTION
This is solved slightly differently in than in #462 because otherwise the Instance cannot be checked for a "non-implemented" exception (not all drivers necessarily support the login command).

Closes #375
Closes #462

Thanks to @@daniellockard, @juliandunn, and @dje!

![hackers1](https://cloud.githubusercontent.com/assets/261548/4686580/801cf8aa-5647-11e4-94e6-da07f2bc3a27.gif)
