### PR TITLE
[ChefZero] Consider `:require_chef_omnibus = 11` to be modern version.

### DIFF
--- a/lib/kitchen/provisioner/chef_zero.rb
+++ b/lib/kitchen/provisioner/chef_zero.rb
@@ -162,7 +162,7 @@ module Kitchen
         version = config[:require_chef_omnibus]
 
         case version
-        when nil, false, true, "latest"
+        when nil, false, true, 11, "11", "latest"
           true
         else
           Gem::Version.new(version) >= Gem::Version.new("11.8.0") ? true : false

--- a/spec/kitchen/provisioner/chef_zero_spec.rb
+++ b/spec/kitchen/provisioner/chef_zero_spec.rb
@@ -337,6 +337,20 @@ describe Kitchen::Provisioner::ChefZero do
 
           sandbox_path("chef-client-zero.rb").file?.must_equal false
         end
+
+        it "a version of '11' is still considered modern" do
+          config[:require_chef_omnibus] = "11"
+          provisioner.create_sandbox
+
+          sandbox_path("chef-client-zero.rb").file?.must_equal false
+        end
+
+        it "a version of 11 is still considered modern" do
+          config[:require_chef_omnibus] = 11
+          provisioner.create_sandbox
+
+          sandbox_path("chef-client-zero.rb").file?.must_equal false
+        end
       end
 
       describe "for old Chef versions" do


### PR DESCRIPTION
We should only care about versions of Chef less than 11.8.0 to be "old"
(i.e. pre-dating chef-client local mode).