### PR TITLE
Del :ssh_retries & :ssh_timeout before ssh connect

### DIFF
--- a/lib/kitchen/ssh.rb
+++ b/lib/kitchen/ssh.rb
@@ -195,6 +195,9 @@ module Kitchen
         Net::SSH::Disconnect, Net::SSH::AuthenticationFailed
       ]
       retries = options[:ssh_retries] || 3
+      timeout = options[:ssh_timeout] || 1
+      options.delete(:ssh_retries) if options.has_key?(:ssh_retries)
+      options.delete(:ssh_timeout) if options.has_key?(:ssh_timeout)
 
       begin
         logger.debug("[SSH] opening connection to #{self}")
@@ -203,7 +206,7 @@ module Kitchen
         retries -= 1
         if retries > 0
           logger.info("[SSH] connection failed, retrying (#{e.inspect})")
-          sleep options[:ssh_timeout] || 1
+          sleep timeout
           retry
         else
           logger.warn("[SSH] connection failed, terminating (#{e.inspect})")


### PR DESCRIPTION
`Net::SSH::start` does not support Kitchen's SSH `:ssh_retries` and
`:ssh_timeout` options. Remove them from the `options` hash before
establish the connection.

Please note that `Kitchen::SSH.new(*build_ssh_args(state))` never builds 
the `:ssh_retries` and `:ssh_timeout` options and they only are passed through
`Kitchen::SSH` when [testing the connection](https://github.com/test-kitchen/test-kitchen/blob/master/lib/kitchen/driver/ssh_base.rb#L180) 

where `Net::SSH::start` is not called.
