### PR TITLE
Populate Chef Zero provisioner cookbook cache

### DIFF
--- a/lib/kitchen/provisioner/chef_zero.rb
+++ b/lib/kitchen/provisioner/chef_zero.rb
@@ -41,6 +41,7 @@ module Kitchen
       def create_sandbox
         super
         prepare_chef_client_zero_rb
+        prepare_chef_zero_cache
         prepare_validation_pem
         prepare_client_rb
       end
@@ -166,6 +167,15 @@ module Kitchen
         File.open(File.join(sandbox_path, "client.rb"), "wb") do |file|
           file.write(format_config_file(data))
         end
+      end
+
+      # Copy sandboxed cookbooks into to the sandbox cache directory. This
+      # will prime the chef-client cache in order to speed up cookbook
+      # synchronization.
+      #
+      # @api private
+      def prepare_chef_zero_cache
+        FileUtils.cp_r(tmpbooks_dir, File.join(sandbox_path, "cache"))
       end
 
       # Generates a string of shell environment variables needed for the

--- a/spec/kitchen/provisioner/chef_zero_spec.rb
+++ b/spec/kitchen/provisioner/chef_zero_spec.rb
@@ -187,7 +187,7 @@ describe Kitchen::Provisioner::ChefZero do
         file.must_include %{client_key "lol"}
       end
 
-      it " supports adding new configuration" do
+      it "supports adding new configuration" do
         config[:client_rb] = {
           :dark_secret => "golang"
         }
@@ -293,6 +293,15 @@ describe Kitchen::Provisioner::ChefZero do
           logged_output.string.must_match debug_line_starting_with(
             "Using a vendored chef-client-zero.rb")
         end
+      end
+    end
+
+    describe "populating cache" do
+
+      it "moves cookbooks into the cache directory" do
+        provisioner.create_sandbox
+
+        sandbox_path("cache/cookbooks").directory?.must_equal true
       end
     end
 


### PR DESCRIPTION
The Chef Zero provisioner can run the test client in local
mode, but when the test client is first created and invoked
it still needs to download cookbooks from the Chef Zero
server. I have found this initial "Synchronizing Cookbooks"
to be slow when there are many cookbooks in the test run list.

This patch copies the cookbooks used to populate the Chef
Zero server into the kitchen cache directory, which is the
cache directory of the test client. When the client runs
its initial "Synchronizing Cookbooks", the cookbooks will
already be in the cache and the initial synchronization
will be faster.

I should add that doing this will increase the size of the
sandbox needing to be transferred to the remote node.
Because of this I would recommend that something like
#466 is a prerequisite to this, otherwise uploading the

sandbox to remote provisioners can be prohibitively slow
(using local provisioners like Vagrant and Docker will
be faster straight away without needing packaging / 
compression).
