### PR TITLE
Fixing issues to support windows in kitchen-ec2, fixes #688, fixes #733

### DIFF
--- a/lib/kitchen/transport/winrm.rb
+++ b/lib/kitchen/transport/winrm.rb
@@ -44,7 +44,7 @@ module Kitchen
       plugin_version Kitchen::VERSION
 
       default_config :port, 5985
-      default_config :username, ".\\administrator"
+      default_config :username, "administrator"
       default_config :password, nil
       default_config :endpoint_template, "http://%{hostname}:%{port}/wsman"
       default_config :rdp_port, 3389

--- a/lib/kitchen/transport/winrm.rb
+++ b/lib/kitchen/transport/winrm.rb
@@ -139,7 +139,8 @@ module Kitchen
             Errno::EACCES, Errno::EADDRINUSE, Errno::ECONNREFUSED,
             Errno::ECONNRESET, Errno::ENETUNREACH, Errno::EHOSTUNREACH,
             ::WinRM::WinRMHTTPTransportError, ::WinRM::WinRMAuthorizationError,
-            HTTPClient::KeepAliveDisconnected
+            HTTPClient::KeepAliveDisconnected,
+            HTTPClient::ConnectTimeoutError
           ].freeze
         end
 

--- a/spec/kitchen/transport/winrm_spec.rb
+++ b/spec/kitchen/transport/winrm_spec.rb
@@ -703,7 +703,7 @@ MSG
       Errno::EACCES, Errno::EADDRINUSE, Errno::ECONNREFUSED,
       Errno::ECONNRESET, Errno::ENETUNREACH, Errno::EHOSTUNREACH,
       ::WinRM::WinRMHTTPTransportError, ::WinRM::WinRMAuthorizationError,
-      HTTPClient::KeepAliveDisconnected
+      HTTPClient::KeepAliveDisconnected, HTTPClient::ConnectTimeoutError
     ].each do |klass|
       describe "raising #{klass}" do
 

--- a/spec/kitchen/transport/winrm_spec.rb
+++ b/spec/kitchen/transport/winrm_spec.rb
@@ -53,8 +53,8 @@ describe Kitchen::Transport::Winrm do
       transport[:port].must_equal 5985
     end
 
-    it "sets :username to .\\administrator by default" do
-      transport[:username].must_equal ".\\administrator"
+    it "sets :username to administrator by default" do
+      transport[:username].must_equal "administrator"
     end
 
     it "sets :password to nil by default" do


### PR DESCRIPTION
Getting a PR ready that my kitchen-ec2 changes will depend on for Windows to work.

Fixes #688
Includes https://github.com/test-kitchen/test-kitchen/pull/728 so I can depend on 1 branch in kitchen-ec2

\cc @fnichol @zl4bv