### PR TITLE
Style/Lint Updates (finstyle 1.5.0)

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -10,7 +10,11 @@ require "kitchen/cli"
 class ArubaHelper
 
   def initialize(argv, stdin = STDIN, stdout = STDOUT, stderr = STDERR, kernel = Kernel)
-    @argv, @stdin, @stdout, @stderr, @kernel = argv, stdin, stdout, stderr, kernel
+    @argv = argv
+    @stdin = stdin
+    @stdout = stdout
+    @stderr = stderr
+    @kernel = kernel
   end
 
   def execute!

--- a/lib/kitchen.rb
+++ b/lib/kitchen.rb
@@ -89,10 +89,10 @@ module Kitchen
       log_location = log_location.to_s
 
       Logger.new(
-          :stdout => $stdout,
-          :logdev => log_location,
-          :level => Util.to_logger_level(level),
-          :log_overwrite => log_overwrite
+        :stdout => $stdout,
+        :logdev => log_location,
+        :level => Util.to_logger_level(level),
+        :log_overwrite => log_overwrite
       )
     end
 

--- a/lib/kitchen/base64_stream.rb
+++ b/lib/kitchen/base64_stream.rb
@@ -31,7 +31,7 @@ module Kitchen
     # @param io_in [#read] input stream
     # @param io_out [#write] output stream
     def self.strict_encode(io_in, io_out)
-      buffer = "" # rubocop:disable Lint/UselessAssignment
+      buffer = ""
       while io_in.read(3 * 1000, buffer)
         io_out.write([buffer].pack("m0"))
       end
@@ -45,7 +45,7 @@ module Kitchen
     # @param io_in [#read] input stream
     # @param io_out [#write] output stream
     def self.strict_decode(io_in, io_out)
-      buffer = "" # rubocop:disable Lint/UselessAssignment
+      buffer = ""
       while io_in.read(3 * 1000, buffer)
         io_out.write(buffer.unpack("m0").first)
       end

--- a/lib/kitchen/driver/base.rb
+++ b/lib/kitchen/driver/base.rb
@@ -108,11 +108,9 @@ module Kitchen
       #
       # @param version [Integer,String] a version number
       #
-      # rubocop:disable Style/TrivialAccessors
       def self.kitchen_driver_api_version(version)
         @api_version = version
       end
-      # rubocop:enable Style/TrivialAccessors
 
       private
 

--- a/lib/kitchen/generator/driver_create.rb
+++ b/lib/kitchen/generator/driver_create.rb
@@ -129,7 +129,7 @@ module Kitchen
       #   found
       # @api private
       def author
-        git_user_name = %x{git config user.name}.chomp
+        git_user_name = `git config user.name`.chomp
         git_user_name.empty? ? "TODO: Write your name" : git_user_name
       end
 
@@ -137,7 +137,7 @@ module Kitchen
       #   if found
       # @api private
       def email
-        git_user_email = %x{git config user.email}.chomp
+        git_user_email = `git config user.email`.chomp
         git_user_email.empty? ? "TODO: Write your email" : git_user_email
       end
 

--- a/lib/kitchen/provisioner/base.rb
+++ b/lib/kitchen/provisioner/base.rb
@@ -176,11 +176,9 @@ module Kitchen
       #
       # @param version [Integer,String] a version number
       #
-      # rubocop:disable Style/TrivialAccessors
       def self.kitchen_provisioner_api_version(version)
         @api_version = version
       end
-      # rubocop:enable Style/TrivialAccessors
 
       private
 

--- a/lib/kitchen/provisioner/chef_zero.rb
+++ b/lib/kitchen/provisioner/chef_zero.rb
@@ -99,10 +99,10 @@ module Kitchen
         # these flags are modern/chef-client local most only and will not work
         # on older versions of chef-client
         if config[:chef_zero_host]
-          args <<  "--chef-zero-host #{config[:chef_zero_host]}"
+          args << "--chef-zero-host #{config[:chef_zero_host]}"
         end
         if config[:chef_zero_port]
-          args <<  "--chef-zero-port #{config[:chef_zero_port]}"
+          args << "--chef-zero-port #{config[:chef_zero_port]}"
         end
       end
 

--- a/lib/kitchen/provisioner/dummy.rb
+++ b/lib/kitchen/provisioner/dummy.rb
@@ -58,7 +58,7 @@ module Kitchen
       #
       # @api private
       def failure_if_set
-        if config[:"fail"]
+        if config[:fail]
           debug("Failure for Provisioner #{name}.")
           raise ActionFailed, "Action #converge failed for #{instance.to_str}."
         elsif config[:random_failure] && randomly_fail?

--- a/lib/kitchen/transport/base.rb
+++ b/lib/kitchen/transport/base.rb
@@ -161,11 +161,9 @@ module Kitchen
       #
       # @param version [Integer,String] a version number
       #
