### PR TITLE
Retry EOFError when trying to establish a connection

### DIFF
--- a/lib/kitchen/transport/ssh.rb
+++ b/lib/kitchen/transport/ssh.rb
@@ -164,7 +164,7 @@ module Kitchen
 
         RESCUE_EXCEPTIONS_ON_ESTABLISH = [
           Errno::EACCES, Errno::EADDRINUSE, Errno::ECONNREFUSED, Errno::ETIMEDOUT,
-          Errno::ECONNRESET, Errno::ENETUNREACH, Errno::EHOSTUNREACH,
+          Errno::ECONNRESET, Errno::ENETUNREACH, Errno::EHOSTUNREACH, EOFError,
           Net::SSH::Disconnect, Net::SSH::AuthenticationFailed, Timeout::Error
         ].freeze
 

--- a/spec/kitchen/transport/ssh_spec.rb
+++ b/spec/kitchen/transport/ssh_spec.rb
@@ -667,7 +667,7 @@ describe Kitchen::Transport::Ssh::Connection do
 
     [
       Errno::EACCES, Errno::EADDRINUSE, Errno::ECONNREFUSED, Errno::ETIMEDOUT,
-      Errno::ECONNRESET, Errno::ENETUNREACH, Errno::EHOSTUNREACH,
+      Errno::ECONNRESET, Errno::ENETUNREACH, Errno::EHOSTUNREACH, EOFError,
       Net::SSH::Disconnect, Net::SSH::AuthenticationFailed, Timeout::Error
     ].each do |klass|
       describe "raising #{klass}" do


### PR DESCRIPTION
Was getting:

```
------Exception-------
Class: EOFError
Message: end of file reached
------Backtrace-------
net-ssh-2.9.2/lib/net/ssh/proxy/command.rb:75:in `read_nonblock'
net-ssh-2.9.2/lib/net/ssh/proxy/command.rb:75:in `recv'
net-ssh-2.9.2/lib/net/ssh/buffered_io.rb:65:in `fill'
net-ssh-2.9.2/lib/net/ssh/transport/packet_stream.rb:88:in `next_packet'
net-ssh-2.9.2/lib/net/ssh/transport/session.rb:183:in `block in poll_message'
net-ssh-2.9.2/lib/net/ssh/transport/session.rb:178:in `loop'
net-ssh-2.9.2/lib/net/ssh/transport/session.rb:178:in `poll_message'
net-ssh-2.9.2/lib/net/ssh/transport/session.rb:215:in `block in wait'
net-ssh-2.9.2/lib/net/ssh/transport/session.rb:213:in `loop'
net-ssh-2.9.2/lib/net/ssh/transport/session.rb:213:in `wait'
net-ssh-2.9.2/lib/net/ssh/transport/session.rb:87:in `initialize'
net-ssh-2.9.2/lib/net/ssh.rb:207:in `new'
net-ssh-2.9.2/lib/net/ssh.rb:207:in `start'
test-kitchen-8186160aeed8/lib/kitchen/transport/ssh.rb:203:in `establish_connection'
test-kitchen-8186160aeed8/lib/kitchen/transport/ssh.rb:270:in `session'
test-kitchen-8186160aeed8/lib/kitchen/transport/ssh.rb:142:in `wait_until_ready'
kitchen-ec2-b27f058ef9bf/lib/kitchen/driver/ec2.rb:227:in `create'
test-kitchen-8186160aeed8/lib/kitchen/instance.rb:424:in `public_send'
test-kitchen-8186160aeed8/lib/kitchen/instance.rb:424:in `block in perform_action'
test-kitchen-8186160aeed8/lib/kitchen/instance.rb:488:in `call'
test-kitchen-8186160aeed8/lib/kitchen/instance.rb:488:in `synchronize_or_call'
test-kitchen-8186160aeed8/lib/kitchen/instance.rb:453:in `block in action'
benchmark.rb:279:in `measure'
test-kitchen-8186160aeed8/lib/kitchen/instance.rb:452:in `action'
test-kitchen-8186160aeed8/lib/kitchen/instance.rb:424:in `perform_action'
test-kitchen-8186160aeed8/lib/kitchen/instance.rb:352:in `create_action'
test-kitchen-8186160aeed8/lib/kitchen/instance.rb:341:in `block in transition_to'
test-kitchen-8186160aeed8/lib/kitchen/instance.rb:340:in `each'
test-kitchen-8186160aeed8/lib/kitchen/instance.rb:340:in `transition_to'
test-kitchen-8186160aeed8/lib/kitchen/instance.rb:160:in `verify'
test-kitchen-8186160aeed8/lib/kitchen/instance.rb:189:in `block in test'
benchmark.rb:279:in `measure'
lib/kitchen/instance.rb:185:in `test'
lib/kitchen/command.rb:176:in `public_send'
lib/kitchen/command.rb:176:in `block (2 levels) in run_action'
```
