### PR TITLE
Add `plugin_version` support for all plugin types.

### DIFF
--- a/lib/kitchen/configurable.rb
+++ b/lib/kitchen/configurable.rb
@@ -129,7 +129,7 @@ module Kitchen
     # etc.).
     #
     # @return [Hash] a diagnostic hash
-    def diagnose_plugins
+    def diagnose_plugin
       result = Hash.new
       result[:name] = name
       result.merge!(self.class.diagnose)
@@ -315,13 +315,37 @@ module Kitchen
     # Class methods which will be mixed in on inclusion of Configurable module.
     module ClassMethods
 
+      # Sets the loaded version of this plugin, usually corresponding to the
+      # RubyGems version of the plugin's library. If the plugin does not set
+      # this value, then `nil` will be used and reported.
+      #
+      # @example setting a version used by RubyGems
+      #
+      #   require "kitchen/driver/vagrant_version"
+      #
+      #   module Kitchen
+      #     module Driver
+      #       class Vagrant < Kitchen::Driver::Base
+      #
+      #         plugin_version Kitchen::Driver::VAGRANT_VERSION
+      #
+      #       end
+      #     end
+      #   end
+      #
+      # @param version [String] a version string
+      def plugin_version(version) # rubocop:disable Style/TrivialAccessors
+        @plugin_version = version
+      end
+
       # Returns a Hash of configuration and other useful diagnostic
       # information.
       #
       # @return [Hash] a diagnostic hash
       def diagnose
         {
-          :class => name
+          :class        => name,
+          :version      => @plugin_version
         }
       end
 

--- a/lib/kitchen/driver/dummy.rb
+++ b/lib/kitchen/driver/dummy.rb
@@ -30,6 +30,8 @@ module Kitchen
     # @author Fletcher Nichol <fnichol@nichol.ca>
     class Dummy < Kitchen::Driver::Base
 
+      plugin_version Kitchen::VERSION
+
       default_config :sleep, 0
       default_config :random_failure, false
 

--- a/lib/kitchen/driver/proxy.rb
+++ b/lib/kitchen/driver/proxy.rb
@@ -19,6 +19,7 @@
 #
 
 require "kitchen"
+require "kitchen/version"
 
 module Kitchen
 
@@ -32,6 +33,8 @@ module Kitchen
     #
     # @author Seth Chisamore <schisamo@opscode.com>
     class Proxy < Kitchen::Driver::SSHBase
+
+      plugin_version Kitchen::VERSION
 
       required_config :host
       required_config :reset_command

--- a/lib/kitchen/instance.rb
+++ b/lib/kitchen/instance.rb
@@ -251,8 +251,8 @@ module Kitchen
       result = Hash.new
       [:driver, :provisioner, :verifier, :transport].each do |sym|
         obj = send(sym)
-        result[sym] = if obj.respond_to?(:diagnose_plugins)
-          obj.diagnose_plugins
+        result[sym] = if obj.respond_to?(:diagnose_plugin)
+          obj.diagnose_plugin
         else
           :unknown
         end

--- a/lib/kitchen/provisioner/chef_solo.rb
+++ b/lib/kitchen/provisioner/chef_solo.rb
@@ -27,6 +27,8 @@ module Kitchen
     # @author Fletcher Nichol <fnichol@nichol.ca>
     class ChefSolo < ChefBase
 
+      plugin_version Kitchen::VERSION
+
       default_config :solo_rb, {}
 
       default_config :chef_solo_path do |provisioner|

--- a/lib/kitchen/provisioner/chef_zero.rb
+++ b/lib/kitchen/provisioner/chef_zero.rb
@@ -27,6 +27,8 @@ module Kitchen
     # @author Fletcher Nichol <fnichol@nichol.ca>
     class ChefZero < ChefBase
 
+      plugin_version Kitchen::VERSION
+
       default_config :client_rb, {}
       default_config :json_attributes, true
       default_config :chef_zero_host, nil

