### PR TITLE
Bump to centos-6.6, fix #663.

### DIFF
--- a/features/kitchen_init_command.feature
+++ b/features/kitchen_init_command.feature
@@ -213,7 +213,7 @@ Feature: Add Test Kitchen support to an existing project
 
     platforms:
       - name: ubuntu-12.04
-      - name: centos-6.4
+      - name: centos-6.6
 
     suites:
       - name: default

--- a/templates/init/kitchen.yml.erb
+++ b/templates/init/kitchen.yml.erb
@@ -7,7 +7,7 @@ provisioner:
 
 platforms:
   - name: ubuntu-12.04
-  - name: centos-6.4
+  - name: centos-6.6
 
 suites:
   - name: default


### PR DESCRIPTION
Fixes #663 

- centos-6.4 is no longer available from opscode-vm-bento.
- Didn't fix kitchen_list_command.feature, which is also dependant on
  centos-6.4-with-small-mem which doesn't seem to have an updated
  version of.