-      # rubocop:disable Style/TrivialAccessors
       def self.kitchen_transport_api_version(version)
         @api_version = version
       end
-      # rubocop:enable Style/TrivialAccessors
     end
   end
 end

--- a/lib/kitchen/verifier/base.rb
+++ b/lib/kitchen/verifier/base.rb
@@ -181,11 +181,9 @@ module Kitchen
       #
       # @param version [Integer,String] a version number
       #
-      # rubocop:disable Style/TrivialAccessors
       def self.kitchen_verifier_api_version(version)
         @api_version = version
       end
-      # rubocop:enable Style/TrivialAccessors
 
       private
 

--- a/lib/kitchen/verifier/dummy.rb
+++ b/lib/kitchen/verifier/dummy.rb
@@ -58,7 +58,7 @@ module Kitchen
       #
       # @api private
       def failure_if_set
-        if config[:"fail"]
+        if config[:fail]
           debug("Failure for Verifier #{name}.")
           raise ActionFailed, "Action #verify failed for #{instance.to_str}."
         elsif config[:random_failure] && randomly_fail?

--- a/spec/kitchen/data_munger_spec.rb
+++ b/spec/kitchen/data_munger_spec.rb
@@ -20,7 +20,7 @@ require_relative "../spec_helper"
 
 require "kitchen/data_munger"
 
-module Kitchen
+module Kitchen # rubocop:disable Metrics/ModuleLength
 
   describe DataMunger do
 

--- a/spec/kitchen/provisioner/chef_zero_spec.rb
+++ b/spec/kitchen/provisioner/chef_zero_spec.rb
@@ -810,7 +810,6 @@ describe Kitchen::Provisioner::ChefZero do
         config[:require_chef_omnibus] = "10.20"
       end
 
-      # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
       def self.common_old_shell_specs
         it "does not set local mode flag" do
           cmd.wont_match regexify(" --local-mode", :partial_line)

--- a/spec/kitchen/ssh_spec.rb
+++ b/spec/kitchen/ssh_spec.rb
@@ -36,7 +36,7 @@ def with_sorted_dir_entries
     class << self
       alias_method :__entries__, :entries unless method_defined?(:__entries__)
 
-      def entries(*args)
+      def entries(*args) # rubocop:disable Lint/NestedMethodDefinition
         send(:__entries__, *args).sort
       end
     end
@@ -95,7 +95,7 @@ module Net
           pty_data = ["xterm", 80, 24, 640, 480, "\0"]
 
           script.events << Class.new(Net::SSH::Test::LocalPacket) do
