### PR TITLE
WinRM connect (with retry) is failing on Windows

### DIFF
--- a/lib/kitchen/transport/winrm.rb
+++ b/lib/kitchen/transport/winrm.rb
@@ -136,7 +136,7 @@ module Kitchen
 
         RESCUE_EXCEPTIONS_ON_ESTABLISH = lambda do
           [
-            Errno::EACCES, Errno::EADDRINUSE, Errno::ECONNREFUSED,
+            Errno::EACCES, Errno::EADDRINUSE, Errno::ECONNREFUSED, Errno::ETIMEDOUT,
             Errno::ECONNRESET, Errno::ENETUNREACH, Errno::EHOSTUNREACH,
             ::WinRM::WinRMHTTPTransportError, ::WinRM::WinRMAuthorizationError,
             HTTPClient::KeepAliveDisconnected,


### PR DESCRIPTION
I just found out that when test kitchen tries to connect to an ec2 instance via winRM it fails because the exception type is not filtered and therefore it fails directly. This only happened on windows machines on linux everything was fine.
The added exception type should now prevent the instant failing, when the ec2 instance is not ready yet.

A related issue is: test-kitchen/kitchen-ec2#175