### PR TITLE
Replace sudo -E

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,4 @@
-Style/FileName:
+AllCops:
   Exclude:
+    - 'spec/**/*'
     - 'support/**/*'

--- a/lib/kitchen/provisioner/base.rb
+++ b/lib/kitchen/provisioner/base.rb
@@ -181,7 +181,9 @@ module Kitchen
       # @return [String] the command, conditionaly prefixed with sudo
       # @api private
       def sudo(script)
-        config[:sudo] ? "sudo -E #{script}" : script
+        return script unless config[:sudo]
+
+        "sudo su -m -c '#{script}'"
       end
     end
   end

--- a/lib/kitchen/provisioner/chef_solo.rb
+++ b/lib/kitchen/provisioner/chef_solo.rb
@@ -41,19 +41,9 @@ module Kitchen
 
       # (see Base#run_command)
       def run_command
-        level = config[:log_level] == :info ? :auto : config[:log_level]
+        cmd = sudo("#{chef_solo_path} #{run_command_args}")
 
-        cmd = sudo(config[:chef_solo_path])
-        args = [
-          "--config #{config[:root_path]}/solo.rb",
-          "--log_level #{level}",
-          "--force-formatter",
-          "--no-color",
-          "--json-attributes #{config[:root_path]}/dna.json"
-        ]
-        args << "--logfile #{config[:log_file]}" if config[:log_file]
-
-        Util.wrap_command([cmd, *args].join(" "))
+        Util.wrap_command(cmd)
       end
 
       private
@@ -70,6 +60,58 @@ module Kitchen
         File.open(File.join(sandbox_path, "solo.rb"), "wb") do |file|
           file.write(format_config_file(data))
         end
+      end
+
+      # Returns a path string to the log file.
+      #
+      # @return [String] path string
+      # @api private
+      def log_file
+        config[:log_file]
+      end
+
+      # Returns a log level symbol.
+      #
+      # @return [Symbol] log level symbol
+      # @api private
+      def log_level
+        level = config[:log_level]
+
+        level == :info ? :auto : level
+      end
+
+      # Returns a root path string.
+      #
+      # @return [String] root path string
+      # @api private
+      def root_path
+        config[:root_path]
+      end
+
+      # Returns an arguments string for running Chef Solo.
+      #
+      # @return [String] arguments string
+      # @api private
+      def run_command_args
+        args = [
+          "--config #{root_path}/solo.rb",
+          "--log_level #{log_level}",
+          "--force-formatter",
+          "--no-color",
+          "--json-attributes #{root_path}/dna.json"
+        ].join(" ")
+
+        args << " --logfile #{log_file}" if log_file
+
+        args
+      end
+
+      # Returns a path string for the Chef Solo binary.
+      #
+      # @return [String] path string
+      # @api private
+      def chef_solo_path
+        config[:chef_solo_path]
       end
     end
   end

--- a/lib/kitchen/provisioner/shell.rb
+++ b/lib/kitchen/provisioner/shell.rb
@@ -46,17 +46,16 @@ module Kitchen
 
       # (see Base#init_command)
       def init_command
-        data = File.join(config[:root_path], "data")
-        cmd = "#{sudo("rm")} -rf #{data} ; mkdir -p #{config[:root_path]}"
+        cmd = "#{sudo("rm -rf #{root_data_path}")} ; mkdir -p #{root_path}"
 
         Util.wrap_command(cmd)
       end
 
       # (see Base#run_command)
       def run_command
-        Util.wrap_command(
-          sudo(File.join(config[:root_path], File.basename(config[:script])))
-        )
+        cmd = sudo(root_script_path)
+
+        Util.wrap_command(cmd)
       end
 
       private
@@ -83,20 +82,53 @@ module Kitchen
       def prepare_script
         info("Preparing script")
 
-        if config[:script]
-          debug("Using script from #{config[:script]}")
-          FileUtils.cp_r(config[:script], sandbox_path)
+        if script
+          debug("Using script from #{script}")
+          FileUtils.cp_r(script, sandbox_path)
         else
           config[:script] = File.join(sandbox_path, "bootstrap.sh")
