### PR TITLE
Add exclude option

### DIFF
--- a/lib/kitchen/cli.rb
+++ b/lib/kitchen/cli.rb
@@ -241,6 +241,7 @@ module Kitchen
       :aliases => "-c",
       :desc => "execute via ssh"
     log_options
+    exclude_option
     def exec(*args)
       update_config!
       perform("exec", "exec", args)

--- a/lib/kitchen/cli.rb
+++ b/lib/kitchen/cli.rb
@@ -93,6 +93,14 @@ module Kitchen
         :type => :boolean
     end
 
+    # Sets the exclude method_option
+    # @api private
+    def self.exclude_option
+      method_option :exclude,
+        :aliases => "-x",
+        :desc => "Set the name or pattern for excluding instances [INSTANCE|REGEXP]"
+    end
+
     desc "list [INSTANCE|REGEXP|all]", "Lists one or more instances"
     method_option :bare,
       :aliases => "-b",
@@ -103,6 +111,7 @@ module Kitchen
       :type => :boolean,
       :desc => "[Deprecated] Please use `kitchen diagnose'"
     log_options
+    exclude_option
     def list(*args)
       update_config!
       perform("list", "list", args)
@@ -166,6 +175,7 @@ module Kitchen
           Run a #{action} against all matching instances concurrently.
         DESC
       log_options
+      exclude_option
       define_method(action) do |*args|
         update_config!
         perform(action, "action", args)
@@ -211,6 +221,7 @@ module Kitchen
       :default => false,
       :desc => "Invoke init command if .kitchen.yml is missing"
     log_options
+    exclude_option
     def test(*args)
       update_config!
       ensure_initialized

--- a/lib/kitchen/command.rb
+++ b/lib/kitchen/command.rb
@@ -142,7 +142,12 @@ module Kitchen
       # @return [Array<Instance>] an array of instances
       # @api private
       def parse_subcommand(arg = nil)
-        arg == "all" ? all_instances : filtered_instances(arg)
+        targets = arg == "all" ? all_instances : filtered_instances(arg)
+        if options[:exclude]
+          excludes = filtered_instances(options[:exclude])
+          excludes.each {|ex| targets.delete(ex) }
+        end
+        targets
       end
     end
 


### PR DESCRIPTION
Hi, I want to add `exclude` option to some actions(create,setup,converge,verify,destroy and list) in order to more useful some execution.

This option uses the same regular expression as the first argument that used to select instances.

Configration example:

``` yml

---
driver:
  name: dummy

transport:
  name: dummy

provisioner:
  name: dummy

platforms:
  - name: ubuntu-14.04
  - name: centos-7.1

suites:
  - name: default
```

Results:

``` bash
marcy@Marcy-MBA:~/github/test-kitchen$ bundle exec kitchen list
Instance             Driver  Provisioner  Verifier  Transport  Last Action
default-ubuntu-1404  Dummy   Dummy        Busser    Dummy      <Not Created>
default-centos-71    Dummy   Dummy        Busser    Dummy      <Not Created>
marcy@Marcy-MBA:~/github/test-kitchen$ bundle exec kitchen list -x centos
Instance             Driver  Provisioner  Verifier  Transport  Last Action
default-ubuntu-1404  Dummy   Dummy        Busser    Dummy      <Not Created>
marcy@Marcy-MBA:~/github/test-kitchen$ bundle exec kitchen create default -x ubuntu
-----> Starting Kitchen (v1.4.1.dev)
-----> Creating <default-centos-71>...
       [Dummy] Create on instance=#<Kitchen::Instance:0x007fbf0a21b418> with state={:my_id=>"default-centos-71-1434642214", :last_action=>"create"}
       Finished creating <default-centos-71> (0m0.00s).
-----> Kitchen is finished. (0m0.01s)
```
