### PR TITLE
Set default log level even if you forget to add it to command line arg

### DIFF
--- a/lib/kitchen/cli.rb
+++ b/lib/kitchen/cli.rb
@@ -345,7 +345,14 @@ module Kitchen
     # @api private
     def update_config!
       if options[:log_level]
-        level = options[:log_level].downcase.to_sym
+        # validate log level specified on command line
+        if Util.to_logger_level(options[:log_level].downcase.to_sym).nil?
+          banner "WARNING - invalid log level specified: \
+\"#{options[:log_level]}\" - reverting to :info log level."
+          level = :info
+        else
+          level = options[:log_level].downcase.to_sym
+        end
         @config.log_level = level
       end
       unless options[:log_overwrite].nil?


### PR DESCRIPTION
Fixes a silly issue for people (like me) who forget how to do use the command line.

This solves the silly use case of:

'kitchen converge --log_level' (with nothing else specified)

If you'd prefer to have it blow up on this error, that's cool, you can probably use the same validation logic and just raise instead of defaulting.