### PR TITLE
don't prompt for passwords when using public keys

### DIFF
--- a/lib/kitchen/transport/ssh.rb
+++ b/lib/kitchen/transport/ssh.rb
@@ -310,6 +310,7 @@ module Kitchen
 
         opts[:keys_only] = true                     if data[:ssh_key]
         opts[:keys] = Array(data[:ssh_key])         if data[:ssh_key]
+        opts[:auth_methods] = ['publickey']         if data[:ssh_key]
         opts[:password] = data[:password]           if data.key?(:password)
         opts[:forward_agent] = data[:forward_agent] if data.key?(:forward_agent)
 


### PR DESCRIPTION
Sometimes when an ssh server is starting up it will accept connections
but fail any authentication attempts, even ones that should be valid.
By default, the ssh client will try to prompt for a password (the
"keyboard-interactive" authentication method) if the "publickey" method
fails, but in our case that's not desired.  We'd prefer that the
connection attempt fail immediately, which will cause a delay and retry.

This commit sets the ssh :auth_methods option to ['publickey'] if a
public key is provided.  This prevents ssh from prompting for a password
which will cause the connection attempt to fail and trigger a retry.