### PR TITLE
Removes extraneous "driver" from help info

### DIFF
--- a/lib/kitchen/cli.rb
+++ b/lib/kitchen/cli.rb
@@ -288,7 +288,7 @@ module Kitchen
 
       # @return [String] basename
       def self.basename
-        super + " driver"
+        super
       end
     end
 


### PR DESCRIPTION
Fix for #613 