-            def types
+            def types # rubocop:disable Lint/NestedMethodDefinition
               if @type == 98 && @data[1] == "pty-req"
                 @types ||= [
                   :long, :string, :bool, :string,

--- a/spec/kitchen/ssh_spec.rb
+++ b/spec/kitchen/ssh_spec.rb
@@ -158,9 +158,9 @@ describe Kitchen::SSH do
           rescue # rubocop:disable Lint/HandleExceptions
           end
 
-          logged_output.string.lines.select { |l|
+          logged_output.string.lines.count { |l|
             l =~ debug_line("[SSH] opening connection to me@foo:22<{:ssh_retries=>3}>")
-          }.size.must_equal opts[:ssh_retries]
+          }.must_equal opts[:ssh_retries]
         end
 
         it "sleeps for 1 second between retries" do
@@ -179,9 +179,9 @@ describe Kitchen::SSH do
           rescue # rubocop:disable Lint/HandleExceptions
           end
 
-          logged_output.string.lines.select { |l|
+          logged_output.string.lines.count { |l|
             l =~ info_line_with("[SSH] connection failed, retrying ")
-          }.size.must_equal 2
+          }.must_equal 2
         end
 
         it "logs the last retry failures on warn" do
@@ -190,9 +190,9 @@ describe Kitchen::SSH do
           rescue # rubocop:disable Lint/HandleExceptions
           end
 
-          logged_output.string.lines.select { |l|
+          logged_output.string.lines.count { |l|
             l =~ warn_line_with("[SSH] connection failed, terminating ")
-          }.size.must_equal 1
+          }.must_equal 1
         end
       end
     end
@@ -642,9 +642,9 @@ describe Kitchen::SSH do
       TCPSocket.stubs(:new).returns(not_ready, not_ready, ready)
       ssh.wait
 
-      logged_output.string.lines.select { |l|
+      logged_output.string.lines.count { |l|
         l =~ info_line_with("Waiting for foo:22...")
-      }.size.must_equal 2
+      }.must_equal 2
     end
   end
 

--- a/spec/kitchen/transport/ssh_spec.rb
+++ b/spec/kitchen/transport/ssh_spec.rb
@@ -36,7 +36,7 @@ def with_sorted_dir_entries
     class << self
       alias_method :__entries__, :entries unless method_defined?(:__entries__)
 
-      def entries(*args)
+      def entries(*args) # rubocop:disable Lint/NestedMethodDefinition
         send(:__entries__, *args).sort
       end
     end
@@ -95,7 +95,7 @@ module Net
           pty_data = ["xterm", 80, 24, 640, 480, "\0"]
 
           script.events << Class.new(Net::SSH::Test::LocalPacket) do
-            def types
+            def types # rubocop:disable Lint/NestedMethodDefinition
               if @type == 98 && @data[1] == "pty-req"
                 @types ||= [
                   :long, :string, :bool, :string,

--- a/spec/kitchen/transport/ssh_spec.rb
+++ b/spec/kitchen/transport/ssh_spec.rb
@@ -579,9 +579,9 @@ describe Kitchen::Transport::Ssh do
         make_connection(state)
         make_connection(state)
 
-        logged_output.string.lines.select { |l|
+        logged_output.string.lines.count { |l|
           l =~ debug_line_with("[SSH] reusing existing connection ")
-        }.size.must_equal 1
+        }.must_equal 1
       end
 
       it "returns a new connection when called again if state differs" do
@@ -602,9 +602,9 @@ describe Kitchen::Transport::Ssh do
         make_connection(state)
         make_connection(state.merge(:port => 9000))
 
-        logged_output.string.lines.select { |l|
+        logged_output.string.lines.count { |l|
           l =~ debug_line_with("[SSH] shutting previous connection ")
-        }.size.must_equal 1
+        }.must_equal 1
       end
     end
     # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
@@ -694,9 +694,9 @@ describe Kitchen::Transport::Ssh::Connection do
             # the raise is not what is being tested here, rather its side-effect
           end
 
-          logged_output.string.lines.select { |l|
+          logged_output.string.lines.count { |l|
             l =~ debug_line("[SSH] opening connection to me@foo<{:port=>22}>")
-          }.size.must_equal 3
+          }.must_equal 3
         end
 
         it "sleeps for :connection_retry_sleep seconds between retries" do
@@ -717,10 +717,10 @@ describe Kitchen::Transport::Ssh::Connection do
             # the raise is not what is being tested here, rather its side-effect
           end
 
-          logged_output.string.lines.select { |l|
+          logged_output.string.lines.count { |l|
             l =~ info_line_with(
               "[SSH] connection failed, retrying in 7 seconds")
-          }.size.must_equal 2
+          }.must_equal 2
         end
 
         it "logs the last retry failures on warn" do
@@ -730,9 +730,9 @@ describe Kitchen::Transport::Ssh::Connection do
             # the raise is not what is being tested here, rather its side-effect
           end
 
-          logged_output.string.lines.select { |l|
+          logged_output.string.lines.count { |l|
             l =~ warn_line_with("[SSH] connection failed, terminating ")
-          }.size.must_equal 1
+          }.must_equal 1
         end
       end
     end
@@ -1161,16 +1161,16 @@ describe Kitchen::Transport::Ssh::Connection do
           # the raise is not what is being tested here, rather its side-effect
         end
 
-        logged_output.string.lines.select { |l|
+        logged_output.string.lines.count { |l|
           l =~ info_line_with(
             "Waiting for SSH service on foo:22, retrying in 3 seconds")
-        }.size.must_equal((300 / 3) - 1)
-        logged_output.string.lines.select { |l|
+        }.must_equal((300 / 3) - 1)
+        logged_output.string.lines.count { |l|
           l =~ debug_line_with("[SSH] connection failed ")
-        }.size.must_equal((300 / 3) - 1)
-        logged_output.string.lines.select { |l|
+        }.must_equal((300 / 3) - 1)
+        logged_output.string.lines.count { |l|
           l =~ warn_line_with("[SSH] connection failed, terminating ")
-        }.size.must_equal 1
+        }.must_equal 1
       end
 
       it "sleeps for 3 seconds between retries" do

--- a/spec/kitchen/transport/winrm_spec.rb
+++ b/spec/kitchen/transport/winrm_spec.rb
@@ -968,7 +968,6 @@ MSG
       transporter.stubs(:upload)
     end
 
-    # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
     def self.common_specs_for_upload
       it "builds a Winrm::FileTransporter" do
         WinRM::Transport::FileTransporter.unstub(:new)
@@ -990,7 +989,6 @@ MSG
         upload
       end
     end
-    # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 
     describe "for a file" do
 

--- a/spec/kitchen/transport/winrm_spec.rb
+++ b/spec/kitchen/transport/winrm_spec.rb
@@ -306,9 +306,9 @@ describe Kitchen::Transport::Winrm do
         make_connection(state)
         make_connection(state)
 
-        logged_output.string.lines.select { |l|
+        logged_output.string.lines.count { |l|
           l =~ debug_line_with("[WinRM] reusing existing connection ")
-        }.size.must_equal 1
+        }.must_equal 1
       end
 
       it "returns a new connection when called again if state differs" do
@@ -329,9 +329,9 @@ describe Kitchen::Transport::Winrm do
         make_connection(state)
         make_connection(state.merge(:port => 9000))
 
-        logged_output.string.lines.select { |l|
+        logged_output.string.lines.count { |l|
           l =~ debug_line_with("[WinRM] shutting previous connection ")
-        }.size.must_equal 1
+        }.must_equal 1
       end
     end
     # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
@@ -732,12 +732,12 @@ MSG
             # the raise is not what is being tested here, rather its side-effect
           end
 
-          logged_output.string.lines.select { |l|
+          logged_output.string.lines.count { |l|
             l =~ debug_line("[WinRM] opening remote shell on #{info}")
-          }.size.must_equal 3
-          logged_output.string.lines.select { |l|
+          }.must_equal 3
+          logged_output.string.lines.count { |l|
             l =~ debug_line("[WinRM] remote shell shell-123 is open on #{info}")
-          }.size.must_equal 0
+          }.must_equal 0
         end
 
         it "sleeps for :connection_retry_sleep seconds between retries" do
@@ -758,10 +758,10 @@ MSG
             # the raise is not what is being tested here, rather its side-effect
           end
 
-          logged_output.string.lines.select { |l|
+          logged_output.string.lines.count { |l|
             l =~ info_line_with(
               "[WinRM] connection failed, retrying in 7 seconds")
-          }.size.must_equal 2
+          }.must_equal 2
         end
 
         it "logs the last retry failures on warn" do
@@ -771,9 +771,9 @@ MSG
             # the raise is not what is being tested here, rather its side-effect
           end
 
-          logged_output.string.lines.select { |l|
+          logged_output.string.lines.count { |l|
             l =~ warn_line_with("[WinRM] connection failed, terminating ")
-          }.size.must_equal 1
+          }.must_equal 1
         end
       end
     end
@@ -1033,16 +1033,16 @@ MSG
           # the raise is not what is being tested here, rather its side-effect
         end
 
-        logged_output.string.lines.select { |l|
+        logged_output.string.lines.count { |l|
           l =~ info_line_with(
             "Waiting for WinRM service on http://foo:5985/wsman, retrying in 3 seconds")
-        }.size.must_equal((300 / 3) - 1)
-        logged_output.string.lines.select { |l|
+        }.must_equal((300 / 3) - 1)
+        logged_output.string.lines.count { |l|
           l =~ debug_line_with("[WinRM] connection failed ")
-        }.size.must_equal((300 / 3) - 1)
-        logged_output.string.lines.select { |l|
+        }.must_equal((300 / 3) - 1)
+        logged_output.string.lines.count { |l|
           l =~ warn_line_with("[WinRM] connection failed, terminating ")
-        }.size.must_equal 1
+        }.must_equal 1
       end
 
       it "sleeps for 3 seconds between retries" do

--- a/spec/kitchen/verifier/busser_spec.rb
+++ b/spec/kitchen/verifier/busser_spec.rb
@@ -135,7 +135,6 @@ describe Kitchen::Verifier::Busser do
     end
   end
 
-  # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
   def self.common_bourne_variable_specs
     it "uses bourne shell" do
       cmd.must_match(/\Ash -c '$/)
@@ -162,9 +161,7 @@ describe Kitchen::Verifier::Busser do
       cmd.must_match regexify(%{GEM_CACHE="/r/gems/cache"; export GEM_CACHE})
     end
   end
-  # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 
-  # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
   def self.common_powershell_variable_specs
     it "sets the BUSSER_ROOT environment variable" do
       cmd.must_match regexify(%{$env:BUSSER_ROOT = "\\r"})
@@ -182,7 +179,6 @@ describe Kitchen::Verifier::Busser do
       cmd.must_match regexify(%{$env:GEM_CACHE = "\\r\\gems\\cache"})
     end
   end
-  # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 
   describe "#install_command" do
 

--- a/test-kitchen.gemspec
+++ b/test-kitchen.gemspec
@@ -48,6 +48,6 @@ Gem::Specification.new do |gem|
   # style and complexity libraries are tightly version pinned as newer releases
   # may introduce new and undesireable style choices which would be immediately
   # enforced in CI
-  gem.add_development_dependency "finstyle",  "1.4.0"
+  gem.add_development_dependency "finstyle",  "1.5.0"
   gem.add_development_dependency "cane",      "2.6.2"
 end


### PR DESCRIPTION
This bumps the effective version of RuboCop to 0.32.1, which we are hoping will lead to less failures in CI…