### PR TITLE
Fix failing feature in `kitchen drvier discover` due to too many gems.

### DIFF
--- a/features/kitchen_driver_discover_command.feature
+++ b/features/kitchen_driver_discover_command.feature
@@ -16,5 +16,4 @@ Feature: Search RubyGems to discover new Test Kitchen Driver gems
   Scenario: Running driver discover returns live results
     When I run `kitchen driver discover`
     Then the exit status should be 0
-    And the output should contain "kitchen-vagrant"
     And the output should contain "kitchen-bluebox"


### PR DESCRIPTION
The code for `kitchen driver discover` was written when there weren't
many RubyGem Drivers published, however this is no longer the case.
Worse, the gems that are returned could be Provisioners, Transports,
etc.

In an attempt to make the output readable, the number of results was
arbitrarily cut off at 49 before adding "...". Guess what? There are now
many more than 49 results!

The easiest fix for this was to remove "kitchen-vagrant" (which fell off
the results due to its sorting), but the usefulness of this subcommand
might not be that high. This is a potential opportunity for deprecation
in the future.