### PR TITLE
Fix monkey patching of IO.read

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -43,7 +43,20 @@ require "tempfile"
 # Nasty hack to redefine IO.read in terms of File#read for fakefs
 class IO
   def self.read(*args)
-    File.open(args[0], "rb") { |f| f.read(args[1]) }
+    length = args[1]
+    offset = args[2]
+    opt = args[3]
+    if length.is_a? Hash
+      opt = length
+      length = nil
+    elsif offset.is_a? Hash
+      opt = offset
+    end
+    if opt && opt.key?(:mode)
+      File.open(args[0], opt) { |f| f.read(length) }
+    else
+      File.open(args[0], "rb", opt) { |f| f.read(length) }
+    end
   end
 end
 


### PR DESCRIPTION
Ruby 2.0 supports one more optional parameter of IO.read, which is hash of read modes.