### PR TITLE
Sandbox creation fix for docker images

### DIFF
--- a/lib/kitchen/provisioner/base.rb
+++ b/lib/kitchen/provisioner/base.rb
@@ -115,7 +115,7 @@ module Kitchen
       #     end
       #   end
       def create_sandbox
-        @sandbox_path = Dir.mktmpdir("#{instance.name}-sandbox-")
+        @sandbox_path = Dir.mktmpdir("#{instance.name.gsub(/\//, "-")}-sandbox-")
         File.chmod(0755, sandbox_path)
         info("Preparing files for transfer")
         debug("Creating local sandbox in #{sandbox_path}")


### PR DESCRIPTION
When attempting to converge with community docker images, the image-name
has an extra "/". eg. [this](https://registry.hub.docker.com/u/base/archlinux/) image,
is created with an image name of "default-base/archlinux-latest".

The ruby library Dir, is used to make a local tmpdir as a local sandbox
before being pushed to the image. Since this cannot create tmpdirs
recursively, this fails to create a sandbox with the extra "/" in the
image name.

This fix will `gsub` the image name and replace any '/' with '-' for
the sole purpose of creating a sandbox directory. This doesn't change
the actual instance.name variable, and only makes a substitution inside
the "create_sandbox" method.

This still works on official repositories with docker, as well as the
vagrant boxes I have tested this fix with.
