### PR TITLE
fixed SuSe OS busser install

### DIFF
--- a/lib/kitchen/verifier/busser.rb
+++ b/lib/kitchen/verifier/busser.rb
@@ -175,7 +175,7 @@ module Kitchen
 
         args = gem
         args += " --version #{version}" if version
-        args += " --no-rdoc --no-ri"
+        args += " --no-rdoc --no-ri --no-format-executable"
         args
       end
 

--- a/spec/kitchen/verifier/busser_spec.rb
+++ b/spec/kitchen/verifier/busser_spec.rb
@@ -237,7 +237,7 @@ describe Kitchen::Verifier::Busser do
 
         it "sets gem install arguments" do
           cmd.must_match regexify(
-            %{gem_install_args="busser --no-rdoc --no-ri"})
+            %{gem_install_args="busser --no-rdoc --no-ri --no-format-executable"})
         end
 
         it "prepends sudo for busser binstub command when :sudo is set" do
@@ -284,7 +284,7 @@ describe Kitchen::Verifier::Busser do
 
         it "sets gem install arguments" do
           cmd.must_match regexify(
-            %{$gem_install_args = "busser --no-rdoc --no-ri"})
+            %{$gem_install_args = "busser --no-rdoc --no-ri --no-format-executable"})
         end
 
         it "sets path to busser binstub command" do


### PR DESCRIPTION
In SuSe-based OS the rubygem binaries are installed with their version number in their name. This behavior can be disabled with the option --no-format-executable. Without this little change the busser installation will fail on SuSe-based OS like OpenSUSE or SLES

testet with 
OS: openSUSE 13.2, SLES 12 Ubuntu 14.04
Provisioner: kitchen-ansible
Driver: kitchen-vagrant
            kitchen-docker

with verifier setting:
verifier:
  ruby_bindir: '/usr/bin'