### PR TITLE
add support for multiple step converge

### DIFF
--- a/lib/kitchen/command/list.rb
+++ b/lib/kitchen/command/list.rb
@@ -61,7 +61,7 @@ module Kitchen
         [
           color_pad(instance.name),
           color_pad(instance.driver.name),
-          color_pad(instance.provisioner.name),
+          color_pad(instance.provisioners.last.name),
           format_last_action(instance.last_action)
         ]
       end

--- a/lib/kitchen/config.rb
+++ b/lib/kitchen/config.rb
@@ -120,6 +120,13 @@ module Kitchen
 
     private
 
+    def each_step(suite_name)
+      name, step = * suite_name.split(/_step_/)
+      (1..step.to_i).map do |count|
+        yield suites.find { |suite| suite.name == "#{name}_step_#{count}" }
+      end
+    end
+
     # Builds the filtered list of Instance objects.
     #
     # @return [Array<Instance] an array of Instances
@@ -241,7 +248,7 @@ module Kitchen
         :logger       => new_logger(suite, platform, index),
         :suite        => suite,
         :platform     => platform,
-        :provisioner  => new_provisioner(suite, platform),
+        :provisioners => new_provisioners(suite, platform),
         :state_file   => new_state_file(suite, platform)
       )
     end
@@ -265,8 +272,26 @@ module Kitchen
       )
     end
 
-    # Builds a newly configured Provisioner object, for a given Suite and
-    # Platform.
+    # Builds an array of newly configured Provisioner objects,
+    # for a given Suite and Platform.
+    #
+    # @param suite [Suite,#name] a Suite
+    # @param platform [Platform,#name] a Platform
+    # @return Array[Provisioner] a new Provisioner object
+    # @api private
+    def new_provisioners(suite, platform)
+      # check if suite name otherwise is a suite step
+      if data.steps?(suite.name)
+        each_step(suite.name) do |step|
+          new_provisioner(step, platform)
+        end
+      else
+        [new_provisioner(suite, platform)]
+      end
+    end
+
+    # Builds a newly configured Provisioner object, for a given Suite
+    # and Platform.
     #
     # @param suite [Suite,#name] a Suite
     # @param platform [Platform,#name] a Platform

--- a/lib/kitchen/data_munger.rb
+++ b/lib/kitchen/data_munger.rb
@@ -104,7 +104,21 @@ module Kitchen
     #
     # @return [Array<Hash>] an Array of Hashes
     def suite_data
-      data.fetch(:suites, [])
+      @suite_data ||= data.fetch(:suites, []).inject([]) do |suites, suite|
+        if suite[:steps]
+          suite[:steps].each_with_index do |sub_suite, index|
+            sub_suite[:name] = "#{suite[:name]}_step_#{index + 1}"
+            suites << sub_suite
+          end
+        else
+          suites << suite
+        end
+        suites
+      end
+    end
+
+    def steps?(suite_name)
+      !data.fetch(:suites, []).find { |suite| suite[:name] == suite_name }
     end
 
     private
@@ -448,7 +462,7 @@ module Kitchen
     #
     # @api private
     def move_chef_data_to_provisioner!
-      data.fetch(:suites, []).each do |suite|
+      suite_data.each do |suite|
         move_chef_data_to_provisioner_at!(suite, :attributes)
         move_chef_data_to_provisioner_at!(suite, :run_list)
       end
@@ -473,6 +487,7 @@ module Kitchen
         pdata = { :name => pdata } if pdata.is_a?(String)
         if !root.fetch(key, nil).nil?
           root[:provisioner] = pdata.rmerge(key => root.delete(key))
+          root[:provisioner]
         end
       end
     end
@@ -721,7 +736,7 @@ module Kitchen
     #   Hash if not found
     # @api private
     def suite_data_for(name)
-      data.fetch(:suites, Hash.new).find(-> { Hash.new }) do |suite|
+      suite_data.find(-> { Hash.new }) do |suite|
         suite.fetch(:name, nil) == name
       end
     end

--- a/spec/kitchen/config_spec.rb
+++ b/spec/kitchen/config_spec.rb
@@ -264,6 +264,7 @@ describe Kitchen::Config do
       Kitchen::DataMunger.stubs(:new).returns(munger)
       config.stubs(:platforms).returns(platforms)
       config.stubs(:suites).returns(suites)
+      munger.stubs(:steps?).returns(false)
     end
 
     it "constructs a Busser object" do
@@ -284,8 +285,20 @@ describe Kitchen::Config do
       config.instances
     end
 
-    it "constructs a Provisioner object" do
+    it "constructs single Provisioner object" do
       munger.expects(:provisioner_data_for).with("tiny", "unax").
+        returns(:name => "provey", :datum => "lots")
+      Kitchen::Provisioner.unstub(:for_plugin)
+      Kitchen::Provisioner.expects(:for_plugin).
+        with("provey", :name => "provey", :datum => "lots")
+
+      config.instances
+    end
+
+    it "constructs Provisioner objects" do
+      munger.stubs(:steps?).returns(true)
+      config.stubs(:each_step).yields(stub(:name => "tiny_step_1"))
+      munger.expects(:provisioner_data_for).with("tiny_step_1", "unax").
         returns(:name => "provey", :datum => "lots")
       Kitchen::Provisioner.unstub(:for_plugin)
       Kitchen::Provisioner.expects(:for_plugin).
