### PR TITLE
Revert "Use a relative name for the connection class."

### DIFF
--- a/lib/kitchen/transport/ssh.rb
+++ b/lib/kitchen/transport/ssh.rb
@@ -330,7 +330,7 @@ module Kitchen
         end
 
         @connection_options = options
-        @connection = self.class::Connection.new(options, &block)
+        @connection = Kitchen::Transport::Ssh::Connection.new(options, &block)
       end
 
       # Return the last saved SSH connection instance.


### PR DESCRIPTION
Reverts test-kitchen/test-kitchen#726

Travis was all green, but should have had it's tests rerun.