### PR TITLE
Fix 'execution expired' error when waiting for WinRM to be ready

### DIFF
--- a/lib/kitchen/transport/winrm.rb
+++ b/lib/kitchen/transport/winrm.rb
@@ -139,7 +139,8 @@ module Kitchen
             Errno::EACCES, Errno::EADDRINUSE, Errno::ECONNREFUSED,
             Errno::ECONNRESET, Errno::ENETUNREACH, Errno::EHOSTUNREACH,
             ::WinRM::WinRMHTTPTransportError, ::WinRM::WinRMAuthorizationError,
-            HTTPClient::KeepAliveDisconnected
+            HTTPClient::KeepAliveDisconnected,
+            HTTPClient::ConnectTimeoutError
           ].freeze
         end
 

--- a/spec/kitchen/transport/winrm_spec.rb
+++ b/spec/kitchen/transport/winrm_spec.rb
@@ -703,7 +703,7 @@ MSG
       Errno::EACCES, Errno::EADDRINUSE, Errno::ECONNREFUSED,
       Errno::ECONNRESET, Errno::ENETUNREACH, Errno::EHOSTUNREACH,
       ::WinRM::WinRMHTTPTransportError, ::WinRM::WinRMAuthorizationError,
-      HTTPClient::KeepAliveDisconnected
+      HTTPClient::KeepAliveDisconnected, HTTPClient::ConnectTimeoutError
     ].each do |klass|
       describe "raising #{klass}" do
 


### PR DESCRIPTION
This fixes test-kitchen/kitchen-ec2#132.

When the EC2 driver calls [Kitchen::Transport::Winrm::Connection#wait_until_ready](https://github.com/test-kitchen/kitchen-ec2/blob/master/lib/kitchen/driver/ec2.rb#L218) and WinRM has not yet been enabled (by an EC2 user-data script in my case) the following error occurs:

```
EC2 instance <i-3a78e3e6> ready.
D      [WinRM] opening remote shell on plaintext::http://ec2-52-64-46-171.ap-southeast-2.compute.amazonaws.com:5985/wsman<{:disable_sspi=>true, :basic_auth_only=>true, :user=>"kitchen", :pass=>"K1tch3nR0ck5"}>
>>>>>> ------Exception-------
>>>>>> Class: Kitchen::ActionFailed
>>>>>> Message: Failed to complete #create action: [execution expired]
>>>>>> ----------------------
>>>>>> Please see .kitchen/logs/kitchen.log for more details
>>>>>> Also try running `kitchen diagnose --all` for configuration
 
D      ------Exception-------
D      Class: Kitchen::ActionFailed
D      Message: Failed to complete #create action: [execution expired]
D      ---Nested Exception---
D      Class: HTTPClient::ConnectTimeoutError
D      Message: execution expired
```

([full stacktrace here](https://gist.github.com/zl4bv/ed5a1b11ecdc610518d2#file-gistfile1-txt))

Rescuing `HTTPClient::ConnectTimeoutError` in the right place seems to fix this error.