### PR TITLE
Fixing bad default setting - if ENV is not set we are accidently setting log_level to nil for whole run

### DIFF
--- a/lib/kitchen/cli.rb
+++ b/lib/kitchen/cli.rb
@@ -64,6 +64,8 @@ module Kitchen
     # high
     MAX_CONCURRENCY = 9999
 
+    attr_reader :config
+
     # Constructs a new instance.
     def initialize(*args)
       super
@@ -76,8 +78,8 @@ module Kitchen
       @config = Kitchen::Config.new(
         :loader     => @loader
       )
-      @config[:log_level] = Kitchen.env_log unless Kitchen.env_log.nil?
-      @config[:log_overwrite] = Kitchen.env_log_overwrite unless Kitchen.env_log_overwrite.nil?
+      @config.log_level = Kitchen.env_log unless Kitchen.env_log.nil?
+      @config.log_overwrite = Kitchen.env_log_overwrite unless Kitchen.env_log_overwrite.nil?
     end
 
     # Sets the logging method_options

--- a/lib/kitchen/cli.rb
+++ b/lib/kitchen/cli.rb
@@ -74,10 +74,10 @@ module Kitchen
         :global_config => ENV["KITCHEN_GLOBAL_YAML"]
       )
       @config = Kitchen::Config.new(
-        :loader     => @loader,
-        :log_level  => Kitchen.env_log,
-        :log_overwrite => Kitchen.env_log_overwrite
+        :loader     => @loader
       )
+      @config[:log_level] = Kitchen.env_log unless Kitchen.env_log.nil?
+      @config[:log_overwrite] = Kitchen.env_log_overwrite unless Kitchen.env_log_overwrite.nil?
     end
 
     # Sets the logging method_options

--- a/spec/kitchen/cli_spec.rb
+++ b/spec/kitchen/cli_spec.rb
@@ -1,0 +1,56 @@
+# -*- encoding: utf-8 -*-
+#
+# Author:: Tyler Ball (<tball@chef.io>)
+#
+# Copyright (C) 2015, Fletcher Nichol
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative "../spec_helper"
+
+require "kitchen/cli"
+require "kitchen"
+
+module Kitchen
+  describe CLI do
+
+    let(:cli) { CLI.new }
+
+    before do
+      @orig_env = ENV.to_hash
+    end
+
+    after do
+      ENV.clear
+      @orig_env.each do |k, v|
+        ENV[k] = v
+      end
+    end
+
+    describe "#initialize" do
+      it "does not set logging config when environment variables are missing" do
+        assert_equal Kitchen::DEFAULT_LOG_LEVEL, cli.config.log_level
+        assert_equal Kitchen::DEFAULT_LOG_OVERWRITE, cli.config.log_overwrite
+      end
+
+      it "does set logging config when environment variables are present" do
+        ENV["KITCHEN_LOG"] = "warn"
+        ENV["KITCHEN_LOG_OVERWRITE"] = "false"
+
+        assert_equal :warn, cli.config.log_level
+        assert_equal false, cli.config.log_overwrite
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
This is a follow up to https://github.com/test-kitchen/test-kitchen/pull/600/files, which introduced a bug.  Not setting ENV[:log_level] causes the converge step to fail because we create the provisioner string `chef-client --log-level` with no supplied log level.

\cc @fnichol @schisamo 