### PR TITLE
Improve support for powershell on Windows by wrapping commands and forcing binary paths

### DIFF
--- a/features/kitchen_list_command.feature
+++ b/features/kitchen_list_command.feature
@@ -22,8 +22,8 @@ Feature: Listing Test Kitchen instances
   Scenario: Listing instances
     When I run `kitchen list`
     Then the exit status should be 0
-    And the output should match /^foobar-ubuntu-1304\s+Dummy\s+ChefSolo\s+\<Not Created\>$/
-    And the output should match /^foobar-centos-64\s+Dummy\s+ChefSolo\s+\<Not Created\>$/
+    And the output should match /^foobar-ubuntu-1304\s+Dummy\s+ChefSolo\s+ssh\s+\<Not Created\>$/
+    And the output should match /^foobar-centos-64\s+Dummy\s+ChefSolo\s+ssh\s+\<Not Created\>$/
 
   Scenario: Listing instances with the --bare option
     When I run `kitchen list --bare`

--- a/lib/kitchen/util.rb
+++ b/lib/kitchen/util.rb
@@ -117,8 +117,7 @@ module Kitchen
 
         "sh -c '\n#{cmd}\n'"
       when "powershell"
-        # Do we need a wrapper for powershell
-        cmd
+        "echo '\n#{cmd}\n' | powershell.exe -Command -"
       else
         raise "[Util.shell_helpers] Unsupported shell: #{shell}"
       end

--- a/spec/kitchen/busser_spec.rb
+++ b/spec/kitchen/busser_spec.rb
@@ -92,7 +92,7 @@ describe Kitchen::Busser do
     it ":busser_bin defaults to a binstub under :root_path" do
       config[:root_path] = "/beep"
 
-      busser[:busser_bin].must_equal "/beep/bin/busser"
+      busser[:busser_bin].must_equal "/beep/gems/bin/busser"
     end
   end
 
@@ -177,21 +177,21 @@ describe Kitchen::Busser do
 
       it "checks if busser is installed" do
         cmd.must_match regexify(
-          %{if ! sudo -E /r/gem list busser -i >/dev/null;}, :partial_line)
+          %{if ! sudo -E /r/ruby /r/gem list busser -i >/dev/null;}, :partial_line)
       end
 
       describe "installing busser" do
 
         it "installs the latest busser gem by default" do
           cmd.must_match regexify(
-            %{sudo -E /r/gem install busser --no-rdoc --no-ri}, :partial_line)
+            %{sudo -E /r/ruby /r/gem install busser --no-rdoc --no-ri}, :partial_line)
         end
 
         it "installs a specific busser version gem" do
           config[:version] = "4.0.7"
 
           cmd.must_match regexify(
-            %{sudo -E /r/gem install busser --version 4.0.7 --no-rdoc --no-ri},
+            %{sudo -E /r/ruby /r/gem install busser --version 4.0.7 --no-rdoc --no-ri},
             :partial_line)
         end
 
@@ -199,7 +199,7 @@ describe Kitchen::Busser do
           config[:version] = "busser@1.2.3"
 
           cmd.must_match regexify(
-            %{sudo -E /r/gem install busser --version 1.2.3 --no-rdoc --no-ri},
+            %{sudo -E /r/ruby /r/gem install busser --version 1.2.3 --no-rdoc --no-ri},
             :partial_line)
         end
 
@@ -207,27 +207,21 @@ describe Kitchen::Busser do
           config[:version] = "foo@9.0.1"
 
           cmd.must_match regexify(
-            %{sudo -E /r/gem install foo --version 9.0.1 --no-rdoc --no-ri},
+            %{sudo -E /r/ruby /r/gem install foo --version 9.0.1 --no-rdoc --no-ri},
             :partial_line)
         end
       end
 
-      it "calculates RubyGem's bindir" do
-        cmd.must_match regexify(
-          %{gem_bindir=`/r/ruby -rrubygems -e "puts Gem.bindir"`},
-          :partial_line)
-      end
-
       it "runs busser setup from the installed gem_bindir binstub" do
         cmd.must_match regexify(
-          %{sudo -E ${gem_bindir}/busser setup}, :partial_line)
+          %{sudo -E /r/ruby /tmp/busser/gems/bin/busser setup}, :partial_line)
       end
 
       it "runs busser plugin install with the :busser_bindir command" do
         config[:busser_bin] = "/b/b"
 
         cmd.must_match regexify(
-          %{sudo -E /b/b plugin install } +
+          %{sudo -E /r/ruby /b/b plugin install } +
             %{busser-abba busser-minispec busser-mondospec},
           :partial_line)
       end
@@ -349,7 +343,7 @@ describe Kitchen::Busser do
 
         files.each do |f, md|
           cmd.must_match regexify([
-            %{echo "Uploading `sudo -E /b/busser suite path`/#{f}},
+            %{echo "Uploading /tmp/busser/suites/#{f}},
             %{(mode=#{md[:perms]})"}
           ].join(" "))
         end
@@ -360,7 +354,7 @@ describe Kitchen::Busser do
 
         helper_files.each do |f, md|
           cmd.must_match regexify([
-            %{echo "Uploading `sudo -E /b/busser suite path`/#{f}},
+            %{echo "Uploading /tmp/busser/suites/#{f}},
             %{(mode=#{md[:perms]})"}
           ].join(" "))
         end
@@ -371,8 +365,8 @@ describe Kitchen::Busser do
 
         files.each do |f, md|
           cmd.must_match regexify([
-            %{echo "#{md[:base64]}" | sudo -E /b/busser deserialize},
-            %{--destination=`sudo -E /b/busser suite path`/#{f}},
+            %{echo "#{md[:base64]}" | sudo -E /r/ruby /b/busser deserialize},
+            %{--destination=/tmp/busser/suites/#{f}},
             %{--md5sum=#{md[:md5]} --perms=#{md[:perms]}}
           ].join(" "))
         end
@@ -383,8 +377,8 @@ describe Kitchen::Busser do
 
         helper_files.each do |f, md|
           cmd.must_match regexify([
-            %{echo "#{md[:base64]}" | sudo -E /b/busser deserialize},
-            %{--destination=`sudo -E /b/busser suite path`/#{f}},
+            %{echo "#{md[:base64]}" | sudo -E /r/ruby /b/busser deserialize},
+            %{--destination=/tmp/busser/suites/#{f}},
             %{--md5sum=#{md[:md5]} --perms=#{md[:perms]}}
           ].join(" "))
         end
@@ -469,17 +463,17 @@ describe Kitchen::Busser do
 
       it "uses sudo for busser test when configured" do
         config[:sudo] = true
-        config[:busser_bin] = "/p/b"
+        config[:busser_bin] = "p/b"
 
-        cmd.must_match regexify("sudo -E /p/b test", :partial_line)
+        cmd.must_match regexify("sudo -E /r/ruby p/b test", :partial_line)
       end
 
       it "does not use sudo for busser test when configured" do
         config[:sudo] = false
         config[:busser_bin] = "/p/b"
 
-        cmd.must_match regexify("/p/b test", :partial_line)
-        cmd.wont_match regexify("sudo -E /p/b test", :partial_line)
+        cmd.must_match regexify("/r/ruby /p/b test", :partial_line)
+        cmd.wont_match regexify("sudo -E /r/ruby /p/b test", :partial_line)
       end
     end
   end


### PR DESCRIPTION
Tested using ssh and winrm transports (using vagrant_winrm driver as I couldn't get winrm transport to work) for both bourne and powershell shells. Both work fine on my setup and Linux builds appear to be unaffected.