### PR TITLE
don't prompt for passwords when using public keys

### DIFF
--- a/lib/kitchen/transport/ssh.rb
+++ b/lib/kitchen/transport/ssh.rb
@@ -310,6 +310,7 @@ module Kitchen
 
         opts[:keys_only] = true                     if data[:ssh_key]
         opts[:keys] = Array(data[:ssh_key])         if data[:ssh_key]
+        opts[:auth_methods] = ["publickey"]         if data[:ssh_key]
         opts[:password] = data[:password]           if data.key?(:password)
         opts[:forward_agent] = data[:forward_agent] if data.key?(:forward_agent)
 

--- a/spec/kitchen/transport/ssh_spec.rb
+++ b/spec/kitchen/transport/ssh_spec.rb
@@ -483,6 +483,16 @@ describe Kitchen::Transport::Ssh do
         make_connection
       end
 
+      it "sets :auth_methods to only publickey if :ssh_key is set in config" do
+        config[:ssh_key] = "ssh_key_from_config"
+
+        klass.expects(:new).with do |hash|
+          hash[:auth_methods] == ["publickey"]
+        end
+
+        make_connection
+      end
+
       it "sets :keys_only to true if :ssh_key is set in state" do
         state[:ssh_key] = "ssh_key_from_config"
         config[:ssh_key] = false


### PR DESCRIPTION
Sometimes when an ssh server is starting up it will accept connections
but fail any authentication attempts, even ones that should be valid.
By default, the ssh client will try to prompt for a password (the
"keyboard-interactive" authentication method) if the "publickey" method
fails, but in our case that's not desired.  We'd prefer that the
connection attempt fail immediately, which will cause a delay and retry.

This commit sets the ssh :auth_methods option to ['publickey'] if a
public key is provided.  This prevents ssh from prompting for a password
which will cause the connection attempt to fail and trigger a retry.