### PR TITLE
Add plugin diagnostics, exposed via `kitchen diagnose`.

### DIFF
--- a/features/kitchen_diagnose_command.feature
+++ b/features/kitchen_diagnose_command.feature
@@ -13,6 +13,12 @@ Feature: Running a diagnosis command
     provisioner:
       name: dummy
 
+    transport:
+      name: dummy
+
+    verifier:
+      name: dummy
+
     platforms:
       - name: cool
       - name: beans
@@ -23,8 +29,19 @@ Feature: Running a diagnosis command
     """
 
   @spawn
+  Scenario: Displaying help
+    When I run `kitchen help diagnose`
+    Then the output should contain:
+    """
+    Usage:
+      kitchen diagnose
+    """
+    And the exit status should be 0
+
+  @spawn
   Scenario: Showing all instances
     When I run `kitchen diagnose`
+    Then the output should contain "timestamp: "
     Then the output should contain "kitchen_version: "
     Then the output should contain "  client-cool:"
     Then the output should contain "  client-beans:"
@@ -45,6 +62,16 @@ Feature: Running a diagnosis command
     And the exit status should be 0
 
   @spawn
+  Scenario: Showing all instances with plugin configuration
+    When I run `kitchen diagnose --plugins`
+    Then the output should contain "plugins:"
+    Then the output should contain "    class: Kitchen::Driver::Dummy"
+    Then the output should contain "    class: Kitchen::Provisioner::Dummy"
+    Then the output should contain "    class: Kitchen::Transport::Dummy"
+    Then the output should contain "    class: Kitchen::Verifier::Dummy"
+    And the exit status should be 0
+
+  @spawn
   Scenario: Coping with loading failure
     Given a file named ".kitchen.local.yml" with:
     """
@@ -59,6 +86,11 @@ Feature: Running a diagnosis command
     And the output should contain:
     """
     instances:
+      error:
+    """
+    And the output should contain:
+    """
+    plugins:
       error:
     """
     And the exit status should be 0

--- a/lib/kitchen/cli.rb
+++ b/lib/kitchen/cli.rb
@@ -112,6 +112,9 @@ module Kitchen
     method_option :loader,
       :type => :boolean,
       :desc => "Include data loader diagnostics"
+    method_option :plugins,
+      :type => :boolean,
+      :desc => "Include plugin diagnostics"
     method_option :instances,
       :type => :boolean,
       :default => true,

--- a/lib/kitchen/command/diagnose.rb
+++ b/lib/kitchen/command/diagnose.rb
@@ -37,10 +37,15 @@ module Kitchen
         loader = record_failure { load_loader }
 
         puts Kitchen::Diagnostic.new(
-          :loader => loader, :instances => instances).read.to_yaml
+          :loader => loader, :instances => instances, :plugins => plugins?
+        ).read.to_yaml
       end
 
       private
+
+      def plugins?
+        options[:all] || options[:plugins]
+      end
 
       # Loads and returns instances if they are requested.
       #

--- a/lib/kitchen/configurable.rb
+++ b/lib/kitchen/configurable.rb
@@ -124,6 +124,18 @@ module Kitchen
       result
     end
 
+    # Returns a Hash of configuration and other useful diagnostic information
+    # associated with the plugin itself (such as loaded version, class name,
+    # etc.).
+    #
+    # @return [Hash] a diagnostic hash
+    def diagnose_plugins
+      result = Hash.new
+      result[:name] = name
+      result.merge!(self.class.diagnose)
+      result
+    end
+
     # Returns the name of this plugin, suitable for display in a CLI.
     #
     # @return [String] name of this plugin
@@ -302,6 +314,16 @@ module Kitchen
 
     # Class methods which will be mixed in on inclusion of Configurable module.
     module ClassMethods
+
+      # Returns a Hash of configuration and other useful diagnostic
+      # information.
+      #
+      # @return [Hash] a diagnostic hash
+      def diagnose
+        {
+          :class => name
+        }
+      end
 
       # Sets a sane default value for a configuration attribute. These values
       # can be overridden by provided configuration or in a subclass with

--- a/lib/kitchen/instance.rb
+++ b/lib/kitchen/instance.rb
@@ -243,6 +243,23 @@ module Kitchen
       result
     end
 
+    # Returns a Hash of configuration and other useful diagnostic information
+    # associated with plugins (such as loaded version, class name, etc.).
+    #
+    # @return [Hash] a diagnostic hash
+    def diagnose_plugins
+      result = Hash.new
+      [:driver, :provisioner, :verifier, :transport].each do |sym|
+        obj = send(sym)
+        result[sym] = if obj.respond_to?(:diagnose_plugins)
+          obj.diagnose_plugins
+        else
+          :unknown
+        end
+      end
+      result
+    end
+
     # Returns the last successfully completed action state of the instance.
     #
     # @return [String] a named action which was last successfully completed

