### PR TITLE
include hidden files when copying over from sandbox to target

### DIFF
--- a/lib/kitchen/provisioner/base.rb
+++ b/lib/kitchen/provisioner/base.rb
@@ -59,7 +59,7 @@ module Kitchen
       # @raise [ActionFailed] if the action could not be completed
       def call(state)
         create_sandbox
-        sandbox_dirs = Dir.glob(File.join(sandbox_path, "*"))
+        sandbox_dirs = Dir.glob(File.join(sandbox_path, "*")) + Dir.glob(File.join(sandbox_path, ".[1-0a-zA-Z]*"))
 
         instance.transport.connection(state) do |conn|
           conn.execute(install_command)

--- a/lib/kitchen/provisioner/base.rb
+++ b/lib/kitchen/provisioner/base.rb
@@ -59,7 +59,7 @@ module Kitchen
       # @raise [ActionFailed] if the action could not be completed
       def call(state)
         create_sandbox
-        sandbox_dirs = Dir.glob(File.join(sandbox_path, "*")) + Dir.glob(File.join(sandbox_path, ".[1-0a-zA-Z]*"))
+        sandbox_dirs = Dir.glob(File.join(sandbox_path, "*")) + Dir.glob(File.join(sandbox_path, ".[a-zA-Z0-9]*"))
 
         instance.transport.connection(state) do |conn|
           conn.execute(install_command)

--- a/lib/kitchen/provisioner/base.rb
+++ b/lib/kitchen/provisioner/base.rb
@@ -60,7 +60,7 @@ module Kitchen
       def call(state)
         create_sandbox
         sandbox_dirs = Dir.glob(File.join(sandbox_path, "*")) + \
-                         Dir.glob(File.join(sandbox_path, ".[a-zA-Z0-9]*"))
+          Dir.glob(File.join(sandbox_path, ".[a-zA-Z0-9]*"))
 
         instance.transport.connection(state) do |conn|
           conn.execute(install_command)

--- a/lib/kitchen/provisioner/base.rb
+++ b/lib/kitchen/provisioner/base.rb
@@ -60,7 +60,7 @@ module Kitchen
       def call(state)
         create_sandbox
         sandbox_dirs = Dir.glob(File.join(sandbox_path, "*")) + \
-                       Dir.glob(File.join(sandbox_path, ".[a-zA-Z0-9]*"))
+                         Dir.glob(File.join(sandbox_path, ".[a-zA-Z0-9]*"))
 
         instance.transport.connection(state) do |conn|
           conn.execute(install_command)

--- a/lib/kitchen/provisioner/base.rb
+++ b/lib/kitchen/provisioner/base.rb
@@ -59,7 +59,8 @@ module Kitchen
       # @raise [ActionFailed] if the action could not be completed
       def call(state)
         create_sandbox
-        sandbox_dirs = Dir.glob(File.join(sandbox_path, "*")) + Dir.glob(File.join(sandbox_path, ".[a-zA-Z0-9]*"))
+        sandbox_dirs = Dir.glob(File.join(sandbox_path, "*")) + \
+                       Dir.glob(File.join(sandbox_path, ".[a-zA-Z0-9]*"))
 
         instance.transport.connection(state) do |conn|
           conn.execute(install_command)


### PR DESCRIPTION
Currently, the upload from sandbox_dir doesn't include hidden files (.e.g [.filename])

This PR aims to include hidden files.