### PR TITLE
Add Provisioner chef_apply

### DIFF
--- a/lib/kitchen/provisioner/chef_apply.rb
+++ b/lib/kitchen/provisioner/chef_apply.rb
@@ -1,0 +1,125 @@
+# -*- encoding: utf-8 -*-
+#
+# Author:: SAWANOBORI Yukihiko <sawanoboriyu@higanworks.com>)
+#
+# Copyright (C) 2015, HiganWorks LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Usage:
+#
+# puts your recipes to` apply/` directory.
+#
+# An example of .kitchen.yml.
+#
+# ---
+# driver:
+#   name: vagrant
+#
+# provisioner:
+#   name: chef_apply
+#
+# platforms:
+#   - name: ubuntu-12.04
+#   - name: centos-6.4
+#
+# suites:
+#   - name: default
+#     run_list:
+#       - recipe1
+#       - recipe2
+#
+#
+# The chef-apply runs twice below.
+#
+# chef-apply apply/recipe1.rb
+# chef-apply apply/recipe2.rb
+
+require "kitchen/provisioner/chef_base"
+
+module Kitchen
+
+  module Provisioner
+
+    # Chef Apply provisioner.
+    #
+    # @author SAWANOBORI Yukihiko <sawanoboriyu@higanworks.com>)
+    class ChefApply < ChefBase
+
+      kitchen_provisioner_api_version 2
+
+      plugin_version Kitchen::VERSION
+
+      default_config :chef_apply_path do |provisioner|
+        provisioner.
+          remote_path_join(%W[#{provisioner[:chef_omnibus_root]} bin chef-apply]).
+          tap { |path| path.concat(".bat") if provisioner.windows_os? }
+      end
+
+      default_config :apply_path do |provisioner|
+        provisioner.calculate_path("apply")
+      end
+      expand_path_for :apply_path
+
+      # (see ChefBase#create_sandbox)
+      def create_sandbox
+        @sandbox_path = Dir.mktmpdir("#{instance.name}-sandbox-")
+        File.chmod(0755, sandbox_path)
+        info("Preparing files for transfer")
+        debug("Creating local sandbox in #{sandbox_path}")
+
+        prepare_json
+        prepare(:apply)
+      end
+
+      # (see ChefBase#init_command)
+      def init_command
+        dirs = %w[
+          apply
+        ].sort.map { |dir| remote_path_join(config[:root_path], dir) }
+
+        vars = if powershell_shell?
+          init_command_vars_for_powershell(dirs)
+        else
+          init_command_vars_for_bourne(dirs)
+        end
+
+        prefix_command(shell_code_from_file(vars, "chef_base_init_command"))
+      end
+
+      # (see ChefSolo#run_command)
+      def run_command
+        level = config[:log_level] == :info ? :auto : config[:log_level]
+
+        lines = []
+        config[:run_list].map do |recipe|
+          cmd = sudo(config[:chef_apply_path]).dup.
+            tap { |str| str.insert(0, "& ") if powershell_shell? }
+          args = [
+            "apply/#{recipe}.rb",
+            "--log_level #{level}",
+            "--no-color"
+          ]
+          args << "--logfile #{config[:log_file]}" if config[:log_file]
+
+          lines << wrap_shell_code(
+            [cmd, *args].join(" ").
+            tap { |str| str.insert(0, reload_ps1_path) if windows_os? }
+          )
+        end
+
+        prefix_command(lines.join("\n"))
+      end
+    end
+  end
+end

--- a/spec/kitchen/provisioner/chef_apply_spec.rb
+++ b/spec/kitchen/provisioner/chef_apply_spec.rb
@@ -1,0 +1,136 @@
+# -*- encoding: utf-8 -*-
+#
+# Author:: SAWANOBORI Yukihiko <sawanoboriyu@higanworks.com>)
+#
+# Copyright (C) 2015, HiganWorks LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative "../../spec_helper"
+
+require "kitchen"
+require "kitchen/provisioner/chef_apply"
+
+describe Kitchen::Provisioner::ChefApply do
+
+  let(:logged_output)   { StringIO.new }
+  let(:logger)          { Logger.new(logged_output) }
+  let(:platform)        { stub(:os_type => nil) }
+  let(:suite)           { stub(:name => "fries") }
+
+  let(:config) do
+    { :test_base_path => "/b", :kitchen_root => "/r", :log_level => :info }
+  end
+
+  let(:instance) do
+    stub(
+      :name => "coolbeans",
+      :logger => logger,
+      :suite => suite,
+      :platform => platform
+    )
+  end
+
+  let(:provisioner) do
+    Kitchen::Provisioner::ChefApply.new(config).finalize_config!(instance)
+  end
+
+  it "provisioner api_version is 2" do
+    provisioner.diagnose_plugin[:api_version].must_equal 2
+  end
+
+  it "plugin_version is set to Kitchen::VERSION" do
+    provisioner.diagnose_plugin[:version].must_equal Kitchen::VERSION
+  end
+
+  describe "default config" do
+
+    it "sets :chef_apply_path to a path using :chef_omnibus_root" do
+      config[:chef_omnibus_root] = "/nice/place"
+
+      provisioner[:chef_apply_path].must_equal "/nice/place/bin/chef-apply"
+    end
+  end
+
+  describe "#create_sandbox" do
+
+    before do
+      @root = Dir.mktmpdir
+      config[:kitchen_root] = @root
+    end
+
+    after do
+      FileUtils.remove_entry(@root)
+      begin
+        provisioner.cleanup_sandbox
+      rescue # rubocop:disable Lint/HandleExceptions
+      end
+    end
+  end
+
+  describe "#run_command" do
+
+    before do
+      config[:run_list] = %w[appry_recipe1 appry_recipe2]
+    end
+
+    let(:cmd) { provisioner.run_command }
+
+    describe "for bourne shells" do
+
+      before { platform.stubs(:shell_type).returns("bourne") }
+
+      it "uses bourne shell" do
+        cmd.must_match(/\Ash -c '$/)
+        cmd.must_match(/'\Z/)
+      end
+
+      it "uses sudo for chef-apply when configured" do
+        config[:chef_omnibus_root] = "/c"
+        config[:sudo] = true
+
+        cmd.must_match regexify("sudo -E /c/bin/chef-apply apply/appry_recipe1.rb ", :partial_line)
+        cmd.must_match regexify("sudo -E /c/bin/chef-apply apply/appry_recipe2.rb ", :partial_line)
+      end
+
+      it "does not use sudo for chef-apply when configured" do
+        config[:chef_omnibus_root] = "/c"
+        config[:sudo] = false
+
+        cmd.must_match regexify("chef-apply apply/appry_recipe1.rb ", :partial_line)
+        cmd.must_match regexify("chef-apply apply/appry_recipe2.rb ", :partial_line)
+        cmd.wont_match regexify("sudo -E /c/bin/chef-apply ")
+      end
+
+      it "sets log level flag on chef-apply to auto by default" do
+        cmd.must_match regexify(" --log_level auto", :partial_line)
+      end
+
+      it "set log level flag for custom level" do
+        config[:log_level] = :extreme
+
+        cmd.must_match regexify(" --log_level extreme", :partial_line)
+      end
+
+      it "sets no color flag on chef-apply" do
+        cmd.must_match regexify(" --no-color", :partial_line)
+      end
+    end
+  end
+
+  def regexify(str, line = :whole_line)
+    r = Regexp.escape(str)
+    r = "^\s*#{r}$" if line == :whole_line
+    Regexp.new(r)
+  end
+end


### PR DESCRIPTION
Hi,

I've added new provider chef_apply.

Usage:

1. create recipes to `apply/` directory.
1. set chef_apply to kitchen provisioner.
1. run kitchen.

An example of `.kitchen.yml` here.

```
---
driver:
  name: vagrant

provisioner:
  name: chef_apply

platforms:
  - name: ubuntu-12.04
  - name: centos-6.4

suites:
  - name: default
    run_list:
      - recipe1
      - recipe2
```

The chef-apply runs twice below.
 - chef-apply apply/recipe1.rb
 - chef-apply apply/recipe2.rb