### PR TITLE
A little update to allow nightlies easily

### DIFF
--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -257,9 +257,15 @@ module Kitchen
       # @return [String] shell variable lines
       # @api private
       def install_command_vars_for_bourne(version)
-        install_flags = %w[latest true].include?(version) ? "" : "-v #{version}"
+        install_flags = %w[latest nightly true].include?(version) ? "" : "-v #{version}"
         if config[:chef_omnibus_install_options]
           install_flags << " " << config[:chef_omnibus_install_options]
+        end
+
+        # Do a little argument shuffling to ensure the latest of the latest!
+        if version.eql? "nightly"
+          version = "latest"
+          install_flags << " -n"
         end
 
         [

--- a/lib/kitchen/provisioner/chef_zero.rb
+++ b/lib/kitchen/provisioner/chef_zero.rb
@@ -166,7 +166,7 @@ module Kitchen
         version = config[:require_chef_omnibus]
 
         case version
-        when nil, false, true, 11, "11", "latest"
+        when nil, false, true, 11, "11", "latest", "nightly"
           true
         else
           Gem::Version.new(version) >= Gem::Version.new("11.8.0") ? true : false

--- a/spec/kitchen/provisioner/chef_base_spec.rb
+++ b/spec/kitchen/provisioner/chef_base_spec.rb
@@ -323,6 +323,14 @@ describe Kitchen::Provisioner::ChefBase do
         cmd.must_match regexify(%{version="latest"})
       end
 
+      it "will install the nightly of chef, if necessary" do
+        config[:require_chef_omnibus] = "nightly"
+
+        cmd.must_match regexify(%{install_flags="-n"})
+        cmd.must_match regexify(%{pretty_version="always install latest version"})
+        cmd.must_match regexify(%{version="latest"})
+      end
+
       it "will install a of chef, unless it exists" do
         config[:require_chef_omnibus] = true
 


### PR DESCRIPTION
The caveat here is that it doesn't work on Windows platforms.

Allows you to do the following in your .kitchen.yml:
```
provisioner:
  name: chef_zero
  require_chef_omnibus: nightly
```

as opposed to this:
```
provisioner:
  name: chef_zero
  require_chef_omnibus: latest
  chef_omnibus_install_options: "-n"
```

This is totally a convenience method!

@fnichol @tyler-ball 
