### PR TITLE
open zip file in binary mode to avoid corrupting zip files on  windows

### DIFF
--- a/lib/kitchen/transport/winrm/tmp_zip.rb
+++ b/lib/kitchen/transport/winrm/tmp_zip.rb
@@ -79,7 +79,7 @@ module Kitchen
           @dir = Pathname.new(dir)
           @method = ::Zip::Entry::DEFLATED
           @compression = Zlib::BEST_COMPRESSION
-          @zip_io = Tempfile.open(["tmpzip-", ".zip"])
+          @zip_io = Tempfile.open(["tmpzip-", ".zip"], :binmode => true)
           write_zip
           @zip_io.close
         end


### PR DESCRIPTION
fixes #643 by opening the zip to create in binary mode. This prevents the output stream from getting corrupted by extra carriage returns.