--- a/lib/kitchen/provisioner/dummy.rb
+++ b/lib/kitchen/provisioner/dummy.rb
@@ -30,6 +30,8 @@ module Kitchen
     # @author Fletcher Nichol <fnichol@nichol.ca>
     class Dummy < Kitchen::Provisioner::Base
 
+      plugin_version Kitchen::VERSION
+
       default_config :sleep, 0
       default_config :random_failure, false
 

--- a/lib/kitchen/provisioner/shell.rb
+++ b/lib/kitchen/provisioner/shell.rb
@@ -17,6 +17,7 @@
 # limitations under the License.
 
 require "kitchen/provisioner/base"
+require "kitchen/version"
 
 module Kitchen
 
@@ -26,6 +27,8 @@ module Kitchen
     #
     # @author Chris Lundquist (<chris.ludnquist@github.com>)
     class Shell < Base
+
+      plugin_version Kitchen::VERSION
 
       default_config :script do |provisioner|
         src = provisioner.powershell_shell? ? "bootstrap.ps1" : "bootstrap.sh"

--- a/lib/kitchen/transport/dummy.rb
+++ b/lib/kitchen/transport/dummy.rb
@@ -28,6 +28,8 @@ module Kitchen
     # plugins.
     class Dummy < Kitchen::Transport::Base
 
+      plugin_version Kitchen::VERSION
+
       default_config :sleep, 1
       default_config :random_exit_code, 0
 

--- a/lib/kitchen/transport/ssh.rb
+++ b/lib/kitchen/transport/ssh.rb
@@ -36,6 +36,8 @@ module Kitchen
     # @author Fletcher Nichol <fnichol@nichol.ca>
     class Ssh < Kitchen::Transport::Base
 
+      plugin_version Kitchen::VERSION
+
       default_config :port, 22
       default_config :username, "root"
       default_config :keepalive, true

--- a/lib/kitchen/transport/winrm.rb
+++ b/lib/kitchen/transport/winrm.rb
@@ -50,6 +50,8 @@ module Kitchen
     # @author Fletcher Nichol <fnichol@nichol.ca>
     class Winrm < Kitchen::Transport::Base
 
+      plugin_version Kitchen::VERSION
+
       default_config :port, 5985
       default_config :username, ".\\administrator"
       default_config :password, nil

--- a/lib/kitchen/verifier/busser.rb
+++ b/lib/kitchen/verifier/busser.rb
@@ -32,6 +32,8 @@ module Kitchen
     # @author Fletcher Nichol <fnichol@nichol.ca>
     class Busser < Kitchen::Verifier::Base
 
