### PR TITLE
Nightlies

### DIFF
--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -262,6 +262,9 @@ module Kitchen
       # @api private
       def install_command_vars_for_bourne(version)
         install_flags = %w[latest true].include?(version) ? "" : "-v #{CGI.escape(version)}"
+        if config[:nightly]
+          install_flags << " " << "-n"
+        end
         if config[:chef_omnibus_install_options]
           install_flags << " " << config[:chef_omnibus_install_options]
         end

--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -36,6 +36,7 @@ module Kitchen
     class ChefBase < Base
 
       default_config :require_chef_omnibus, true
+      default_config :nightly, false
       default_config :chef_omnibus_url, "https://www.chef.io/chef/install.sh"
       default_config :chef_omnibus_install_options, nil
       default_config :run_list, []

--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -105,8 +105,8 @@ module Kitchen
       #   for installing a Windows MSI package
       def default_windows_chef_metadata_url
         version = config[:require_chef_omnibus]
-        version = "latest" if version == true
-        nightly = config[:nightly]
+        nightly = config[:nightly] || version == "nightly"
+        version = "latest" if version == true || version == "nightly"
 
         base = if config[:chef_omnibus_url] =~ %r{/install.sh$}
           "#{File.dirname(config[:chef_omnibus_url])}/"
@@ -262,8 +262,8 @@ module Kitchen
       # @return [String] shell variable lines
       # @api private
       def install_command_vars_for_bourne(version)
-        install_flags = %w[latest true].include?(version) ? "" : "-v #{CGI.escape(version)}"
-        if config[:nightly]
+        install_flags = %w[latest true nightly].include?(version) ? "" : "-v #{CGI.escape(version)}"
+        if config[:nightly] || version == "nightly"
           install_flags << " " << "-n"
         end
         if config[:chef_omnibus_install_options]

--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -105,6 +105,8 @@ module Kitchen
       def default_windows_chef_metadata_url
         version = config[:require_chef_omnibus]
         version = "latest" if version == true
+        nightly = config[:nightly]
+
         base = if config[:chef_omnibus_url] =~ %r{/install.sh$}
           "#{File.dirname(config[:chef_omnibus_url])}/"
         else
@@ -114,6 +116,7 @@ module Kitchen
         url = "#{base}#{metadata_project_from_options}"
         url << "?p=windows&m=x86_64&pv=2008r2" # same pacakge for all versions
         url << "&v=#{CGI.escape(version.to_s.downcase)}"
+        url << "&nightlies=true" if nightly
         url
       end
 

--- a/spec/kitchen/provisioner/chef_base_spec.rb
+++ b/spec/kitchen/provisioner/chef_base_spec.rb
@@ -175,6 +175,28 @@ describe Kitchen::Provisioner::ChefBase do
           provisioner[:chef_metadata_url].
             must_equal "#{base_url}-chefdk?p=windows&m=x86_64&pv=2008r2&v=0.3"
         end
+
+        it "defaults to a nightly from :nightly" do
+          config[:nightly] = true
+
+          provisioner[:chef_metadata_url].
+            must_equal "#{base_url}?p=windows&m=x86_64&pv=2008r2&v=latest&nightlies=true"
+        end
+
+        it "defaults to nightly from :require_chef_omnibus" do
+          config[:require_chef_omnibus] = "nightly"
+
+          provisioner[:chef_metadata_url].
+            must_equal "#{base_url}?p=windows&m=x86_64&pv=2008r2&v=latest&nightlies=true"
+        end
+
+        it "defaults to versioned nightly from :require_chef_omnibus and :nightly" do
+          config[:require_chef_omnibus] = 12.4
+          config[:nightly] = true
+
+          provisioner[:chef_metadata_url].
+            must_equal "#{base_url}?p=windows&m=x86_64&pv=2008r2&v=12.4&nightlies=true"
+        end
       end
     end
 
@@ -323,7 +345,7 @@ describe Kitchen::Provisioner::ChefBase do
         cmd.must_match regexify(%{version="10.1.0.rc.1"})
       end
 
-      it "will install a nightly, if necessary" do
+      it "will install an explicit nightly, if necessary" do
         config[:require_chef_omnibus] = "12.5.0-current.0+20150721082808.git.14.c91b337-1"
 
         cmd.must_match(
@@ -332,6 +354,12 @@ describe Kitchen::Provisioner::ChefBase do
           regexify(%{pretty_version="12.5.0-current.0+20150721082808.git.14.c91b337-1"}))
         cmd.must_match(
           regexify(%{version="12.5.0-current.0+20150721082808.git.14.c91b337-1"}))
+      end
+
+      it "will install a nightly, if necessary" do
+        config[:nightly] = true
+
+        cmd.must_match regexify(%{install_flags="-n"})
       end
 
       it "will install the latest of chef, if necessary" do


### PR DESCRIPTION
This allows specifying nightlies in the following manner:
```yaml
provisioner:
  require_chef_omnibus: nightly
```
or
```yaml
provisioner:
  nightly: true
```
or
```yaml
provisioner:
  require_chef_omnibus: 12.4
  nightly: true
```