### PR TITLE
Omnibus script cleanup

### DIFF
--- a/support/chef_base_install_command.sh
+++ b/support/chef_base_install_command.sh
@@ -208,6 +208,7 @@ main() {
 
     do_download "$chef_omnibus_url" /tmp/install.sh;
     $sudo_sh /tmp/install.sh $install_flags;
+    rm $tmp_stderr /tmp/install.sh;
   else
     echo "-----> Chef Omnibus installation detected (${pretty_version})";
   fi


### PR DESCRIPTION
Files left over by the Omnibus installation script can cause ownership-related problems for subsequent runs if they were initially created as another user.