### PR TITLE
Adds number_of_password_prompts as a SSH option

### DIFF
--- a/lib/kitchen/transport/ssh.rb
+++ b/lib/kitchen/transport/ssh.rb
@@ -48,6 +48,7 @@ module Kitchen
       default_config :connection_retries, 5
       default_config :connection_retry_sleep, 1
       default_config :max_wait_until_ready, 600
+      default_config :number_of_password_prompts, 3
 
       default_config :ssh_key, nil
       expand_path_for :ssh_key
@@ -292,20 +293,21 @@ module Kitchen
       # @api private
       def connection_options(data) # rubocop:disable Metrics/MethodLength
         opts = {
-          :logger                 => logger,
-          :user_known_hosts_file  => "/dev/null",
-          :paranoid               => false,
-          :hostname               => data[:hostname],
-          :port                   => data[:port],
-          :username               => data[:username],
-          :compression            => data[:compression],
-          :compression_level      => data[:compression_level],
-          :keepalive              => data[:keepalive],
-          :keepalive_interval     => data[:keepalive_interval],
-          :timeout                => data[:connection_timeout],
-          :connection_retries     => data[:connection_retries],
-          :connection_retry_sleep => data[:connection_retry_sleep],
-          :max_wait_until_ready   => data[:max_wait_until_ready]
+          :logger                     => logger,
+          :user_known_hosts_file      => "/dev/null",
+          :paranoid                   => false,
+          :hostname                   => data[:hostname],
+          :port                       => data[:port],
+          :username                   => data[:username],
+          :compression                => data[:compression],
+          :compression_level          => data[:compression_level],
+          :keepalive                  => data[:keepalive],
+          :keepalive_interval         => data[:keepalive_interval],
+          :timeout                    => data[:connection_timeout],
+          :connection_retries         => data[:connection_retries],
+          :connection_retry_sleep     => data[:connection_retry_sleep],
+          :max_wait_until_ready       => data[:max_wait_until_ready],
+          :number_of_password_prompts => data[:number_of_password_prompts]
         }
 
         opts[:keys_only] = true                     if data[:ssh_key]

--- a/spec/kitchen/transport/ssh_spec.rb
+++ b/spec/kitchen/transport/ssh_spec.rb
@@ -196,6 +196,10 @@ describe Kitchen::Transport::Ssh do
       transport[:max_wait_until_ready].must_equal 600
     end
 
+    it "sets :number_of_password_prompts to 3 by default" do
+      transport[:number_of_password_prompts].must_equal 3
+    end
+
     it "sets :ssh_key to nil by default" do
       transport[:ssh_key].must_equal nil
     end
@@ -468,6 +472,27 @@ describe Kitchen::Transport::Ssh do
 
         klass.expects(:new).with do |hash|
           hash[:max_wait_until_ready] == "max_from_state"
+        end
+
+        make_connection
+      end
+
+      it "sets :number_of_password_prompts from config" do
+        config[:number_of_password_prompts] = "max_from_config"
+
+        klass.expects(:new).with do |hash|
+          hash[:number_of_password_prompts] == "max_from_config"
+        end
+
+        make_connection
+      end
+
+      it "sets :number_of_password_prompts from state over config data" do
+        state[:number_of_password_prompts] = "max_from_state"
+        config[:number_of_password_prompts] = "max_from_config"
+
+        klass.expects(:new).with do |hash|
+          hash[:number_of_password_prompts] == "max_from_state"
         end
 
         make_connection


### PR DESCRIPTION
This allows this option of Net::SSH to be changed from within a driver. This
is needed when a VM template spins up an ssh daemon when the cloud-provided
password isn't set yet. This would prompt for a password, while this should
just fail.

The cloudstack driver needs this option to allow wait_for_sshd to wait for
an actual working sshd, and the possibility to login with the user/pass combo.

I assume other drivers might benefit from this too.

I actually need this to fix the "wait_for_sshd" in the cloudstack driver, on templates which have an sshd started before they set the password through the cloud-tools, and thus prompt for a password when the server is hit in between these two actions. 

I added some basic (copy-paste) tests, but I have no idea how i should actually test the correct functioning of this specific option. I have tested this locally on a working setup (with the needed changes in the cloudstack driver added, verifying the fix to my problem). 
