### PR TITLE
Add SSH keepalive options, so that long-running commands don't time out

### DIFF
--- a/lib/kitchen/driver/ssh_base.rb
+++ b/lib/kitchen/driver/ssh_base.rb
@@ -120,6 +120,8 @@ module Kitchen
         opts[:port] = combined[:port] if combined[:port]
         opts[:keys] = Array(combined[:ssh_key]) if combined[:ssh_key]
         opts[:logger] = logger
+        opts[:keepalive] = true
+        opts[:keepalive_interval] = 60
 
         [combined[:hostname], combined[:username], opts]
       end


### PR DESCRIPTION
NOTE: WIP,  looking for help to make this configurable.

While working with a Chef user (Windows host, Linux guest), we noticed that his test-kitchen runs failed during very long resources where no output was emitted for several minutes. 

We noticed that net-ssh has `:keepalive` defaulted to `false`.   By changing it to true and lowering the `:keepalive_interval` we were able to eliminate the failures.
