### PR TITLE
Add :sudo_command to Provisioners, Verifiers, & ShellOut.

### DIFF
--- a/lib/kitchen/provisioner/base.rb
+++ b/lib/kitchen/provisioner/base.rb
@@ -40,6 +40,10 @@ module Kitchen
         provisioner.windows_os? ? nil : true
       end
 
+      default_config :sudo_command do |provisioner|
+        provisioner.windows_os? ? nil : "sudo -E"
+      end
+
       expand_path_for :test_base_path
 
       # Constructs a new provisioner by providing a configuration hash.
@@ -179,7 +183,7 @@ module Kitchen
       # @return [String] the command, conditionaly prefixed with sudo
       # @api private
       def sudo(script)
-        config[:sudo] ? "sudo -E #{script}" : script
+        config[:sudo] ? "#{config[:sudo_command]} #{script}" : script
       end
     end
   end

--- a/lib/kitchen/shell_out.rb
+++ b/lib/kitchen/shell_out.rb
@@ -35,6 +35,8 @@ module Kitchen
     # @param options [Hash] additional configuration of command
     # @option options [TrueClass, FalseClass] :use_sudo whether or not to use
     #   sudo
+    # @option options [String] :sudo_command custom sudo command to use.
+    #   Default is "sudo -E".
     # @option options [String] :log_subject used in the output or log header
     #   for clarity and context. Default is "local".
     # @option options [String] :cwd the directory to chdir to before running
@@ -56,7 +58,9 @@ module Kitchen
     # @raise [ShellCommandFailed] if the command fails
     # @raise [Error] for all other unexpected exceptions
     def run_command(cmd, options = {})
-      cmd = "sudo -E #{cmd}" if options.fetch(:use_sudo, false)
+      if options.fetch(:use_sudo, false)
+        cmd = "#{options.fetch(:sudo_command, "sudo -E")} #{cmd}"
+      end
       subject = "[#{options.fetch(:log_subject, "local")} command]"
 
       debug("#{subject} BEGIN (#{cmd})")
@@ -81,7 +85,7 @@ module Kitchen
     # @api private
     def shell_opts(options)
       filtered_opts = options.reject do |key, _value|
-        [:use_sudo, :log_subject, :quiet].include?(key)
+        [:use_sudo, :sudo_command, :log_subject, :quiet].include?(key)
       end
       { :live_stream => logger, :timeout => 60000 }.merge(filtered_opts)
     end

--- a/lib/kitchen/verifier/base.rb
+++ b/lib/kitchen/verifier/base.rb
@@ -44,6 +44,10 @@ module Kitchen
         verifier.windows_os? ? nil : true
       end
 
+      default_config :sudo_command do |verifier|
+        verifier.windows_os? ? nil : "sudo -E"
+      end
+
       default_config(:suite_name) { |busser| busser.instance.suite.name }
 
       # Creates a new Verifier object using the provided configuration data
@@ -184,7 +188,7 @@ module Kitchen
       # @return [String] the command, conditionaly prefixed with sudo
       # @api private
       def sudo(script)
-        config[:sudo] ? "sudo -E #{script}" : script
+        config[:sudo] ? "#{config[:sudo_command]} #{script}" : script
       end
     end
   end

--- a/spec/kitchen/provisioner/base_spec.rb
+++ b/spec/kitchen/provisioner/base_spec.rb
@@ -101,6 +101,10 @@ describe Kitchen::Provisioner::Base do
       it ":sudo defaults to true" do
         provisioner[:sudo].must_equal true
       end
+
+      it ":sudo_command defaults to sudo -E" do
+        provisioner[:sudo_command].must_equal "sudo -E"
+      end
     end
 
     describe "for windows operating systems" do
@@ -113,6 +117,10 @@ describe Kitchen::Provisioner::Base do
 
       it ":sudo defaults to nil" do
         provisioner[:sudo].must_equal nil
+      end
+
+      it ":sudo_command defaults to nil" do
+        provisioner[:sudo_command].must_equal nil
       end
     end
 
@@ -287,16 +295,34 @@ describe Kitchen::Provisioner::Base do
 
   describe "#sudo" do
 
-    it "if :sudo is set, prepend sudo command" do
-      config[:sudo] = true
+    describe "with :sudo set" do
 
-      provisioner.send(:sudo, "wakka").must_equal("sudo -E wakka")
+      before { config[:sudo] = true }
+
+      it "prepends sudo command" do
+        provisioner.send(:sudo, "wakka").must_equal("sudo -E wakka")
+      end
+
+      it "customizes sudo when :sudo_command is set" do
+        config[:sudo_command] = "blueto -Ohai"
+
+        provisioner.send(:sudo, "wakka").must_equal("blueto -Ohai wakka")
+      end
     end
 
