### PR TITLE
Update kitchen.yml.erb

### DIFF
--- a/templates/init/kitchen.yml.erb
+++ b/templates/init/kitchen.yml.erb
@@ -6,8 +6,8 @@ provisioner:
   name: <%= config[:provisioner] %>
 
 platforms:
-  - name: ubuntu-14.04
-  - name: centos-7.1
+  - name: chef/ubuntu-14.04
+  - name: chef/centos-7.1
 
 suites:
   - name: default


### PR DESCRIPTION
We should update this so it talks to atlas and queries correctly. `centos-7.1` does return anything.