### PR TITLE
Add more options for WinRM

### DIFF
--- a/test-kitchen.gemspec
+++ b/test-kitchen.gemspec
@@ -35,6 +35,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "pry-byebug"
   gem.add_development_dependency "pry-stack_explorer"
   gem.add_development_dependency "winrm-transport", "~> 1.0", ">= 1.0.3"
+  gem.add_development_dependency "winrm-s", "~> 0.3"
 
   gem.add_development_dependency "bundler",   "~> 1.3"
   gem.add_development_dependency "rake"


### PR DESCRIPTION
Uses winrm-s to allow sspinegotiate auth from Windows hosts to Windows guests.

Adds winrm_transport to the configuration options for the winrm transport with defaults to plaintext (the current behavior) and can be set to sspinegotiate.

The effect is that we don't have to have AllowUnencypted set to $true for the WinRM service on the target machines.

This won't help drivers that have their own reliance on WinRM as a communication option (like kitchen-vagrant), but any driver that uses the transport abstraction can take advantage of this.

