### PR TITLE
Exit the execute loop once the exit code is found.

### DIFF
--- a/lib/kitchen/transport/ssh.rb
+++ b/lib/kitchen/transport/ssh.rb
@@ -245,7 +245,7 @@ module Kitchen
               end
             end
           end
-          session.loop { !exit_code.nil? }
+          session.loop { exit_code.nil? }
           exit_code
         end
 

--- a/lib/kitchen/transport/ssh.rb
+++ b/lib/kitchen/transport/ssh.rb
@@ -245,7 +245,7 @@ module Kitchen
               end
             end
           end
-          session.loop
+          session.loop { !exit_code.nil? }
           exit_code
         end
 


### PR DESCRIPTION
This matters when multiple, parallel operations are using the same session.
