### PR TITLE
Updates the gem path to install everything in /tmp/verifier

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 
 rvm:
-  - 2.2
+  - 2.2.3
   - 2.1
   - 2.0.0
   - ruby-head

--- a/lib/kitchen/verifier/base.rb
+++ b/lib/kitchen/verifier/base.rb
@@ -44,6 +44,8 @@ module Kitchen
         verifier.windows_os? ? nil : true
       end
 
+      default_config :chef_omnibus_root, "/opt/chef"
+
       default_config :sudo_command do |verifier|
         verifier.windows_os? ? nil : "sudo -E"
       end

--- a/lib/kitchen/verifier/busser.rb
+++ b/lib/kitchen/verifier/busser.rb
@@ -46,7 +46,7 @@ module Kitchen
         if verifier.windows_os?
           "$env:systemdrive\\opscode\\chef\\embedded\\bin"
         else
-          "/opt/chef/embedded/bin"
+          verifier.remote_path_join(%W[#{verifier[:chef_omnibus_root]} embedded bin])
         end
       end
 
@@ -173,9 +173,16 @@ module Kitchen
         gem, version = config[:version].split("@")
         gem, version = "busser", gem if gem =~ /^\d+\.\d+\.\d+/
 
+        root = config[:root_path]
+        gem_bin = remote_path_join(root, "bin")
+
+        # We don't want the gems to be installed in the home directory,
+        # this will force the bindir and the gem install location both
+        # to be under /tmp/verifier
         args = gem
         args += " --version #{version}" if version
-        args += " --no-rdoc --no-ri --no-format-executable"
+        args += " --no-rdoc --no-ri --no-format-executable -n #{gem_bin}"
+        args += " --no-user-install"
         args
       end
 

--- a/spec/kitchen/verifier/busser_spec.rb
+++ b/spec/kitchen/verifier/busser_spec.rb
@@ -237,12 +237,12 @@ describe Kitchen::Verifier::Busser do
           cmd.must_match regexify(%{version="the_best"})
         end
 
-        # rubocop:disable Metrics/LineLength
         it "sets gem install arguments" do
           cmd.must_match regexify(
-            %{gem_install_args="busser --no-rdoc --no-ri --no-format-executable -n /r/bin --no-user-install"})
+            "gem_install_args=\"busser --no-rdoc --no-ri --no-format-executable" \
+            " -n /r/bin --no-user-install\""
+          )
         end
-        # rubocop:enable Metrics/LineLength
 
         it "prepends sudo for busser binstub command when :sudo is set" do
           cmd.must_match regexify(%{busser="sudo -E /r/bin/busser"})
@@ -286,12 +286,12 @@ describe Kitchen::Verifier::Busser do
           cmd.must_match regexify(%{$version = "the_best"})
         end
 
-        # rubocop:disable Metrics/LineLength
         it "sets gem install arguments" do
           cmd.must_match regexify(
-            %{$gem_install_args = "busser --no-rdoc --no-ri --no-format-executable -n \\r\\bin --no-user-install"})
+            "$gem_install_args = \"busser --no-rdoc --no-ri --no-format-executable" \
+            " -n \\r\\bin --no-user-install\""
+          )
         end
-        # rubocop:enable Metrics/LineLength
 
         it "sets path to busser binstub command" do
           cmd.must_match regexify(%{$busser = "\\r\\bin\\busser.bat"})

--- a/spec/kitchen/verifier/busser_spec.rb
+++ b/spec/kitchen/verifier/busser_spec.rb
@@ -101,7 +101,9 @@ describe Kitchen::Verifier::Busser do
 
     describe "for unix operating systems" do
 
-      before { platform.stubs(:os_type).returns("unix") }
+      before {
+        platform.stubs(:os_type).returns("unix")
+      }
 
       it ":ruby_bindir defaults the an Omnibus Chef installation" do
         verifier[:ruby_bindir].must_equal "/opt/chef/embedded/bin"
@@ -235,10 +237,12 @@ describe Kitchen::Verifier::Busser do
           cmd.must_match regexify(%{version="the_best"})
         end
 
+        # rubocop:disable Metrics/LineLength
         it "sets gem install arguments" do
           cmd.must_match regexify(
-            %{gem_install_args="busser --no-rdoc --no-ri --no-format-executable"})
+            %{gem_install_args="busser --no-rdoc --no-ri --no-format-executable -n /r/bin --no-user-install"})
         end
+        # rubocop:enable Metrics/LineLength
 
         it "prepends sudo for busser binstub command when :sudo is set" do
           cmd.must_match regexify(%{busser="sudo -E /r/bin/busser"})
@@ -282,10 +286,12 @@ describe Kitchen::Verifier::Busser do
           cmd.must_match regexify(%{$version = "the_best"})
         end
 
+        # rubocop:disable Metrics/LineLength
         it "sets gem install arguments" do
           cmd.must_match regexify(
-            %{$gem_install_args = "busser --no-rdoc --no-ri --no-format-executable"})
+            %{$gem_install_args = "busser --no-rdoc --no-ri --no-format-executable -n \\r\\bin --no-user-install"})
         end
+        # rubocop:enable Metrics/LineLength
 
         it "sets path to busser binstub command" do
           cmd.must_match regexify(%{$busser = "\\r\\bin\\busser.bat"})

--- a/support/busser_install_command.sh
+++ b/support/busser_install_command.sh
@@ -7,8 +7,7 @@ else
 fi
 
 if test ! -f "$BUSSER_ROOT/bin/busser"; then
-  gem_bindir=`$ruby -rrubygems -e "puts Gem.bindir"`
-  $gem_bindir/busser setup
+  $busser setup
 fi
 
 echo "       Installing Busser plugins: $plugins"


### PR DESCRIPTION
@fnichol @patrick-wright @tyler-ball 

This may resolve #830 

The only thing I can't really figure out is you have to add the following:

`verifier:
  chef_omnibus_root: /opt/chefdk`

This is so that the verifier can find ruby and suchlike.