### PR TITLE
install omnibus-chef before install busser if ruby missing for avoid `gem: command not found`

### DIFF
--- a/lib/kitchen/busser.rb
+++ b/lib/kitchen/busser.rb
@@ -18,7 +18,8 @@
 
 require "base64"
 require "digest"
-require "Kitchen/provisioner/chef_base"
+require "kitchen"
+require "kitchen/provisioner/chef_base"
 
 module Kitchen
 

--- a/lib/kitchen/busser.rb
+++ b/lib/kitchen/busser.rb
@@ -294,7 +294,7 @@ module Kitchen
       [
         "if [ ! -d #{config[:ruby_bindir]} ] ; then",
         omnibus_chef_install_command,
-        'fi ;',
+        "fi ;",
         %{BUSSER_ROOT="#{config[:root_path]}"},
         %{GEM_HOME="#{config[:root_path]}/gems"},
         %{GEM_PATH="#{config[:root_path]}/gems"},
@@ -321,7 +321,7 @@ module Kitchen
     # (see ChefBase#install_command)
     def omnibus_chef_install_command
       lines = Kitchen::Provisioner::ChefBase.new.instance_eval(
-         '[Util.shell_helpers, chef_shell_helpers, chef_install_function]'
+         "[Util.shell_helpers, chef_shell_helpers, chef_install_function]"
       )
       lines.join("\n")
     end

--- a/lib/kitchen/busser.rb
+++ b/lib/kitchen/busser.rb
@@ -18,6 +18,7 @@
 
 require "base64"
 require "digest"
+require "Kitchen/provisioner/chef_base"
 
 module Kitchen
 
@@ -290,6 +291,9 @@ module Kitchen
     # @api private
     def busser_setup_env
       [
+        "if [ ! -d #{config[:ruby_bindir]} ] ; then",
+        omnibus_chef_install_command,
+        'fi ;',
         %{BUSSER_ROOT="#{config[:root_path]}"},
         %{GEM_HOME="#{config[:root_path]}/gems"},
         %{GEM_PATH="#{config[:root_path]}/gems"},
@@ -311,6 +315,14 @@ module Kitchen
       args += " --version #{version}" if version
       args += " --no-rdoc --no-ri"
       args
+    end
+
+    # (see ChefBase#install_command)
+    def omnibus_chef_install_command
+      lines = Kitchen::Provisioner::ChefBase.new.instance_eval(
+         '[Util.shell_helpers, chef_shell_helpers, chef_install_function]'
+      )
+      lines.join("\n")
     end
   end
 end


### PR DESCRIPTION
Hi, 

This PR is written for problem of https://github.com/test-kitchen/test-kitchen/issues/347. (and maybe https://github.com/test-kitchen/test-kitchen/issues/362 too?)
In rare cases, there is that I would like to run test on VM which was provisioned by shell with bats .

I think that this is a temporary implement until policy of yours will be determined.