-    it "if :sudo is falsy, do not include sudo command" do
-      config[:sudo] = false
+    describe "with :sudo falsey" do
 
-      provisioner.send(:sudo, "wakka").must_equal("wakka")
+      before { config[:sudo] = false }
+
+      it "does not include sudo command" do
+        provisioner.send(:sudo, "wakka").must_equal("wakka")
+      end
+
+      it "does not include sudo command, even when :sudo_command is set" do
+        config[:sudo_command] = "blueto -Ohai"
+
+        provisioner.send(:sudo, "wakka").must_equal("wakka")
+      end
     end
   end
 end

--- a/spec/kitchen/shell_out_spec.rb
+++ b/spec/kitchen/shell_out_spec.rb
@@ -112,6 +112,13 @@ describe Kitchen::ShellOut do
       subject.run_command("yo", :use_sudo => true)
     end
 
+    it "prepends with custom :sudo_command if :use_sudo is truthy" do
+      Mixlib::ShellOut.unstub(:new)
+      Mixlib::ShellOut.expects(:new).with("wat yo", opts).returns(command)
+
+      subject.run_command("yo", :use_sudo => true, :sudo_command => "wat")
+    end
+
     it "logs a debug BEGIN message" do
       subject.run_command("echo whoopa\ndoopa\ndo")
 

--- a/spec/kitchen/verifier/base_spec.rb
+++ b/spec/kitchen/verifier/base_spec.rb
@@ -102,6 +102,10 @@ describe Kitchen::Verifier::Base do
         verifier[:sudo].must_equal true
       end
 
+      it ":sudo_command defaults to sudo -E" do
+        verifier[:sudo_command].must_equal "sudo -E"
+      end
+
       it ":root_path defaults to '/tmp/verifier'" do
         verifier[:root_path].must_equal "/tmp/verifier"
       end
@@ -113,6 +117,10 @@ describe Kitchen::Verifier::Base do
 
       it ":sudo defaults to nil" do
         verifier[:sudo].must_equal nil
+      end
+
+      it ":sudo_command defaults to nil" do
+        verifier[:sudo_command].must_equal nil
       end
 
       it ":root_path defaults to $env:TEMP\\verifier" do
@@ -295,16 +303,34 @@ describe Kitchen::Verifier::Base do
 
   describe "#sudo" do
 
-    it "if :sudo is set, prepend sudo command" do
-      config[:sudo] = true
+    describe "with :sudo set" do
 
-      verifier.send(:sudo, "wakka").must_equal("sudo -E wakka")
+      before { config[:sudo] = true }
+
+      it "prepends sudo command" do
+        verifier.send(:sudo, "wakka").must_equal("sudo -E wakka")
+      end
+
+      it "customizes sudo when :sudo_command is set" do
+        config[:sudo_command] = "blueto -Ohai"
+
+        verifier.send(:sudo, "wakka").must_equal("blueto -Ohai wakka")
+      end
     end
 
-    it "if :sudo is falsy, do not include sudo command" do
-      config[:sudo] = false
+    describe "with :sudo falsey" do
 
-      verifier.send(:sudo, "wakka").must_equal("wakka")
+      before { config[:sudo] = false }
+
+      it "does not include sudo command" do
+        verifier.send(:sudo, "wakka").must_equal("wakka")
+      end
+
+      it "does not include sudo command, even when :sudo_command is set" do
+        config[:sudo_command] = "blueto -Ohai"
+
+        verifier.send(:sudo, "wakka").must_equal("wakka")
+      end
     end
   end
 end


### PR DESCRIPTION
In an effort to better support older distros (such as CentOS 5), and
other distros which don't ship with sudo in $PATH (such as Solaris),
a new configuration attribute is introduced into `Provisioner::Base` and
`Verifier::Base` called `:sudo_command`. For greatest portability and
backwards compatibility this defaults to `"sudo -E"` but is now
customizable depending on your situation.

For example:

    ---
    driver:
      name: vagrant

    platforms:
      - name: centos-7.0                      # defaults apply
      - name: centos-5.11                     # removes -E flag
        provisioner:
          sudo_command: sudo
        verifier:
          sudo_command: sudo
      - name: solaris-10                      # sets custom path to sudo
        provisioner:
          sudo_command: /usr/local/bin/sudo
        verifier:
          sudo_command: /usr/local/bin/sudo

Note that a future feature proposes a way to remove the
provisioner/verifier duplication but this would only be a convenience,
not a behavior change to this commit.

Finally, `Driver::Base` was not augemented with this configuration
attribute as it is no longer responsible for creating the commands to
execute on remote instances--this is now soley the purview of
Provisioner and Verifier plugins.

Closes #592
Closes #629
Closes #307
References #321