### PR TITLE
Fixes Chef Client installation on Windows Guests

### DIFF
--- a/support/chef_helpers.ps1
+++ b/support/chef_helpers.ps1
@@ -29,13 +29,7 @@ function download_chef($chef_url, $chef_msi) {
 
 # function to install chef with sort of a nice progress bar
 function install_chef {
-  $proc_msi = Start-Process -FilePath 'msiexec.exe' -ArgumentList "/qn /i $chef_msi" -Passthru
-  $bar = ""
-  while (-Not $proc_msi.HasExited ) {
-    Write-Host -NoNewline "`r`t[MSI] [$bar"
-    Start-Sleep 2
-    $bar += "#"
-  }
+  $proc_msi = Start-Process -FilePath 'msiexec.exe' -ArgumentList "/qn /i $chef_msi" -Passthru -Wait
 
   if ($proc_msi.ExitCode -ne 0) {
     throw "msiexec was not successful. Received exit code $($proc_msi.ExitCode)"

--- a/support/chef_helpers.ps1
+++ b/support/chef_helpers.ps1
@@ -29,17 +29,11 @@ function download_chef($chef_url, $chef_msi) {
 
 # function to install chef with sort of a nice progress bar
 function install_chef {
-  $proc_msi = Start-Process -FilePath 'msiexec.exe' -ArgumentList "/qn /i $chef_msi" -Passthru
-  $bar = ""
-  while (-Not $proc_msi.HasExited ) {
-    Write-Host -NoNewline "`r`t[MSI] [$bar"
-    Start-Sleep 2
-    $bar += "#"
-  }
+  $proc_msi = Start-Process -FilePath 'msiexec.exe' -ArgumentList "/qn /i $chef_msi" -Passthru -Wait
 
   if ($proc_msi.ExitCode -ne 0) {
     throw "msiexec was not successful. Received exit code $($proc_msi.ExitCode)"
   }
   rm -r $chef_msi
-  Write-Host -NoNewline "`r`t[MSI] [$bar] Completed!\n"
+  Write-Host -NoNewline "`r`t[MSI] Completed!\n"
 }

--- a/support/chef_helpers.ps1
+++ b/support/chef_helpers.ps1
@@ -36,7 +36,7 @@ function install_chef {
     Start-Sleep 2
     $bar += "#"
   }
-
+  $proc_msi.WaitForExit()
   if ($proc_msi.ExitCode -ne 0) {
     throw "msiexec was not successful. Received exit code $($proc_msi.ExitCode)"
   }

--- a/support/chef_helpers.ps1
+++ b/support/chef_helpers.ps1
@@ -29,7 +29,13 @@ function download_chef($chef_url, $chef_msi) {
 
 # function to install chef with sort of a nice progress bar
 function install_chef {
-  $proc_msi = Start-Process -FilePath 'msiexec.exe' -ArgumentList "/qn /i $chef_msi" -Passthru -Wait
+  $proc_msi = Start-Process -FilePath 'msiexec.exe' -ArgumentList "/qn /i $chef_msi" -Passthru
+  $bar = ""
+  while (-Not $proc_msi.HasExited ) {
+    Write-Host -NoNewline "`r`t[MSI] [$bar"
+    Start-Sleep 2
+    $bar += "#"
+  }
 
   if ($proc_msi.ExitCode -ne 0) {
     throw "msiexec was not successful. Received exit code $($proc_msi.ExitCode)"

--- a/support/chef_helpers.ps1
+++ b/support/chef_helpers.ps1
@@ -36,7 +36,7 @@ function install_chef {
     Start-Sleep 2
     $bar += "#"
   }
-  $proc_msi.WaitForExit()
+
   if ($proc_msi.ExitCode -ne 0) {
     throw "msiexec was not successful. Received exit code $($proc_msi.ExitCode)"
   }


### PR DESCRIPTION
Fixes #601 - It removes the progress bar as the MSI installs due to calling Start-Process with the -Wait option, but keeps the check on the Exitcode.

cc @afiune @jdmundrawala 