### PR TITLE
Ensure sandbox_path is not within kitchen_root.

### DIFF
--- a/lib/kitchen/provisioner/base.rb
+++ b/lib/kitchen/provisioner/base.rb
@@ -141,7 +141,18 @@ module Kitchen
       # @return [String] the absolute path to the sandbox directory
       # @raise [ClientError] if the sandbox directory has no yet been created
       #   by calling `#create_sandbox`
+      # @raise [ClientError] if the system temp directory has incorrect
+      #   permissions causing the mktempdir call to try to use config[:kitchen_root]
+      #   instead.
       def sandbox_path
+        if File.dirname(@sandbox_path) == config[:kitchen_root]
+          raise ClientError,
+            "There was a problem attempting to write to your " \
+            "default system temp directory. Check the permissions, and on " \
+            "non-windows hosts ensure the tmp sticky bit is set on the temp " \
+            "directory."
+        end
+
         @sandbox_path || (raise ClientError, "Sandbox directory has not yet " \
           "been created. Please run #{self.class}#create_sandox before " \
           "trying to access the path.")


### PR DESCRIPTION
# Summary of Change

In rare cases the system temp directory becomes unusable, which results
in the mktmpdir trying to use the current working directory. This
becomes an issue as the default value for kitchen_root is also cwd
which results in a confusing cyclical error in which it attempts to copy
the cookbooks into a temp directory within the path which is is
copying. This should avoid most instances of this error, and present a
possible solution in simple terms.
# Related Issues

Resolves Issue #779
# Validation
- [ ] `sudo chmod 0777 /tmp`
- [ ] Attempt to run `kitchen converge` on a cookbook, it should raise a ClientError with the message, "There was a problem attempting to write to your default system temp directory. Check the permissions, and on non-windows hosts ensure the tmp sticky bit is set on the temp directory."
- [ ] `sudo chmod 1777 /tmp'
- [ ] Attempt to run `kitchen converge` on a cookbook, everything should work normally.