--- a/spec/kitchen/configurable_spec.rb
+++ b/spec/kitchen/configurable_spec.rb
@@ -392,6 +392,21 @@ describe Kitchen::Configurable do
     end
   end
 
+  describe "#diagnose_plugins" do
+
+    it "returns a plugin hash for a plugin without version" do
+      subject.diagnose_plugins.must_equal(
+        :name => "Tiny", :class => "Kitchen::Thing::Tiny"
+      )
+    end
+
+    it "returns a plugin hash for a plugin with version" do
+      subject.diagnose_plugins.must_equal(
+        :name => "Tiny", :class => "Kitchen::Thing::Tiny"
+      )
+    end
+  end
+
   describe "#calculate_path" do
 
     let(:config) do

--- a/spec/kitchen/instance_spec.rb
+++ b/spec/kitchen/instance_spec.rb
@@ -384,6 +384,81 @@ describe Kitchen::Instance do
     end
   end
 
+  describe "#diagnose_plugins" do
+
+    it "returns a hash" do
+      instance.diagnose_plugins.must_be_instance_of Hash
+    end
+
+    it "sets :driver key to driver's plugin_diagnose info" do
+      driver.class.stubs(:diagnose).returns(:a => "b")
+
+      instance.diagnose_plugins[:driver].must_equal(
+        :name => "Dummy",
+        :a => "b"
+      )
+    end
+
+    it "sets :driver key to :unknown if class doesn't have #diagnose" do
+      opts[:driver] = Class.new(driver.class) {
+        undef_method :diagnose_plugins
+      }.new({})
+
+      instance.diagnose_plugins[:driver].must_equal(:unknown)
+    end
+
+    it "sets :provisioner key to provisioner's plugin_diagnose info" do
+      provisioner.class.stubs(:diagnose).returns(:a => "b")
+
+      instance.diagnose_plugins[:provisioner].must_equal(
+        :name => "Dummy",
+        :a => "b"
+      )
+    end
+
+    it "sets :provisioner key to :unknown if class doesn't have #diagnose" do
+      opts[:provisioner] = Class.new(driver.class) {
+        undef_method :diagnose_plugins
+      }.new({})
+
+      instance.diagnose_plugins[:provisioner].must_equal(:unknown)
+    end
+
+    it "sets :verifier key to verifier's plugin_diagnose info" do
+      verifier.class.stubs(:diagnose).returns(:a => "b")
+
+      instance.diagnose_plugins[:verifier].must_equal(
+        :name => "Dummy",
+        :a => "b"
+      )
+    end
+
+    it "sets :verifier key to :unknown if class doesn't have #diagnose" do
+      opts[:verifier] = Class.new(verifier.class) {
+        undef_method :diagnose_plugins
+      }.new({})
+
+      instance.diagnose_plugins[:verifier].must_equal(:unknown)
+    end
+
+    it "sets :transport key to transport's plugin_diagnose info" do
+      transport.class.stubs(:diagnose).returns(:a => "b")
+
+      instance.diagnose_plugins[:transport].must_equal(
+        :name => "Dummy",
+        :a => "b"
+      )
+    end
+
+    it "sets :transport key to :unknown if class doesn't have #diagnose" do
+      opts[:transport] = Class.new(transport.class) {
+        undef_method :diagnose_plugins
+      }.new({})
+
+      instance.diagnose_plugins[:transport].must_equal(:unknown)
+    end
+  end
+
   describe "performing actions" do
 
     describe "#create" do


### PR DESCRIPTION
This command adds a new flag to `kitchen diagnose`: `--plugins` which
adds a `:plugins` hash to the diagnostic output. It is the unique set of
all loaded Driver, Provisioner, Verifier, and Transport plugins which is
keyed by the `#name` of the plugin.

For example, a .kitchen.yml with the following configuration:

    ---
    driver:
      name: vagrant

    provisioner:
      name: chef_zero

    verifier:
      name: dummy

    platforms:
      - name: ubuntu-14.04
        transport:
          name: ssh
      - name: centos-7.0
        driver:
          name: docker
        transport:
          name: ssh
      - name: windows-2012r2-core
        transport:
          name: winrm

with an invocation of `kitchen diagnose --plugins` would produce a
diagnostic output similar to:

    ---
    timestamp: 2015-03-28 00:43:32 UTC
    kitchen_version: 1.4.0.dev
    plugins:
      driver:
        Docker:
          class: Kitchen::Driver::Docker
        Vagrant:
          class: Kitchen::Driver::Vagrant
      provisioner:
        ChefZero:
          class: Kitchen::Provisioner::ChefZero
      transport:
        Ssh:
          class: Kitchen::Transport::Ssh
        Winrm:
          class: Kitchen::Transport::Winrm
      verifier:
        Dummy:
          class: Kitchen::Verifier::Dummy