### PR TITLE
Use a relative name for the connection class.

### DIFF
--- a/lib/kitchen/transport/ssh.rb
+++ b/lib/kitchen/transport/ssh.rb
@@ -330,7 +330,7 @@ module Kitchen
         end
 
         @connection_options = options
-        @connection = Kitchen::Transport::Ssh::Connection.new(options, &block)
+        @connection = self.class::Connection.new(options, &block)
       end
 
       # Return the last saved SSH connection instance.


### PR DESCRIPTION
This makes life easier for subclassing.