### PR TITLE
If bundler is defined, require any items defined within Gemfile

### DIFF
--- a/bin/kitchen
+++ b/bin/kitchen
@@ -10,4 +10,6 @@ require "rubygems"
 require "kitchen/cli"
 require "kitchen/errors"
 
+Bundler.require if defined?(Bundler)
+
 Kitchen.with_friendly_errors { Kitchen::CLI.start }


### PR DESCRIPTION
ohai! I would like to be able to have some gems be loaded automatically based on the Gemfile. This change allows that if Bundler is around.
