### PR TITLE
Allow to set chef-zero-host when using the Chef Zero provider

### DIFF
--- a/lib/kitchen/provisioner/chef_zero.rb
+++ b/lib/kitchen/provisioner/chef_zero.rb
@@ -30,6 +30,7 @@ module Kitchen
       default_config :client_rb, {}
       default_config :ruby_bindir, "/opt/chef/embedded/bin"
       default_config :json_attributes, true
+      default_config :chef_zero_host, nil
       default_config :chef_zero_port, 8889
 
       default_config :chef_client_path do |provisioner|
@@ -77,6 +78,9 @@ module Kitchen
           "--force-formatter",
           "--no-color"
         ]
+        if config[:chef_zero_host]
+          args <<  "--chef-zero-host #{config[:chef_zero_host]}"
+        end
         if config[:chef_zero_port]
           args <<  "--chef-zero-port #{config[:chef_zero_port]}"
         end

--- a/spec/kitchen/provisioner/chef_zero_spec.rb
+++ b/spec/kitchen/provisioner/chef_zero_spec.rb
@@ -62,6 +62,10 @@ describe Kitchen::Provisioner::ChefZero do
       provisioner[:json_attributes].must_equal true
     end
 
+    it "does not set :chef_zero_host" do
+      provisioner[:chef_zero_host].must_equal nil
+    end
+
     it "sets :chef_zero_port to 8889" do
       provisioner[:chef_zero_port].must_equal 8889
     end
@@ -431,10 +435,22 @@ describe Kitchen::Provisioner::ChefZero do
         cmd.must_match regexify(" --chef-zero-port 8889", :partial_line)
       end
 
+      it "sets chef zero host flag for custom host" do
+        config[:chef_zero_host] = '192.168.0.1'
+
+        cmd.must_match regexify(" --chef-zero-host 192.168.0.1", :partial_line)
+      end
+
       it "sets chef zero port flag for custom port" do
         config[:chef_zero_port] = 123
 
         cmd.must_match regexify(" --chef-zero-port 123", :partial_line)
+      end
+
+      it "does not set chef zero host flag when value is falsey" do
+        config[:chef_zero_host] = nil
+
+        cmd.wont_match regexify(" --chef-zero-host ", :partial_line)
       end
 
       it "does not set chef zero port flag when value is falsey" do


### PR DESCRIPTION
This fix introduces a new configuration option chef_zero_host for the
Chef Zero provider. Using this option, you can bind the Chef Zero
server to another address than localhost.

Being able to set the host is nice when using test kitchen to test cookbooks that create docker containers or VMs which in turn use chef to configure themselves. This way the "nested" Chef clients inside the containers or VMs can access Test Kitchen's Chef Zero server, too.

Example kitchen.yml:

```
- name: 'ops_server'
  driver:
    network:
    -
      - 'private_network'
      - ip: '192.168.99.100'
  provisioner:
    chef_zero_host: '192.168.99.100'
    client_rb:
      chef_server_url: 'http://192.168.99.100:8889'
```
