### PR TITLE
[ChefSolo,ChefZero] Ensure that secret key is deleted before converge.

### DIFF
--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -118,8 +118,10 @@ module Kitchen
 
       # (see Base#init_command)
       def init_command
-        dirs = %w[cookbooks data data_bags environments roles clients].
-          sort.map { |dir| remote_path_join(config[:root_path], dir) }
+        dirs = %w[
+          cookbooks data data_bags environments roles clients
+          encrypted_data_bag_secret
+        ].sort.map { |dir| remote_path_join(config[:root_path], dir) }
 
         vars = if powershell_shell?
           init_command_vars_for_powershell(dirs)

--- a/spec/kitchen/provisioner/chef_base_spec.rb
+++ b/spec/kitchen/provisioner/chef_base_spec.rb
@@ -529,7 +529,7 @@ describe Kitchen::Provisioner::ChefBase do
         config[:root_path] = "/route"
         dirs = %W[
           /route/clients /route/cookbooks /route/data /route/data_bags
-          /route/environments /route/roles
+          /route/encrypted_data_bag_secret /route/environments /route/roles
         ].join(" ")
 
         cmd.must_match regexify(%{dirs="#{dirs}"})
@@ -583,7 +583,8 @@ describe Kitchen::Provisioner::ChefBase do
         config[:root_path] = "\\route"
         dirs = %W[
           "\\route\\clients" "\\route\\cookbooks" "\\route\\data"
-          "\\route\\data_bags" "\\route\\environments" "\\route\\roles"
+          "\\route\\data_bags" "\\route\\encrypted_data_bag_secret"
+          "\\route\\environments" "\\route\\roles"
         ].join(", ")
 
         cmd.must_match regexify(%{$dirs = @(#{dirs})})


### PR DESCRIPTION
This fixes an issue where the permissions of the file on the workstation
get transferred to the remote host, and then prevent file overriding on
subsequent converges. Instead we'll wipe this file and re-upload it on
each converge, exactly like `cookbooks/`, `environments/`, etc.

Closes #611