### PR TITLE
Update platform version defaults in `kitchen init` command.

### DIFF
--- a/features/kitchen_init_command.feature
+++ b/features/kitchen_init_command.feature
@@ -212,8 +212,8 @@ Feature: Add Test Kitchen support to an existing project
       name: chef_solo
 
     platforms:
-      - name: ubuntu-12.04
-      - name: centos-6.6
+      - name: ubuntu-14.04
+      - name: centos-7.1
 
     suites:
       - name: default

--- a/templates/init/kitchen.yml.erb
+++ b/templates/init/kitchen.yml.erb
@@ -6,8 +6,8 @@ provisioner:
   name: <%= config[:provisioner] %>
 
 platforms:
-  - name: ubuntu-12.04
-  - name: centos-6.6
+  - name: ubuntu-14.04
+  - name: centos-7.1
 
 suites:
   - name: default


### PR DESCRIPTION
The updated platforms are:

- ubuntu-14.04
- centos-7.1

References #707
References #663
References chef/chef-dk#382
References chef/chef-dk#378