### PR TITLE
Add hooks for instance cleanup before exit.

### DIFF
--- a/lib/kitchen/command.rb
+++ b/lib/kitchen/command.rb
@@ -174,6 +174,7 @@ module Kitchen
           threads << Thread.new do
             while instance = queue.pop
               instance.public_send(action, *args)
+              instance.cleanup!
             end
           end
         end

--- a/lib/kitchen/instance.rb
+++ b/lib/kitchen/instance.rb
@@ -267,6 +267,13 @@ module Kitchen
       state_file.read[:last_action]
     end
 
+    # Clean up any per-instance resources before exiting.
+    #
+    # @return [void]
+    def cleanup!
+      @transport.cleanup! if @transport
+    end
+
     private
 
     # @return [StateFile] a state file object that can be read from or written

--- a/lib/kitchen/transport/base.rb
+++ b/lib/kitchen/transport/base.rb
@@ -58,6 +58,13 @@ module Kitchen
         raise ClientError, "#{self.class}#connection must be implemented"
       end
 
+      # Closes the connection, if it is still active.
+      #
+      # @return [void]
+      def cleanup!
+        # This method may be left unimplemented if that is applicable
+      end
+
       # A Connection instance can be generated and re-generated, given new
       # connection details such as connection port, hostname, credentials, etc.
       # This object is responsible for carrying out the actions on the remote

--- a/lib/kitchen/transport/ssh.rb
+++ b/lib/kitchen/transport/ssh.rb
@@ -85,6 +85,15 @@ module Kitchen
         end
       end
 
+      # (see Base#cleanup!)
+      def cleanup!
+        if @connection
+          logger.debug("[SSH] shutting previous connection #{@connection}")
+          @connection.close
+          @connection = @connection_options = nil
+        end
+      end
+
       # A Connection instance can be generated and re-generated, given new
       # connection details such as connection port, hostname, credentials, etc.
       # This object is responsible for carrying out the actions on the remote
@@ -334,11 +343,7 @@ module Kitchen
       # @return [Ssh::Connection] an SSH Connection instance
       # @api private
       def create_new_connection(options, &block)
-        if @connection
-          logger.debug("[SSH] shutting previous connection #{@connection}")
-          @connection.close
-        end
-
+        cleanup!
         @connection_options = options
         @connection = Kitchen::Transport::Ssh::Connection.new(options, &block)
       end


### PR DESCRIPTION
This fixes the zlib warning and can be extended in the future if needed.