+      plugin_version Kitchen::VERSION
+
       default_config :busser_bin do |verifier|
         verifier.
           remote_path_join(%W[#{verifier[:root_path]} bin busser]).

--- a/lib/kitchen/verifier/dummy.rb
+++ b/lib/kitchen/verifier/dummy.rb
@@ -30,6 +30,8 @@ module Kitchen
     # @author Fletcher Nichol <fnichol@nichol.ca>
     class Dummy < Kitchen::Verifier::Base
 
+      plugin_version Kitchen::VERSION
+
       default_config :sleep, 0
       default_config :random_failure, false
 

--- a/spec/kitchen/configurable_spec.rb
+++ b/spec/kitchen/configurable_spec.rb
@@ -39,6 +39,11 @@ module Kitchen
       end
     end
 
+    class Versioned < Tiny
+
+      plugin_version "1.8.17"
+    end
+
     class StaticDefaults
 
       include Kitchen::Configurable
@@ -392,17 +397,20 @@ describe Kitchen::Configurable do
     end
   end
 
-  describe "#diagnose_plugins" do
+  describe "#diagnose_plugin" do
 
     it "returns a plugin hash for a plugin without version" do
-      subject.diagnose_plugins.must_equal(
-        :name => "Tiny", :class => "Kitchen::Thing::Tiny"
+      subject.diagnose_plugin.must_equal(
+        :name => "Tiny", :class => "Kitchen::Thing::Tiny",
+        :version => nil
       )
     end
 
     it "returns a plugin hash for a plugin with version" do
-      subject.diagnose_plugins.must_equal(
-        :name => "Tiny", :class => "Kitchen::Thing::Tiny"
+      subject = Kitchen::Thing::Versioned.new(config).finalize_config!(instance)
+      subject.diagnose_plugin.must_equal(
+        :name => "Versioned", :class => "Kitchen::Thing::Versioned",
+        :version => "1.8.17"
       )
     end
   end

--- a/spec/kitchen/driver/dummy_spec.rb
+++ b/spec/kitchen/driver/dummy_spec.rb
@@ -37,6 +37,10 @@ describe Kitchen::Driver::Dummy do
     Kitchen::Driver::Dummy.new(config).finalize_config!(instance)
   end
 
+  it "plugin_version is set to Kitchen::VERSION" do
+    driver.diagnose_plugin[:version].must_equal Kitchen::VERSION
+  end
+
   describe "default_config" do
 
     it "sets :sleep to 0 by default" do

--- a/spec/kitchen/driver/proxy_spec.rb
+++ b/spec/kitchen/driver/proxy_spec.rb
@@ -38,6 +38,10 @@ describe Kitchen::Driver::Proxy do
     Kitchen::Driver::Proxy.new(config).finalize_config!(instance)
   end
 
+  it "plugin_version is set to Kitchen::VERSION" do
+    driver.diagnose_plugin[:version].must_equal Kitchen::VERSION
+  end
+
   describe "non-parallel action" do
 
     it "create must be serially executed" do

--- a/spec/kitchen/driver/ssh_base_spec.rb
+++ b/spec/kitchen/driver/ssh_base_spec.rb
@@ -109,6 +109,10 @@ describe Kitchen::Driver::SSHBase do
     Kitchen::Driver::SSHBase.new(config).finalize_config!(instance)
   end
 
+  it "plugin_version is not set" do
+    driver.diagnose_plugin[:version].must_equal nil
+  end
+
   describe "configuration" do
 
     it ":sudo defaults to true" do

--- a/spec/kitchen/instance_spec.rb
+++ b/spec/kitchen/instance_spec.rb
@@ -401,7 +401,7 @@ describe Kitchen::Instance do
 
     it "sets :driver key to :unknown if class doesn't have #diagnose" do
       opts[:driver] = Class.new(driver.class) {
-        undef_method :diagnose_plugins
+        undef_method :diagnose_plugin
       }.new({})
 
       instance.diagnose_plugins[:driver].must_equal(:unknown)
@@ -418,7 +418,7 @@ describe Kitchen::Instance do
 
     it "sets :provisioner key to :unknown if class doesn't have #diagnose" do
       opts[:provisioner] = Class.new(driver.class) {
-        undef_method :diagnose_plugins
+        undef_method :diagnose_plugin
       }.new({})
 
       instance.diagnose_plugins[:provisioner].must_equal(:unknown)
@@ -435,7 +435,7 @@ describe Kitchen::Instance do
 
     it "sets :verifier key to :unknown if class doesn't have #diagnose" do
       opts[:verifier] = Class.new(verifier.class) {
-        undef_method :diagnose_plugins
+        undef_method :diagnose_plugin
       }.new({})
 
       instance.diagnose_plugins[:verifier].must_equal(:unknown)
@@ -452,7 +452,7 @@ describe Kitchen::Instance do
 
     it "sets :transport key to :unknown if class doesn't have #diagnose" do
       opts[:transport] = Class.new(transport.class) {
-        undef_method :diagnose_plugins
+        undef_method :diagnose_plugin
       }.new({})
 
       instance.diagnose_plugins[:transport].must_equal(:unknown)

--- a/spec/kitchen/provisioner/chef_solo_spec.rb
+++ b/spec/kitchen/provisioner/chef_solo_spec.rb
@@ -45,6 +45,10 @@ describe Kitchen::Provisioner::ChefSolo do
     Kitchen::Provisioner::ChefSolo.new(config).finalize_config!(instance)
   end
 
+  it "plugin_version is set to Kitchen::VERSION" do
+    provisioner.diagnose_plugin[:version].must_equal Kitchen::VERSION
+  end
+
   describe "default config" do
 
     describe "for unix operating systems" do

--- a/spec/kitchen/provisioner/chef_zero_spec.rb
+++ b/spec/kitchen/provisioner/chef_zero_spec.rb
@@ -45,6 +45,10 @@ describe Kitchen::Provisioner::ChefZero do
     Kitchen::Provisioner::ChefZero.new(config).finalize_config!(instance)
   end
 
+  it "plugin_version is set to Kitchen::VERSION" do
+    provisioner.diagnose_plugin[:version].must_equal Kitchen::VERSION
+  end
+
   describe "default config" do
 
     describe "for unix operating systems" do

--- a/spec/kitchen/provisioner/dummy_spec.rb
+++ b/spec/kitchen/provisioner/dummy_spec.rb
@@ -49,6 +49,10 @@ describe Kitchen::Provisioner::Dummy do
     Kitchen::Provisioner::Dummy.new(config).finalize_config!(instance)
   end
 
+  it "plugin_version is set to Kitchen::VERSION" do
+    provisioner.diagnose_plugin[:version].must_equal Kitchen::VERSION
+  end
+
   describe "configuration" do
 
     it "sets :sleep to 0 by default" do

--- a/spec/kitchen/provisioner/shell_spec.rb
+++ b/spec/kitchen/provisioner/shell_spec.rb
@@ -49,6 +49,11 @@ describe Kitchen::Provisioner::Shell do
     }.new(config).finalize_config!(instance)
   end
 
+  it "plugin_version is set to Kitchen::VERSION" do
+    provisioner = Kitchen::Provisioner::Shell.new(config).finalize_config!(instance)
+    provisioner.diagnose_plugin[:version].must_equal Kitchen::VERSION
+  end
+
   describe "configuration" do
 
     describe "for bourne shells" do

--- a/spec/kitchen/transport/ssh_spec.rb
+++ b/spec/kitchen/transport/ssh_spec.rb
@@ -127,6 +127,10 @@ describe Kitchen::Transport::Ssh do
     Kitchen::Transport::Ssh.new(config).finalize_config!(instance)
   end
 
+  it "plugin_version is set to Kitchen::VERSION" do
+    transport.diagnose_plugin[:version].must_equal Kitchen::VERSION
+  end
+
   describe "default_config" do
 
     it "sets :port to 22 by default" do

--- a/spec/kitchen/transport/winrm_spec.rb
+++ b/spec/kitchen/transport/winrm_spec.rb
@@ -35,6 +35,10 @@ describe Kitchen::Transport::Winrm do
     Kitchen::Transport::Winrm.new(config).finalize_config!(instance)
   end
 
+  it "plugin_version is set to Kitchen::VERSION" do
+    transport.diagnose_plugin[:version].must_equal Kitchen::VERSION
+  end
+
   describe "default_config" do
 
     it "sets :port to 5985 by default" do

--- a/spec/kitchen/verifier/busser_spec.rb
+++ b/spec/kitchen/verifier/busser_spec.rb
@@ -89,6 +89,10 @@ describe Kitchen::Verifier::Busser do
   #   }.must_raise Kitchen::UserError
   # end
 
+  it "plugin_version is set to Kitchen::VERSION" do
+    verifier.diagnose_plugin[:version].must_equal Kitchen::VERSION
+  end
+
   describe "configuration" do
 
     describe "for unix operating systems" do

--- a/spec/kitchen/verifier/dummy_spec.rb
+++ b/spec/kitchen/verifier/dummy_spec.rb
@@ -49,6 +49,10 @@ describe Kitchen::Verifier::Dummy do
     Kitchen::Verifier::Dummy.new(config).finalize_config!(instance)
   end
 
+  it "plugin_version is set to Kitchen::VERSION" do
+    verifier.diagnose_plugin[:version].must_equal Kitchen::VERSION
+  end
+
   describe "configuration" do
 
     it "sets :sleep to 0 by default" do


### PR DESCRIPTION
This commit provides a new mechanism to report the version of the loaded
Driver, Provisioner, Verifier, or Transport plugin. This information is
exposed in the `:plugin` section of `kitchen diagnose`.