### PR TITLE
[Transport::SSH] Expand path for `:ssh_key` if provided in kitchen.yml.

### DIFF
--- a/lib/kitchen/configurable.rb
+++ b/lib/kitchen/configurable.rb
@@ -207,7 +207,7 @@ module Kitchen
       expanded_paths = LazyHash.new(self.class.expanded_paths, self).to_hash
 
       expanded_paths.each do |key, should_expand|
-        next if !should_expand || config[key].nil?
+        next if !should_expand || config[key].nil? || config[key] == false
 
         config[key] = if config[key].is_a?(Array)
           config[key].map { |path| File.expand_path(path, root_path) }

--- a/lib/kitchen/transport/ssh.rb
+++ b/lib/kitchen/transport/ssh.rb
@@ -49,6 +49,9 @@ module Kitchen
       default_config :connection_retry_sleep, 1
       default_config :max_wait_until_ready, 600
 
+      default_config :ssh_key, nil
+      expand_path_for :ssh_key
+
       # (see Base#connection)
       def connection(state, &block)
         options = connection_options(config.to_hash.merge(state))

--- a/spec/kitchen/configurable_spec.rb
+++ b/spec/kitchen/configurable_spec.rb
@@ -344,6 +344,18 @@ describe Kitchen::Configurable do
 
         subject[:complex_path].must_equal "/tmp/yo/self/complex"
       end
+
+      it "leaves a nil config value as nil" do
+        config[:success_path] = nil
+
+        subject[:success_path].must_equal nil
+      end
+
+      it "leaves a false config value as false" do
+        config[:success_path] = false
+
+        subject[:success_path].must_equal false
+      end
     end
 
     describe "using inherited static expand_path_for statements" do

--- a/spec/kitchen/transport/ssh_spec.rb
+++ b/spec/kitchen/transport/ssh_spec.rb
@@ -168,6 +168,17 @@ describe Kitchen::Transport::Ssh do
     it "sets :max_wait_until_ready to 600 by default" do
       transport[:max_wait_until_ready].must_equal 600
     end
+
+    it "sets :ssh_key to nil by default" do
+      transport[:ssh_key].must_equal nil
+    end
+
+    it "expands :ssh_path path if set" do
+      config[:kitchen_root] = "/rooty"
+      config[:ssh_key] = "my_key"
+
+      transport[:ssh_key].must_equal "/rooty/my_key"
+    end
   end
 
   describe "#connection" do
@@ -415,10 +426,11 @@ describe Kitchen::Transport::Ssh do
       end
 
       it "sets :keys to an array if :ssh_key is set in config" do
+        config[:kitchen_root] = "/r"
         config[:ssh_key] = "ssh_key_from_config"
 
         klass.expects(:new).with do |hash|
-          hash[:keys] == ["ssh_key_from_config"]
+          hash[:keys] == ["/r/ssh_key_from_config"]
         end
 
         make_connection


### PR DESCRIPTION
Closes #389