### PR TITLE
Replace `/` with `-` in Instance names.

### DIFF
--- a/lib/kitchen/instance.rb
+++ b/lib/kitchen/instance.rb
@@ -42,7 +42,7 @@ module Kitchen
       # @param platform [Platform,#name] a Platform
       # @return [String] a normalized, consistent name for an instance
       def name_for(suite, platform)
-        "#{suite.name}-#{platform.name}".gsub(/_/, "-").gsub(/\./, "")
+        "#{suite.name}-#{platform.name}".gsub(%r{[_,/]}, "-").gsub(/\./, "")
       end
     end
 

--- a/spec/kitchen/instance_spec.rb
+++ b/spec/kitchen/instance_spec.rb
@@ -147,6 +147,21 @@ describe Kitchen::Instance do
       Kitchen::Instance.name_for(suite("_s__s_"), platform("pp_")).
         must_equal "-s--s--pp-"
     end
+
+    it "transforms forward slashes to dashes in suite name" do
+      Kitchen::Instance.name_for(suite("suite/ness"), platform("platform")).
+        must_equal "suite-ness-platform"
+    end
+
+    it "transforms forward slashes to dashes in platform name" do
+      Kitchen::Instance.name_for(suite("suite"), platform("platform/s")).
+        must_equal "suite-platform-s"
+    end
+
+    it "transforms forward slashes to dashes in suite and platform names" do
+      Kitchen::Instance.name_for(suite("/s//s/"), platform("pp/")).
+        must_equal "-s--s--pp-"
+    end
   end
 
   describe "#suite" do


### PR DESCRIPTION
This further allows instance names to be used as server hostnames in
most cases (underscores and periods have been previously handled).

Closes #543
