### PR TITLE
Force busser to be run with correct/extant ruby under powershell

### DIFF
--- a/lib/kitchen/busser.rb
+++ b/lib/kitchen/busser.rb
@@ -195,7 +195,7 @@ module Kitchen
       # Overwrite the sudo configuration comming from the Transport
       config[:sudo] = instance.transport.sudo
       # Smart way to do this?
-      config[:busser_bin] = "busser" if shell.eql?("powershell")
+      config[:busser_bin] = "#{config[:ruby_bindir]}/ruby #{config[:root_path]}/gems/bin/busser" if shell.eql?("powershell")
       self
     end
 


### PR DESCRIPTION
When spinning up an omnibus-installed chef, busser.bat points at a ruby that doesn't exist. As a result, when it's run by powershell it bombs with an error saying ruby doesn't exist.

This modifies override for busser_bin to force usage the ruby in ruby_bindir.

It's still not a very smart way to do this, but it got busser working on my setup.