### PR TITLE
Fix handling of chunked ssh output.

### DIFF
--- a/lib/kitchen/logger.rb
+++ b/lib/kitchen/logger.rb
@@ -343,13 +343,10 @@ module Kitchen
       # @param msg [String] a message
       def <<(msg)
         @buffer ||= ""
-        lines, _, remainder = msg.rpartition("\n")
-        if lines.empty?
-          @buffer << remainder
-        else
-          lines.insert(0, @buffer)
-          lines.split("\n").each { |l| format_line(l.chomp) }
-          @buffer = ""
+        @buffer += msg
+        while i = @buffer.index("\n")
+          format_line(@buffer[0, i].chomp)
+          @buffer[0, i+1] = ''
         end
       end
 

--- a/lib/kitchen/logger.rb
+++ b/lib/kitchen/logger.rb
@@ -346,7 +346,7 @@ module Kitchen
         @buffer += msg
         while i = @buffer.index("\n")
           format_line(@buffer[0, i].chomp)
-          @buffer[0, i+1] = ''
+          @buffer[0, i + 1] = ""
         end
       end
 

--- a/spec/kitchen/logger_spec.rb
+++ b/spec/kitchen/logger_spec.rb
@@ -282,6 +282,16 @@ describe Kitchen::Logger do
         )
       end
 
+      it "logger that receives full line plus partial line will flush on next message with newline" do
+        logger << "partially\no"
+        logger << "kay\n"
+
+        stdout.string.must_equal(
+          colorize("       partially", opts[:color]) + "\n" +
+          colorize("       okay", opts[:color]) + "\n"
+        )
+      end
+
       it "logger chomps carriage return characters" do
         logger << [
           "-----> banner\r",

--- a/spec/kitchen/logger_spec.rb
+++ b/spec/kitchen/logger_spec.rb
@@ -282,7 +282,7 @@ describe Kitchen::Logger do
         )
       end
 
-      it "logger that receives full line plus partial line will flush on next message with newline" do
+      it "logger that receives mixed first chunk will flush next message with newline" do
         logger << "partially\no"
         logger << "kay\n"
 


### PR DESCRIPTION
This fixes issue #685 (Chef client output isn't complete).

The `<<` method was discarding the remainder if there were any line feeds in
the `msg`. This commit simplifies the logic to:
* append the new message to whatever buffer exists
* output whatever complete lines exist in the buffer
* remove any consumed lines from the buffer