### PR TITLE
[ChefZero,ChefSolo] Support symbol values in solo.rb & client.rb.

### DIFF
--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -212,7 +212,9 @@ module Kitchen
       # @return [String] a string representation
       # @api private
       def format_value(obj)
-        if obj.is_a?(String)
+        if obj.is_a?(String) && obj =~ /^:/
+          obj
+        elsif obj.is_a?(String)
           %{"#{obj.gsub(/\\/, "\\\\\\\\")}"}
         elsif obj.is_a?(Array)
           %{[#{obj.map { |i| format_value(i) }.join(", ")}]}

--- a/spec/kitchen/provisioner/chef_solo_spec.rb
+++ b/spec/kitchen/provisioner/chef_solo_spec.rb
@@ -258,9 +258,9 @@ describe Kitchen::Provisioner::ChefSolo do
         file.must_include %{foo 7}
       end
 
-      it "formats symbol values correctly" do
+      it "formats symbol-looking string values correctly" do
         config[:solo_rb] = {
-          :foo => :bar
+          :foo => ":bar"
         }
         provisioner.create_sandbox
 

--- a/spec/kitchen/provisioner/chef_zero_spec.rb
+++ b/spec/kitchen/provisioner/chef_zero_spec.rb
@@ -283,9 +283,9 @@ describe Kitchen::Provisioner::ChefZero do
         file.must_include %{foo 7}
       end
 
-      it "formats symbol values correctly" do
+      it "formats symbol-looking string values correctly" do
         config[:client_rb] = {
-          :foo => :bar
+          :foo => ":bar"
         }
         provisioner.create_sandbox
 


### PR DESCRIPTION
This will allow for setting such as the following to serialize correctly
into `client.rb` or `solo.rb` (depending on the Provisioner).

    ---
    driver:
      name: vagrant

    provisioner:
      name: chef_zero
      client_rb:
        ssl_verify_mode: :verify_none

    platforms:
      - name: centos-7.0

    suites:
      - name: default

Closes #556