### PR TITLE
Adding support for hidden files 

### DIFF
--- a/lib/kitchen/provisioner/base.rb
+++ b/lib/kitchen/provisioner/base.rb
@@ -59,7 +59,7 @@ module Kitchen
       # @raise [ActionFailed] if the action could not be completed
       def call(state)
         create_sandbox
-        sandbox_dirs = Dir.glob(File.join(sandbox_path, "*"))
+        sandbox_dirs = Dir.glob(File.join(sandbox_path, "*")) + Dir.glob(File.join(sandbox_path, ".[1-0a-zA-Z]*"))
 
         instance.transport.connection(state) do |conn|
           conn.execute(install_command)


### PR DESCRIPTION
When copying files to the sandbox_dir, current call to Dir.glob neglects hidden files.
This PR aims to include hidden files as well.