### PR TITLE
Rescue Errno::ETIMEDOUT instead of Timeout::Error on Establish

### DIFF
--- a/lib/kitchen/transport/ssh.rb
+++ b/lib/kitchen/transport/ssh.rb
@@ -155,7 +155,7 @@ module Kitchen
         RESCUE_EXCEPTIONS_ON_ESTABLISH = [
           Errno::EACCES, Errno::EADDRINUSE, Errno::ECONNREFUSED,
           Errno::ECONNRESET, Errno::ENETUNREACH, Errno::EHOSTUNREACH,
-          Net::SSH::Disconnect, Net::SSH::AuthenticationFailed, Timeout::Error
+          Net::SSH::Disconnect, Net::SSH::AuthenticationFailed, Errno::ETIMEDOUT
         ].freeze
 
         # @return [Integer] how many times to retry when failing to execute

--- a/spec/kitchen/transport/ssh_spec.rb
+++ b/spec/kitchen/transport/ssh_spec.rb
@@ -669,7 +669,7 @@ describe Kitchen::Transport::Ssh::Connection do
     [
       Errno::EACCES, Errno::EADDRINUSE, Errno::ECONNREFUSED,
       Errno::ECONNRESET, Errno::ENETUNREACH, Errno::EHOSTUNREACH,
-      Net::SSH::Disconnect, Net::SSH::AuthenticationFailed, Timeout::Error
+      Net::SSH::Disconnect, Net::SSH::AuthenticationFailed, Errno::ETIMEDOUT
     ].each do |klass|
       describe "raising #{klass}" do
 


### PR DESCRIPTION
Fix #800 
net-ssh 2.10 does not use 'timeout' anymore, it use the Socket `connect_timeout` instead.
See: https://github.com/net-ssh/net-ssh/commit/58b379787b19b47e3b17f73ac05bda208772bb3c and https://github.com/net-ssh/net-ssh/commit/9bfbdc98e8d36e8f62792a6ecdd258bc232b9d9a