### PR TITLE
[Transport::Winrm] Truncate destination file for overwriting.

### DIFF
--- a/support/decode_files.ps1.erb
+++ b/support/decode_files.ps1.erb
@@ -8,6 +8,7 @@ Function Decode-Base64File($src, $dst) {
     $b64 = New-Object -TypeName System.Security.Cryptography.FromBase64Transform
     $m = [System.Security.Cryptography.CryptoStreamMode]::Read
     $d = New-Object -TypeName System.Security.Cryptography.CryptoStream $in,$b64,$m
+    echo $null > $dst
     Copy-Stream $d ($out = [System.IO.File]::OpenWrite($dst))
   } Finally { Cleanup $in; Cleanup $out; Cleanup $d }
 }


### PR DESCRIPTION
If the destination file already exists and is larger than the new
source, the tail of the file will still contain content from the last
upload. Instead, we'll truncate an empty file before streaming the
decoded file into the destination.