@@ -322,7 +335,7 @@ describe Kitchen::Config do
         :logger => "logger",
         :suite => suites.first,
         :platform => platforms.first,
-        :provisioner => "provisioner",
+        :provisioners => ["provisioner"],
         :state_file => "state_file"
       )
       config.instances

--- a/spec/kitchen/driver/ssh_base_spec.rb
+++ b/spec/kitchen/driver/ssh_base_spec.rb
@@ -52,7 +52,7 @@ describe Kitchen::Driver::SSHBase do
       :name         => "coolbeans",
       :logger       => logger,
       :busser       => busser,
-      :provisioner  => provisioner,
+      :provisioners => [provisioner],
       :to_str       => "instance"
     )
   end
@@ -286,7 +286,7 @@ describe Kitchen::Driver::SSHBase do
   describe "#converge" do
 
     let(:cmd)         { driver.converge(state) }
-    let(:connection)  { stub(:exec => true) }
+    let(:connection)  { stub(:exec => true, :wait => true) }
 
     before do
       state[:hostname] = "fizzy"

--- a/spec/kitchen/instance_spec.rb
+++ b/spec/kitchen/instance_spec.rb
@@ -93,13 +93,13 @@ describe Kitchen::Instance do
   let(:logger_io)   { StringIO.new }
   let(:logger)      { Kitchen::Logger.new(:logdev => logger_io) }
   let(:instance)    { Kitchen::Instance.new(opts) }
-  let(:provisioner) { Kitchen::Provisioner::Dummy.new({}) }
+  let(:provisioners) { [Kitchen::Provisioner::Dummy.new({})] }
   let(:state_file)  { DummyStateFile.new }
   let(:busser)      { Kitchen::Busser.new(suite.name, {}) }
 
   let(:opts) do
     { :suite => suite, :platform => platform, :driver => driver,
-      :provisioner => provisioner, :busser => busser,
+      :provisioners => provisioners, :busser => busser,
       :logger => logger, :state_file => state_file }
   end
 
@@ -217,20 +217,22 @@ describe Kitchen::Instance do
     end
   end
 
-  describe "#provisioner" do
+  describe "#provisioners" do
 
-    it "returns its provisioner" do
-      instance.provisioner.must_equal provisioner
+    it "returns its provisioners" do
+      instance.provisioners.must_equal provisioners
     end
 
     it "raises an ArgumentError if missing" do
-      opts.delete(:provisioner)
+      opts.delete(:provisioners)
       proc { Kitchen::Instance.new(opts) }.must_raise Kitchen::ClientError
     end
 
     it "sets Provisioner#instance to itself" do
       # it's mind-bottling
-      instance.provisioner.instance.must_equal instance
+      instance.provisioners.each do |provisioner|
+        provisioner.instance.must_equal instance
+      end
     end
   end
 
@@ -297,18 +299,22 @@ describe Kitchen::Instance do
       instance.diagnose[:state_file].must_equal :unknown
     end
 
-    it "sets :provisioner key to provisioner's diganose info" do
+    it "sets :provisioners key to provisioner's diganose info" do
+      provisioner = provisioners.first
       provisioner.stubs(:diagnose).returns(:a => "b")
+      provisioners.stubs(:[]).returns(provisioner)
 
-      instance.diagnose[:provisioner].must_equal(:a => "b")
+      instance.diagnose[:provisioners].first.must_equal(:a => "b")
     end
 
-    it "sets :provisioner key to :unknown if obj can't respond to #diagnose" do
-      opts[:provisioner] = Class.new(provisioner.class) {
-        undef_method :diagnose
-      }.new
+    it "sets :provisioners key to :unknown if obj can't respond to #diagnose" do
+      opts[:provisioners] = [
+        Class.new(provisioners.first.class) {
+          undef_method :diagnose
+        }.new
+      ]
 
-      instance.diagnose[:provisioner].must_equal :unknown
+      instance.diagnose[:provisioners].first.must_equal :unknown
     end
 
     it "sets :busser key to busser's diganose info" do


### PR DESCRIPTION
This change allows multiple provisioner runs to be made on a single converge.  This can be used to test migration between cookbooks versions #339, to install a new kernel #324 (using cookbook-reboot-handler patched with emiddleton/cookbook-reboot-handler@a94e40edca2dccf3dcc17334825b6489edde6103) and to make converge more robust #162

Converge steps are defined as an array of step hashes as shown below.  (step hashes support all suite keys except name: and steps:).

``` yaml
platforms:
  - name: centos-6.4

suites:
  - name: mysuite
    steps:
      - run_list:
        - recipe[wakame-vdc::default]
      - run_list:
        - recipe[wakame-vdc::default]
```

Each step result in a new instance with _step_n attached to the suite name i.e

``` shell
# kitchen list

Instance                  Driver   Provisioner  Last Action
mysuite-step-1-centos-64  Vagrant  ChefSolo     <Not Created>
mysuite-step-2-centos-64  Vagrant  ChefSolo     <Not Created>
```

This allows test to be run at each step in the convergence process.
