### PR TITLE
Commandline option to force color output

### DIFF
--- a/lib/kitchen/cli.rb
+++ b/lib/kitchen/cli.rb
@@ -91,6 +91,10 @@ module Kitchen
       method_option :log_overwrite,
         :desc => "Set to false to prevent log overwriting each time Test Kitchen runs",
         :type => :boolean
+      method_option :color,
+        :type => :boolean,
+        :lazy_default => $stdout.tty?,
+        :desc => "Toggle color output for STDOUT logger"
     end
 
     desc "list [INSTANCE|REGEXP|all]", "Lists one or more instances"
@@ -338,13 +342,14 @@ module Kitchen
       unless options[:log_overwrite].nil?
         @config.log_overwrite = options[:log_overwrite]
       end
+      @config.colorize = options[:color] unless options[:color].nil?
 
       # Now that we have required configs, lets create our file logger
       Kitchen.logger = Kitchen.default_file_logger(
         level,
         options[:log_overwrite]
       )
-
+      
       update_parallel!
     end
 

--- a/lib/kitchen/config.rb
+++ b/lib/kitchen/config.rb
@@ -77,6 +77,14 @@ module Kitchen
     # @api private
     attr_accessor :log_overwrite
 
+    # @return [Boolean] whether to force color output or not in logger
+    # @api private
+    attr_accessor :log_overwrite
+
+    # @return [Boolean] whether to force color output or not in logger
+    # @api private
+    attr_accessor :colorize
+
     # Creates a new configuration, representing a particular testing
     # configuration for a project.
     #
@@ -100,6 +108,7 @@ module Kitchen
       @kitchen_root   = options.fetch(:kitchen_root) { Dir.pwd }
       @log_level      = options.fetch(:log_level) { Kitchen::DEFAULT_LOG_LEVEL }
       @log_overwrite  = options.fetch(:log_overwrite) { Kitchen::DEFAULT_LOG_OVERWRITE }
+      @colorize       = options.fetch(:colorize) { Kitchen.tty? } 
       @log_root       = options.fetch(:log_root) { default_log_root }
       @test_base_path = options.fetch(:test_base_path) { default_test_base_path }
     end
@@ -264,7 +273,8 @@ module Kitchen
         :logdev   => log_location,
         :level    => Util.to_logger_level(log_level),
         :log_overwrite => log_overwrite,
-        :progname => name
+        :progname => name,
+        :colorize => @colorize
       )
     end
 

--- a/lib/kitchen/logger.rb
+++ b/lib/kitchen/logger.rb
@@ -78,8 +78,8 @@ module Kitchen
     def populate_loggers(color, options)
       @loggers = []
       @loggers << logdev unless logdev.nil?
-      @loggers << stdout_logger(options[:stdout], color) if options[:stdout]
-      @loggers << stdout_logger($stdout, color) if @loggers.empty?
+      @loggers << stdout_logger(options[:stdout], color, options[:colorize]) if options[:stdout]
+      @loggers << stdout_logger($stdout, color, options[:colorize]) if @loggers.empty?
     end
     private :populate_loggers
 
@@ -288,9 +288,9 @@ module Kitchen
     # @param color [Symbol] color to use when outputing messages
     # @return [StdoutLogger] a new logger
     # @api private
-    def stdout_logger(stdout, color)
+    def stdout_logger(stdout, color, colorize)
       logger = StdoutLogger.new(stdout)
-      if Kitchen.tty?
+      if colorize
         logger.formatter = proc do |_severity, _datetime, _progname, msg|
           Color.colorize("#{msg}", color).concat("\n")
         end


### PR DESCRIPTION
adds commandline flag ot enable disable color output:

`--color` - This is useful when running kitchen from environment that is not a tty.
`--no-color` - Useful when running kitchen from terminals that do not support ANSI

### Can be tested with:

should not give color output
```
chef exec kitchen destroy  | cat
```
should not give color output
```
chef exec kitchen destroy --no-color
```
should give color output:
```
chef exec kitchen destroy --color | cat
````