### PR TITLE
Config class should be initialized with env variables if they are set

### DIFF
--- a/lib/kitchen/config.rb
+++ b/lib/kitchen/config.rb
@@ -95,13 +95,16 @@ module Kitchen
     #   directories (default: `"#{kitchen_root}/test/integration"`)
     # @option options [Symbol] :log_level the log level verbosity that the
     #   loggers will use when outputing information (default: `:info`)
+
     def initialize(options = {})
-      @loader         = options.fetch(:loader) { Kitchen::Loader::YAML.new }
-      @kitchen_root   = options.fetch(:kitchen_root) { Dir.pwd }
-      @log_level      = options.fetch(:log_level) { Kitchen::DEFAULT_LOG_LEVEL }
-      @log_overwrite  = options.fetch(:log_overwrite) { Kitchen::DEFAULT_LOG_OVERWRITE }
-      @log_root       = options.fetch(:log_root) { default_log_root }
-      @test_base_path = options.fetch(:test_base_path) { default_test_base_path }
+      @loader            = options.fetch(:loader) { Kitchen::Loader::YAML.new }
+      @kitchen_root      = options.fetch(:kitchen_root) { Dir.pwd }
+      init_log_level     = Kitchen.env_log || Kitchen::DEFAULT_LOG_LEVEL
+      @log_level         = options.fetch(:log_level) { init_log_level }
+      init_log_overwrite = Kitchen.env_log_overwrite || Kitchen::DEFAULT_LOG_OVERWRITE
+      @log_overwrite     = options.fetch(:log_overwrite) { init_log_overwrite }
+      @log_root          = options.fetch(:log_root) { default_log_root }
+      @test_base_path    = options.fetch(:test_base_path) { default_test_base_path }
     end
 
     # @return [Collection<Instance>] all instances, resulting from all

--- a/lib/kitchen/rake_tasks.rb
+++ b/lib/kitchen/rake_tasks.rb
@@ -32,7 +32,6 @@ module Kitchen
     # @yield [self] gives itself to the block
     def initialize
       @config = Kitchen::Config.new
-      Kitchen.logger = Kitchen.default_file_logger(nil, false)
       yield self if block_given?
       define
     end


### PR DESCRIPTION
Preferring environment variable if set over the default values when an instance of config class is initialized.
Also removed a redundant line from rake_tasks. Config class creates a logger instance.
