### PR TITLE
Fix for net-ssh 2.10.0.

### DIFF
--- a/lib/kitchen/transport/ssh.rb
+++ b/lib/kitchen/transport/ssh.rb
@@ -52,13 +52,8 @@ module Kitchen
       default_config :ssh_key, nil
       expand_path_for :ssh_key
 
-      default_config :compression, "zlib"
-      required_config :compression do |attr, value, transport|
-        if !%W[zlib none].include?(value)
-          raise UserError, "#{transport} :#{attr} value may only " \
-            "be set to `none' or `zlib'."
-        end
-      end
+      default_config :compression, true
+      required_config :compression
 
       default_config :compression_level do |transport|
         transport[:compression] == "none" ? 0 : 6

--- a/spec/kitchen/transport/ssh_spec.rb
+++ b/spec/kitchen/transport/ssh_spec.rb
@@ -145,21 +145,14 @@ describe Kitchen::Transport::Ssh do
       transport[:username].must_equal "root"
     end
 
-    it "sets :compression to zlib by default" do
-      transport[:compression].must_equal "zlib"
+    it "sets :compression to true by default" do
+      transport[:compression].must_equal true
     end
 
     it "sets :compression to none if set to none" do
       config[:compression] = "none"
 
       transport[:compression].must_equal "none"
-    end
-
-    it "raises a UserError if :compression is set to a bogus value" do
-      config[:compression] = "boom"
-
-      err = proc { transport }.must_raise Kitchen::UserError
-      err.message.must_match(%r{value may only be set to `none' or `zlib'})
     end
 
     it "sets :compression_level to 6 by default" do


### PR DESCRIPTION
This sets the default compression to auto-negotiate the best available. This is broken currently because net-ssh no longer silently allows falling back to no compression and OpenSSH uses `"zlib@openssh.com"`, not `"zlib"`. I've removed the validation as it is incorrect and in the future it would be nice to not need an ASAP release for this kind of issue. If a user misconfigured the compression setting, they will now notice immediately because it will refuse to connect.

Fixes #729.