### PR TITLE
add select() to LazyHash to work with kitchen-ec2

### DIFF
--- a/lib/kitchen/lazy_hash.rb
+++ b/lib/kitchen/lazy_hash.rb
@@ -105,6 +105,15 @@ module Kitchen
       hash
     end
 
+    # Yields each key/value pair to the provided block.  Returns a new
+    # Hash with only the keys and rendered values for which the block
+    # returns true.
+    #
+    # @return [Hash] a new hash
+    def select(&block)
+      to_hash.select(&block)
+    end
+
     private
 
     # Returns an object or invokes call with context if object is callable.

--- a/spec/kitchen/lazy_hash_spec.rb
+++ b/spec/kitchen/lazy_hash_spec.rb
@@ -87,4 +87,11 @@ describe Kitchen::LazyHash do
       converted.fetch(:genre).must_equal "heavy metal"
     end
   end
+
+  describe "select" do
+    it "calls Procs when appropriate" do
+      Kitchen::LazyHash.new(hash_obj, context).select { |_, _| true }.
+        must_equal :shed_color => "blue", :barn => "locked", :genre => "heavy metal"
+    end
+  end
 end


### PR DESCRIPTION
While trying to learn about ssh timeouts with test-kitchen and the
kitchen-ec2 driver I tried updating to test-kitchen 30c0ba5 and started
having problems connecting to an ec2 instance.  I could create an
instance but when I tried to connect to it to converge I got:

D      [SSH] opening connection to #<Proc:0x007f8ce829ac30@/Users/tcabot/.rvm/gems/ruby-2.2.2/bundler/gems/kitchen-ec2-2ea5bb8bf94e/lib/kitchen/driver/ec2.rb:60>@hostname.compute-1.amazonaws.com<{:user_known_hosts_file=>"/dev/null", :paranoid=>false, :port=>22, :compression=>"zlib", :compression_level=>6, :keepalive=>true, :keepalive_interval=>60, :timeout=>15, :keys_only=>true, :keys=>["/Users/tcabot/.ssh/keyfile.pem"]}>

Note that the username (before the @hostname) is a Proc not a String.

The problem is in ssh_base.rb and lazy_hash.rb.
ssh_base#backcompat_merged_state() calls config.select().  config
is a LazyHash object, and the value of the :username key is a Proc
defined in ec2.rb at line 60 that's supposed to call the driver to
get the username.  That works if you use an array reference, e.g.,
config[:username] will be "root", but it fails to call the Proc if
you call select() on the LazyHash, so the Hash that gets returned
has a Proc for :username instead of a String.

I added an implementation of select() to LazyHash that first calls
to_hash() to "proc_or_val" the values of the hash, and then selects from
that Hash.  This lets me connect:

D      [SSH] opening connection to root@hostname.compute-1.amazonaws.com:22<{:user_known_hosts_file=>"/dev/null", :paranoid=>false, :keys_only=>true, :port=>22, :keys=>["/Users/tcabot/.ssh/keyfile.pem"]}>