### PR TITLE
ensure that $BUSSER_ROOT is owned by the current user... 

### DIFF
--- a/support/busser_install_command.sh
+++ b/support/busser_install_command.sh
@@ -1,3 +1,9 @@
+
+# Ensure that $BUSSER_ROOT is owned by the current user, which migh not be the
+# case if parts of $BUSSER_ROOT are mounted via vagrant synched folders.
+# See https://github.com/test-kitchen/test-kitchen/issues/671 
+sudo chown -R $USER:$USER $BUSSER_ROOT
+
 $gem list busser -i 2>&1 >/dev/null
 if test $? -ne 0; then
   echo "-----> Installing Busser ($version)"


### PR DESCRIPTION
...to compensate for permission issues with vagrant synched folders

This PR is meant to work around the [permission issue mentioned here](https://github.com/test-kitchen/test-kitchen/issues/671#issuecomment-87449673) which occurs if parts of `$BUSSER_ROOT` (e.g. `/tmp/verifier/gems/cache`) are mounted via vagrant-cachier / vagrant synched folders.

I really don't like this workaround and would be happy if you decline it. Really. I mainly created the PR to get feedback on better ways / places to fix it.

**Considerations:**
- Since vagrant-cachier does not support windows guests I have only considered the `busser_install_command.sh`, not the .bat variant
- Initially wanted to place that fix somewhere in kitchen-vagrant (since it fixes a problem that occurs in a vagrant specific setup), but I decided against it because kitchen-vagrant does not know anything about `$BUSSER_ROOT`
- :warning: this might break things if the `$USER`'s group is not `$USER`!
