### PR TITLE
bump mixlib-shellout deps

### DIFF
--- a/test-kitchen.gemspec
+++ b/test-kitchen.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 1.9.1"
 
-  gem.add_dependency "mixlib-shellout", "~> 1.2"
+  gem.add_dependency "mixlib-shellout", ">= 1.2", "< 3.0"
   gem.add_dependency "net-scp",         "~> 1.1"
   gem.add_dependency "net-ssh",         "~> 2.7"
   gem.add_dependency "safe_yaml",       "~> 1.0"


### PR DESCRIPTION
the encoding changes that prompted mixlib-shellout to bump to 2.0 should
not affect test-kitchen, so leave the bottom version at 1.2 and raise
the top constraint to 2.x
