### PR TITLE
[Breaking] Correct global YAML merge order to lowest (from highest).

### DIFF
--- a/lib/kitchen/loader/yaml.rb
+++ b/lib/kitchen/loader/yaml.rb
@@ -112,8 +112,8 @@ module Kitchen
       # returns a new merged Hash. There are 3 sources of configuration data:
       #
       # 1. global config
-      # 2. local config
-      # 3. project config
+      # 2. project config
+      # 3. local config
       #
       # The merge order is 3 -> 2 -> 1, meaning that the highest number in the
       # above list has merge precedence over any lower numbered source.
@@ -121,12 +121,12 @@ module Kitchen
       # @return [Hash] a new merged Hash
       # @api private
       def combined_hash
-        y = if @process_local
-          normalize(yaml).rmerge(normalize(local_yaml))
+        y = if @process_global
+          normalize(global_yaml).rmerge(normalize(yaml))
         else
           normalize(yaml)
         end
-        @process_global ? y.rmerge(normalize(global_yaml)) : y
+        @process_local ? y.rmerge(normalize(local_yaml)) : y
       end
 
       # Loads and returns the Kitchen config YAML as a Hash.

--- a/spec/kitchen/loader/yaml_spec.rb
+++ b/spec/kitchen/loader/yaml_spec.rb
@@ -154,6 +154,17 @@ describe Kitchen::Loader::YAML do
       )
     end
 
+    it "merges kitchen.yml over configuration in global config" do
+      stub_global!(
+        "common" => { "thekey" => "nope" }
+      )
+      stub_yaml!(".kitchen.yml",
+        "common" => { "thekey" => "yep" }
+      )
+
+      loader.read.must_equal(:common => { :thekey => "yep" })
+    end
+
     it "merges kitchen.local.yml over configuration in kitchen.yml" do
       stub_yaml!(".kitchen.yml",
         "common" => { "thekey" => "nope" }
@@ -165,7 +176,7 @@ describe Kitchen::Loader::YAML do
       loader.read.must_equal(:common => { :thekey => "yep" })
     end
 
-    it "merges global config over both kitchen.local.yml and kitchen.yml" do
+    it "merges kitchen.local.yml over both kitchen.yml and global config" do
       stub_yaml!(".kitchen.yml",
         "common" => { "thekey" => "nope" }
       )
@@ -176,7 +187,7 @@ describe Kitchen::Loader::YAML do
         "common" => { "thekey" => "kinda" }
       )
 
-      loader.read.must_equal(:common => { :thekey => "kinda" })
+      loader.read.must_equal(:common => { :thekey => "yep" })
     end
 
     NORMALIZED_KEYS = {


### PR DESCRIPTION
This addresses a merge order bug-of-intention between the following
files:
- .kitchen.yml (project config)
- .kitchen.local.yml (local config)
- $HOME/.kitchen/config.yml (global config)

The intended behavior was that:
1. baseline common configuration can go in the global config
2. any colliding values in the project config "win" over the global
   config
3. any colliding values in the local config "win" over the project
   config (and consequently also the global config)

This commit restores the intended merge semantics.

Closes #524
