### PR TITLE
Windows2003 guest fix

### DIFF
--- a/lib/kitchen/transport/winrm_file_transfer/remote_zip_file.rb
+++ b/lib/kitchen/transport/winrm_file_transfer/remote_zip_file.rb
@@ -93,7 +93,7 @@ module Kitchen
             $shellApplication = new-object -com shell.application
 
             $zipPackage = $shellApplication.NameSpace('#{remote_path}')
-            Remove-Item -Recurse -Force $dest | Out-Null
+            if ( Test-Path $dest ) { Remove-Item -Recurse -Force $dest | Out-Null }
             mkdir $dest -ErrorAction SilentlyContinue | Out-Null
             $destinationFolder = $shellApplication.NameSpace($dest)
             $destinationFolder.CopyHere($zipPackage.Items(),0x10) | Out-Null

--- a/lib/kitchen/transport/winrm_file_transfer/remote_zip_file.rb
+++ b/lib/kitchen/transport/winrm_file_transfer/remote_zip_file.rb
@@ -55,6 +55,7 @@ module Kitchen
           logger.debug("iterating files in '#{glob}'")
           Zip::File.open(archive, "w") do |zipfile|
             Dir.glob(glob).each do |file|
+              next if File.directory?(file)
               logger.debug("adding zip entry for '#{file}'")
               entry = Zip::Entry.new(
                 archive,

--- a/lib/kitchen/transport/winrm_file_transfer/remote_zip_file.rb
+++ b/lib/kitchen/transport/winrm_file_transfer/remote_zip_file.rb
@@ -93,6 +93,7 @@ module Kitchen
             $shellApplication = new-object -com shell.application
 
             $zipPackage = $shellApplication.NameSpace('#{remote_path}')
+            Remove-Item -Recurse -Force $dest | Out-Null
             mkdir $dest -ErrorAction SilentlyContinue | Out-Null
             $destinationFolder = $shellApplication.NameSpace($dest)
             $destinationFolder.CopyHere($zipPackage.Items(),0x10) | Out-Null


### PR DESCRIPTION
May be not relevant for all Windows versions, however, the following changes in the transport workflow  made the 'windows-guest-support' branch of test kitchen work with my Windows 2003R2 box on Vagrant.
Please,contact me if you need any more info about the topic.