-          info("#{File.basename(config[:script])} not found " \
+          info("#{File.basename(script)} not found " \
             "so Kitchen will run a stubbed script. Is this intended?")
-          File.open(config[:script], "wb") do |file|
+          File.open(script, "wb") do |file|
             file.write(%{#!/bin/sh\necho "NO BOOTSTRAP SCRIPT PRESENT"\n})
           end
         end
 
-        FileUtils.chmod(0755,
-          File.join(sandbox_path, File.basename(config[:script])))
+        FileUtils.chmod(0755, File.join(sandbox_path, File.basename(script)))
+      end
+
+      # Returns a path string to the root directory.
+      #
+      # @return [String] path string
+      # @api private
+      def root_path
+        config[:root_path]
+      end
+
+      # Returns a path string to the root data directory.
+      #
+      # @return [String] path string
+      # @api private
+      def root_data_path
+        File.join(root_path, "data")
+      end
+
+      # Returns a path string to the root script.
+      #
+      # @return [String] path string
+      # @api private
+      def root_script_path
+        script_name = File.basename(script)
+
+        File.join(root_path, script_name)
+      end
+
+      # Returns a path string to the bootstrap script.
+      #
+      # @return [String] path string
+      # @api private
+      def script
+        config[:script]
       end
     end
   end

--- a/lib/kitchen/shell_out.rb
+++ b/lib/kitchen/shell_out.rb
@@ -56,7 +56,7 @@ module Kitchen
     # @raise [ShellCommandFailed] if the command fails
     # @raise [Error] for all other unexpected exceptions
     def run_command(cmd, options = {})
-      cmd = "sudo -E #{cmd}" if options.fetch(:use_sudo, false)
+      cmd = "sudo su -m -c '#{cmd}'" if options.fetch(:use_sudo, false)
       subject = "[#{options.fetch(:log_subject, "local")} command]"
 
       debug("#{subject} BEGIN (#{cmd})")

--- a/spec/kitchen/busser_spec.rb
+++ b/spec/kitchen/busser_spec.rb
@@ -175,21 +175,24 @@ describe Kitchen::Busser do
 
       it "checks if busser is installed" do
         cmd.must_match regexify(
-          %{if ! sudo -E /r/gem list busser -i >/dev/null;}, :partial_line)
+          %{if ! sudo su -m -c '/r/gem list busser -i >/dev/null';},
+          :partial_line)
       end
 
       describe "installing busser" do
 
         it "installs the latest busser gem by default" do
           cmd.must_match regexify(
-            %{sudo -E /r/gem install busser --no-rdoc --no-ri}, :partial_line)
+            %{sudo su -m -c '/r/gem install busser --no-rdoc --no-ri'},
+            :partial_line)
         end
 
         it "installs a specific busser version gem" do
           config[:version] = "4.0.7"
 
           cmd.must_match regexify(
-            %{sudo -E /r/gem install busser --version 4.0.7 --no-rdoc --no-ri},
+            %{sudo su -m -c '/r/gem install busser --version 4.0.7 } +
+              %{--no-rdoc --no-ri'},
             :partial_line)
         end
 
@@ -197,7 +200,8 @@ describe Kitchen::Busser do
           config[:version] = "busser@1.2.3"
 
           cmd.must_match regexify(
-            %{sudo -E /r/gem install busser --version 1.2.3 --no-rdoc --no-ri},
+            %{sudo su -m -c '/r/gem install busser --version 1.2.3 } +
+              %{--no-rdoc --no-ri'},
             :partial_line)
         end
 
@@ -205,28 +209,25 @@ describe Kitchen::Busser do
           config[:version] = "foo@9.0.1"
 
           cmd.must_match regexify(
-            %{sudo -E /r/gem install foo --version 9.0.1 --no-rdoc --no-ri},
+            %{sudo su -m -c '/r/gem install foo --version 9.0.1 --no-rdoc } +
+              %{--no-ri'},
             :partial_line)
         end
       end
 
-      it "calculates RubyGem's bindir" do
-        cmd.must_match regexify(
-          %{gem_bindir=`/r/ruby -rrubygems -e "puts Gem.bindir"`},
-          :partial_line)
-      end
-
       it "runs busser setup from the installed gem_bindir binstub" do
         cmd.must_match regexify(
-          %{sudo -E ${gem_bindir}/busser setup}, :partial_line)
+          %{sudo su -m -c '`/r/ruby -rrubygems -e "puts Gem.bindir"`/busser } +
+            %{setup'},
+          :partial_line)
       end
 
       it "runs busser plugin install with the :busser_bindir command" do
         config[:busser_bin] = "/b/b"
 
         cmd.must_match regexify(
-          %{sudo -E /b/b plugin install } +
-            %{busser-abba busser-minispec busser-mondospec},
+          %{sudo su -m -c '/b/b plugin install } +
+            %{busser-abba busser-minispec busser-mondospec'},
           :partial_line)
       end
     end
@@ -347,7 +348,7 @@ describe Kitchen::Busser do
 
         files.each do |f, md|
           cmd.must_match regexify([
-            %{echo "Uploading `sudo -E /b/busser suite path`/#{f}},
+            %{echo "Uploading `sudo su -m -c '/b/busser suite path'`/#{f}},
             %{(mode=#{md[:perms]})"}
           ].join(" "))
         end
@@ -358,7 +359,7 @@ describe Kitchen::Busser do
 
         helper_files.each do |f, md|
           cmd.must_match regexify([
-            %{echo "Uploading `sudo -E /b/busser suite path`/#{f}},
+            %{echo "Uploading `sudo su -m -c '/b/busser suite path'`/#{f}},
             %{(mode=#{md[:perms]})"}
           ].join(" "))
         end
@@ -369,9 +370,9 @@ describe Kitchen::Busser do
 
         files.each do |f, md|
           cmd.must_match regexify([
-            %{echo "#{md[:base64]}" | sudo -E /b/busser deserialize},
-            %{--destination=`sudo -E /b/busser suite path`/#{f}},
-            %{--md5sum=#{md[:md5]} --perms=#{md[:perms]}}
+            %{echo "#{md[:base64]}" | sudo su -m -c '/b/busser deserialize},
+            %{--destination=`sudo su -m -c '/b/busser suite path'`/#{f}},
+            %{--md5sum=#{md[:md5]} --perms=#{md[:perms]}'}
           ].join(" "))
         end
       end
@@ -381,9 +382,9 @@ describe Kitchen::Busser do
 
         helper_files.each do |f, md|
           cmd.must_match regexify([
-            %{echo "#{md[:base64]}" | sudo -E /b/busser deserialize},
-            %{--destination=`sudo -E /b/busser suite path`/#{f}},
-            %{--md5sum=#{md[:md5]} --perms=#{md[:perms]}}
+            %{echo "#{md[:base64]}" | sudo su -m -c '/b/busser deserialize},
+            %{--destination=`sudo su -m -c '/b/busser suite path'`/#{f}},
+            %{--md5sum=#{md[:md5]} --perms=#{md[:perms]}'}
           ].join(" "))
         end
       end
@@ -469,7 +470,7 @@ describe Kitchen::Busser do
         config[:sudo] = true
         config[:busser_bin] = "/p/b"
 
-        cmd.must_match regexify("sudo -E /p/b test", :partial_line)
+        cmd.must_match regexify("sudo su -m -c '/p/b test'", :partial_line)
       end
 
       it "does not use sudo for busser test when configured" do
@@ -477,7 +478,7 @@ describe Kitchen::Busser do
         config[:busser_bin] = "/p/b"
 
         cmd.must_match regexify("/p/b test", :partial_line)
-        cmd.wont_match regexify("sudo -E /p/b test", :partial_line)
+        cmd.wont_match regexify("sudo su -m -c '/p/b test'", :partial_line)
       end
     end
   end

--- a/spec/kitchen/provisioner/base_spec.rb
+++ b/spec/kitchen/provisioner/base_spec.rb
@@ -138,7 +138,7 @@ describe Kitchen::Provisioner::Base do
     it "if :sudo is set, prepend sudo command" do
       config[:sudo] = true
 
-      provisioner.send(:sudo, "wakka").must_equal("sudo -E wakka")
+      provisioner.send(:sudo, "wakka").must_equal("sudo su -m -c 'wakka'")
     end
 
     it "if :sudo is falsy, do not include sudo command" do

--- a/spec/kitchen/provisioner/chef_base_spec.rb
+++ b/spec/kitchen/provisioner/chef_base_spec.rb
@@ -139,7 +139,7 @@ describe Kitchen::Provisioner::ChefBase do
       config[:require_chef_omnibus] = "1.2.3"
 
       provisioner.install_command.must_match regexify(
-        "sudo -E sh /tmp/install.sh -v 1.2.3")
+        "sudo su -m -c 'sh /tmp/install.sh -v 1.2.3'")
       provisioner.install_command.must_match regexify(
         "Installing Chef Omnibus (1.2.3)", :partial_line)
     end
@@ -148,7 +148,7 @@ describe Kitchen::Provisioner::ChefBase do
       config[:require_chef_omnibus] = "11.10"
 
       provisioner.install_command.must_match regexify(
-        "sudo -E sh /tmp/install.sh -v 11.10")
+        "sudo su -m -c 'sh /tmp/install.sh -v 11.10'")
       provisioner.install_command.must_match regexify(
         "Installing Chef Omnibus (11.10)", :partial_line)
     end
@@ -157,7 +157,7 @@ describe Kitchen::Provisioner::ChefBase do
       config[:require_chef_omnibus] = "12"
 
       provisioner.install_command.must_match regexify(
-        "sudo -E sh /tmp/install.sh -v 12")
+        "sudo su -m -c 'sh /tmp/install.sh -v 12'")
       provisioner.install_command.must_match regexify(
         "Installing Chef Omnibus (12)", :partial_line)
     end
@@ -166,7 +166,7 @@ describe Kitchen::Provisioner::ChefBase do
       config[:require_chef_omnibus] = "10.1.0.RC.1"
 
       provisioner.install_command.must_match regexify(
-        "sudo -E sh /tmp/install.sh -v 10.1.0.rc.1")
+        "sudo su -m -c 'sh /tmp/install.sh -v 10.1.0.rc.1'")
       provisioner.install_command.must_match regexify(
         "Installing Chef Omnibus (10.1.0.rc.1)", :partial_line)
     end
@@ -175,7 +175,7 @@ describe Kitchen::Provisioner::ChefBase do
       config[:require_chef_omnibus] = "latest"
 
       provisioner.install_command.must_match regexify(
-        "sudo -E sh /tmp/install.sh ")
+        "sudo su -m -c 'sh /tmp/install.sh '")
       provisioner.install_command.must_match regexify(
         "Installing Chef Omnibus (always install latest version)",
         :partial_line
@@ -186,7 +186,7 @@ describe Kitchen::Provisioner::ChefBase do
       config[:require_chef_omnibus] = true
 
       provisioner.install_command.must_match regexify(
-        "sudo -E sh /tmp/install.sh ")
+        "sudo su -m -c 'sh /tmp/install.sh '")
       provisioner.install_command.must_match regexify(
         "Installing Chef Omnibus (install only if missing)", :partial_line)
     end
@@ -195,7 +195,7 @@ describe Kitchen::Provisioner::ChefBase do
       config[:chef_omnibus_install_options] = "-P chefdk"
 
       provisioner.install_command.must_match regexify(
-        "sudo -E sh /tmp/install.sh -P chefdk")
+        "sudo su -m -c 'sh /tmp/install.sh -P chefdk'")
       provisioner.install_command.must_match regexify(
         "Installing Chef Omnibus (install only if missing)", :partial_line)
     end
@@ -205,7 +205,7 @@ describe Kitchen::Provisioner::ChefBase do
       config[:chef_omnibus_install_options] = "-d /tmp/place"
 
       provisioner.install_command.must_match regexify(
-        "sudo -E sh /tmp/install.sh -v 11 -d /tmp/place")
+        "sudo su -m -c 'sh /tmp/install.sh -v 11 -d /tmp/place'")
     end
   end
 
@@ -220,7 +220,7 @@ describe Kitchen::Provisioner::ChefBase do
       config[:sudo] = true
 
       provisioner.init_command.
-        must_match regexify("sudo -E rm -rf ", :partial_line)
+        must_match regexify("sudo su -m -c 'rm -rf ", :partial_line)
     end
 
     it "does not use sudo for rm when configured" do
@@ -229,14 +229,15 @@ describe Kitchen::Provisioner::ChefBase do
       provisioner.init_command.
         must_match regexify("rm -rf ", :partial_line)
       provisioner.init_command.
-        wont_match regexify("sudo -E rm -rf ", :partial_line)
+        wont_match regexify("sudo su -m -c 'rm -rf ", :partial_line)
     end
 
     %w[cookbooks data data_bags environments roles clients].each do |dir|
       it "removes the #{dir} directory" do
         config[:root_path] = "/route"
 
-        provisioner.init_command.must_match %r{rm -rf\b.*\s+/route/#{dir}\s+}
+        provisioner.init_command.
+          must_match %r{'rm -rf\b.*\s+/route/#{dir}[\s']+}
       end
     end
 

--- a/spec/kitchen/provisioner/chef_solo_spec.rb
+++ b/spec/kitchen/provisioner/chef_solo_spec.rb
@@ -238,7 +238,8 @@ describe Kitchen::Provisioner::ChefSolo do
       config[:chef_omnibus_root] = "/c"
       config[:sudo] = true
 
-      cmd.must_match regexify("sudo -E /c/bin/chef-solo ", :partial_line)
+      cmd.must_match regexify("sudo su -m -c '/c/bin/chef-solo ",
+                              :partial_line)
     end
 
     it "does not use sudo for chef-solo when configured" do
@@ -246,7 +247,8 @@ describe Kitchen::Provisioner::ChefSolo do
       config[:sudo] = false
 
       cmd.must_match regexify("chef-solo ", :partial_line)
-      cmd.wont_match regexify("sudo -E /c/bin/chef-solo ", :partial_line)
+      cmd.wont_match regexify("sudo su -m -c '/c/bin/chef-solo' ",
+                              :partial_line)
     end
 
     it "sets config flag on chef-solo" do

--- a/spec/kitchen/provisioner/chef_zero_spec.rb
+++ b/spec/kitchen/provisioner/chef_zero_spec.rb
@@ -360,12 +360,13 @@ describe Kitchen::Provisioner::ChefZero do
 
       it "checks if chef-zero is installed" do
         cmd.must_match regexify(
-          %{if ! sudo -E /rbd/gem list chef-zero -i >/dev/null; then})
+          %{if ! sudo su -m -c '/rbd/gem list chef-zero -i >/dev/null'; then})
       end
 
       it "installs the chef gem" do
         cmd.must_match regexify(
-          %{sudo -E /rbd/gem install chef --no-ri --no-rdoc --conservative})
+          %{sudo su -m -c '/rbd/gem install chef --no-ri --no-rdoc } +
+            %{--conservative'})
       end
     end
   end
@@ -387,7 +388,8 @@ describe Kitchen::Provisioner::ChefZero do
         config[:chef_omnibus_root] = "/c"
         config[:sudo] = true
 
-        cmd.must_match regexify("sudo -E /c/bin/chef-client ", :partial_line)
+        cmd.must_match regexify("sudo su -m -c '/c/bin/chef-client ",
+                                :partial_line)
       end
 
       it "does not use sudo for chef-client when configured" do
@@ -395,7 +397,8 @@ describe Kitchen::Provisioner::ChefZero do
         config[:sudo] = false
 
         cmd.must_match regexify("/c/bin/chef-client ", :partial_line)
-        cmd.wont_match regexify("sudo -E /c/bin/chef-client ", :partial_line)
+        cmd.wont_match regexify("sudo su -m -c '/c/bin/chef-client' ",
+                                :partial_line)
       end
 
       it "sets local mode flag on chef-client" do
@@ -505,7 +508,7 @@ describe Kitchen::Provisioner::ChefZero do
         config[:sudo] = true
 
         cmd.must_match regexify(
-          "sudo -E /r/bin/ruby /x/chef-client-zero.rb ", :partial_line)
+          "sudo su -m -c '/r/bin/ruby /x/chef-client-zero.rb' ", :partial_line)
       end
 
       it "does not use sudo for ruby when configured" do
@@ -515,7 +518,7 @@ describe Kitchen::Provisioner::ChefZero do
         cmd.must_match regexify(
           "/r/bin/ruby /x/chef-client-zero.rb ", :partial_line)
         cmd.wont_match regexify(
-          "sudo -E /r/bin/ruby /x/chef-client-zero.rb ", :partial_line)
+          "sudo su -m -c '/r/bin/ruby /x/chef-client-zero.rb' ", :partial_line)
       end
 
       it "does not set local mode flag" do

--- a/spec/kitchen/provisioner/shell_spec.rb
+++ b/spec/kitchen/provisioner/shell_spec.rb
@@ -69,7 +69,7 @@ describe Kitchen::Provisioner::Shell do
     it "uses sudo for rm when configured" do
       config[:sudo] = true
 
-      cmd.must_match regexify("sudo -E rm -rf ", :partial_line)
+      cmd.must_match regexify("sudo su -m -c 'rm -rf ", :partial_line)
     end
 
     it "does not use sudo for rm when configured" do
@@ -78,13 +78,13 @@ describe Kitchen::Provisioner::Shell do
       provisioner.init_command.
         must_match regexify("rm -rf ", :partial_line)
       provisioner.init_command.
-        wont_match regexify("sudo -E rm -rf ", :partial_line)
+        wont_match regexify("sudo su -m -c 'rm -rf ", :partial_line)
     end
 
     it "removes the data directory" do
       config[:root_path] = "/route"
 
-      cmd.must_match %r{rm -rf\b.*\s+/route/data\s+}
+      cmd.must_match %r{'rm -rf\b.*\s+/route/data'\s+}
     end
 
     it "creates :root_path directory" do
@@ -107,7 +107,7 @@ describe Kitchen::Provisioner::Shell do
       config[:root_path] = "/r"
       config[:sudo] = true
 
-      cmd.must_match regexify("sudo -E /r/bootstrap.sh", :partial_line)
+      cmd.must_match regexify("sudo su -m -c '/r/bootstrap.sh'", :partial_line)
     end
 
     it "does not use sudo for script when configured" do
@@ -115,7 +115,7 @@ describe Kitchen::Provisioner::Shell do
       config[:sudo] = false
 
       cmd.must_match regexify("/r/bootstrap.sh", :partial_line)
-      cmd.wont_match regexify("sudo -E /r/bootstrap.sh", :partial_line)
+      cmd.wont_match regexify("sudo su -m -c '/r/bootstrap.sh'", :partial_line)
     end
   end
 

--- a/spec/kitchen/shell_out_spec.rb
+++ b/spec/kitchen/shell_out_spec.rb
@@ -107,7 +107,8 @@ describe Kitchen::ShellOut do
 
     it "prepends with sudo if :use_sudo is truthy" do
       Mixlib::ShellOut.unstub(:new)
-      Mixlib::ShellOut.expects(:new).with("sudo -E yo", opts).returns(command)
+      Mixlib::ShellOut.expects(:new).with("sudo su -m -c 'yo'", opts).
+        returns(command)
 
       subject.run_command("yo", :use_sudo => true)
     end

--- a/spec/kitchen/ssh_spec.rb
+++ b/spec/kitchen/ssh_spec.rb
@@ -406,6 +406,7 @@ describe Kitchen::SSH do
     end
 
     it "logs upload progress to debug" do
+      # FIXME: this isn't guaranteed to be /tmp
       remote_base = "/tmp/#{File.basename(@dir)}"
 
       with_sorted_dir_entries do


### PR DESCRIPTION
This fixes #307; any other changes are intended to be refactors to improve readability and reduce complexity.

`sudo su -m` was chosen to maintain compatibility with the current usage of `sudo -E`.