### PR TITLE
option to remove chef repo from server after chef run

### DIFF
--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -76,6 +76,8 @@ module Kitchen
       end
       expand_path_for :encrypted_data_bag_secret_key_path
 
+      default_config :remove_chef_repo, false
+
       def install_command
         return unless config[:require_chef_omnibus]
 
@@ -387,6 +389,14 @@ module Kitchen
         File.open(File.join(fake_cb, "metadata.rb"), "wb") do |file|
           file.write(%{name "#{name}\n"})
         end
+      end
+
+      def remove_chef_repo
+        config[:remove_chef_repo]
+      end
+
+      def remove_repo
+        remove_chef_repo ? "; #{sudo('rm')} -rf /tmp/kitchen " : nil
       end
 
       def resolve_with_berkshelf

--- a/lib/kitchen/provisioner/chef_solo.rb
+++ b/lib/kitchen/provisioner/chef_solo.rb
@@ -40,7 +40,8 @@ module Kitchen
           "--config #{config[:root_path]}/solo.rb",
           "--json-attributes #{config[:root_path]}/dna.json",
           config[:log_file] ? "--logfile #{config[:log_file]}" : nil,
-          "--log_level #{config[:log_level]}"
+          "--log_level #{config[:log_level]}",
+          remove_repo
         ].join(" ")
       end
 

--- a/lib/kitchen/provisioner/chef_zero.rb
+++ b/lib/kitchen/provisioner/chef_zero.rb
@@ -67,7 +67,7 @@ module Kitchen
         if config[:json_attributes]
           args << "--json-attributes #{config[:root_path]}/dna.json"
         end
-
+        args << remove_repo
         if local_mode_supported?
           ["#{sudo('chef-client')} -z"].concat(args).join(" ")
         else

--- a/lib/kitchen/provisioner/puppet/librarian.rb
+++ b/lib/kitchen/provisioner/puppet/librarian.rb
@@ -1,0 +1,82 @@
+# -*- encoding: utf-8 -*-
+#
+# Author:: Fletcher Nichol (<fnichol@nichol.ca>) Neill Turner (<neillwturner@gmail.com>)
+#
+# Copyright (C) 2013, Fletcher Nichol, Neill Turner
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'kitchen/errors'
+require 'kitchen/logging'
+
+module Kitchen
+
+  module Provisioner
+
+    module Puppet
+
+      # Puppet module resolver that uses Librarian-Puppet and a Puppetfile to
+      # calculate # dependencies.
+      #
+       class Librarian
+
+        include Logging
+
+
+        def initialize(puppetfile, path, logger = Kitchen.logger)
+          @puppetfile   = puppetfile
+          @path       = path
+          @logger     = logger
+        end
+
+        def self.load!(logger = Kitchen.logger)
+          load_librarian!(logger)
+        end
+
+        def resolve
+          version = ::Librarian::Puppet::VERSION
+          info("Resolving module dependencies with Librarian-Puppet #{version}...")
+          debug("Using Puppetfile from #{puppetfile}")
+
+          env = ::Librarian::Puppet::Environment.new(
+            :project_path => File.dirname(puppetfile))
+          env.config_db.local["path"] = path
+          ::Librarian::Action::Resolve.new(env).run
+          ::Librarian::Action::Install.new(env).run
+        end
+
+        attr_reader :puppetfile, :path, :logger
+
+        def self.load_librarian!(logger)
+          first_load = require 'librarian/puppet/environment'
+          require 'librarian/action/resolve'
+          require 'librarian/action/install'
+
+          version = ::Librarian::Puppet::VERSION
+          if first_load
+            logger.debug("Librarian-Puppet #{version} library loaded")
+          else
+            logger.debug("Librarian-Puppet #{version} previously loaded")
+          end
+        rescue LoadError => e
+          logger.fatal("The `librarian-puppet' gem is missing and must be installed" +
+            " or cannot be properly activated. Run" +
+            " `gem install librarian-puppet` or add the following to your" +
+            " Gemfile if you are using Bundler: `gem 'librarian-puppet'`.")
+          raise UserError,
+            "Could not load or activate Librarian-Puppet (#{e.message})"
+        end
+      end
+    end
+  end
+end

--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 # See https://github.com/neillturner/kitchen-puppet/blob/master/provisioner_options.md
-# for documentation configuration parameters with puppet_apply provisioner.  
+# for documentation configuration parameters with puppet_apply provisioner.
 #
 
 require 'kitchen/provisioner/base'
@@ -42,7 +42,7 @@ module Kitchen
       default_config :puppet_yum_repo, "https://yum.puppetlabs.com/puppetlabs-release-el-6.noarch.rpm"
       default_config :chef_bootstrap_url, "https://www.getchef.com/chef/install.sh"
 
-      default_config :hiera_data_remote_path, '/var/lib/hiera' 
+      default_config :hiera_data_remote_path, '/var/lib/hiera'
       default_config :manifest, 'site.pp'
 
       default_config :manifests_path do |provisioner|
@@ -78,11 +78,11 @@ module Kitchen
             "-v #{config[:puppet_version]}"
           else
             ""
-          end             
-          <<-INSTALL            
+          end
+          <<-INSTALL
           if [ ! -d "#{config[:puppet_omnibus_remote_path]}" ]; then
             echo "-----> Installing Puppet Omnibus"
-            curl -o /tmp/puppet_install.sh #{config[:puppet_omnibus_url]} 
+            curl -o /tmp/puppet_install.sh #{config[:puppet_omnibus_url]}
             #{sudo('sh')} /tmp/puppet_install.sh #{version}
           fi
           #{install_busser}
@@ -102,10 +102,10 @@ module Kitchen
           INSTALL
                  when "redhat", "centos", "fedora"
                   info("Installing puppet on #{puppet_platform}")
-          <<-INSTALL            
+          <<-INSTALL
           if [ ! $(which puppet) ]; then
             #{sudo('rpm')} -ivh #{puppet_yum_repo}
-                    #{update_packages_redhat_cmd}           
+                    #{update_packages_redhat_cmd}
             #{sudo('yum')} -y install puppet#{puppet_redhat_version}
           fi
           #{install_busser}
@@ -114,23 +114,23 @@ module Kitchen
           info("Installing puppet, will try to determine platform os")
           <<-INSTALL
           if [ ! $(which puppet) ]; then
-            if [ -f /etc/centos-release ] || [ -f /etc/redhat-release ]; then   
+            if [ -f /etc/centos-release ] || [ -f /etc/redhat-release ]; then
                #{sudo('rpm')} -ivh #{puppet_yum_repo}
-               #{update_packages_redhat_cmd}           
+               #{update_packages_redhat_cmd}
                #{sudo('yum')} -y install puppet#{puppet_redhat_version}
             else
                #{sudo('wget')} #{puppet_apt_repo}
                #{sudo('dpkg')} -i #{puppet_apt_repo_file}
                #{update_packages_debian_cmd}
                #{sudo('apt-get')} -y install puppet#{puppet_debian_version}
-            fi                  
+            fi
           fi
           #{install_busser}
           INSTALL
-         end 
-        end  
+         end
+        end
       end
-          
+
       def install_busser
           <<-INSTALL
           # install chef omnibus so that busser works as this is needed to run tests :(
@@ -140,16 +140,17 @@ module Kitchen
           if [ ! -d "/opt/chef" ]
           then
             echo "-----> Installing Chef Omnibus to install busser to run tests"
-            curl -o /tmp/install.sh #{chef_url} 
+            curl -o /tmp/install.sh #{chef_url}
             #{sudo('sh')} /tmp/install.sh
           fi
           INSTALL
-          end     
+          end
 
         def init_command
           dirs = %w{modules manifests hiera hiera.yaml}.
             map { |dir| File.join(config[:root_path], dir) }.join(" ")
-          cmd = "#{sudo('rm')} -rf #{dirs} #{hiera_data_remote_path} /etc/hiera.yaml /etc/puppet/hiera.yaml; mkdir -p #{config[:root_path]}"
+          cmd = "#{sudo('rm')} -rf #{dirs} #{hiera_data_remote_path} /etc/hiera.yaml /etc/puppet/hiera.yaml;"
+          cmd = cmd+" mkdir -p #{config[:root_path]}"
           debug(cmd)
           cmd
         end
@@ -192,7 +193,7 @@ module Kitchen
               sudo('cp -r'), File.join(config[:root_path], 'hiera'), '/var/lib/'
             ].join(' ')
           end
-                  
+
           if hiera_data and hiera_data_remote_path != '/var/lib/hiera'
             commands << [
               sudo('mkdir -p'), hiera_data_remote_path
@@ -201,7 +202,7 @@ module Kitchen
               sudo('cp -r'), File.join(config[:root_path], 'hiera/*'), hiera_data_remote_path
             ].join(' ')
           end
-                  
+
           command = commands.join(' && ')
           debug(command)
           command
@@ -260,12 +261,12 @@ module Kitchen
 
         def hiera_data_remote_path
           config[:hiera_data_remote_path]
-        end             
-                
+        end
+
         def puppet_debian_version
           config[:puppet_version] ? "=#{config[:puppet_version]}" : nil
         end
-                  
+
         def puppet_redhat_version
           config[:puppet_version] ? "-#{config[:puppet_version]}" : nil
         end
@@ -281,15 +282,15 @@ module Kitchen
         def puppet_verbose_flag
           config[:puppet_verbose] ? '-v' : nil
         end
-                
+
         def puppet_platform
           config[:puppet_platform].to_s.downcase
-        end             
+        end
 
         def update_packages_debian_cmd
-          config[:update_package_repos] ? "#{sudo('apt-get')} update" : nil  
+          config[:update_package_repos] ? "#{sudo('apt-get')} update" : nil
         end
-                
+
         def update_packages_redhat_cmd
           config[:update_package_repos] ? "#{sudo('yum')} makecache" : nil
         end
@@ -313,11 +314,11 @@ module Kitchen
         def puppet_yum_repo
           config[:puppet_yum_repo]
         end
-                
+
         def chef_url
           config[:chef_bootstrap_url]
-        end     
-                
+        end
+
         def prepare_manifests
           info('Preparing manifests')
           debug("Using manifests from #{manifests}")

--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -1,0 +1,368 @@
+# -*- encoding: utf-8 -*-
+#
+# Author:: Chris Lundquist (<chris.lundquist@github.com>) Neill Turner (<neillwturner@gmail.com>)
+#
+# Copyright (C) 2013,2014 Chris Lundquist, Neill Turner
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#   
+# See https://github.com/neillturner/kitchen-puppet/blob/master/provisioner_options.md
+# for documentation configuration parameters with puppet_apply provisioner.  
+#
+
+require 'kitchen/provisioner/base'
+require 'kitchen/provisioner/puppet/librarian'
+
+module Kitchen
+
+  module Provisioner
+    #
+    # Puppet Apply provisioner.
+    #
+    class PuppetApply < Base
+      attr_accessor :tmp_dir
+
+      default_config :require_puppet_omnibus, false
+      # TODO use something like https://github.com/fnichol/omnibus-puppet
+      default_config :puppet_omnibus_url, nil
+	  default_config :puppet_omnibus_remote_path, '/opt/puppet'
+      default_config :puppet_version, nil
+	  default_config :require_puppet_repo, true
+      default_config :puppet_apt_repo, "http://apt.puppetlabs.com/puppetlabs-release-precise.deb"
+	  default_config :puppet_yum_repo, "https://yum.puppetlabs.com/puppetlabs-release-el-6.noarch.rpm"
+	  default_config :chef_bootstrap_url, "https://www.getchef.com/chef/install.sh"
+
+	  default_config :hiera_data_remote_path, '/var/lib/hiera' 
+      default_config :manifest, 'site.pp'
+
+      default_config :manifests_path do |provisioner|
+        provisioner.calculate_path('manifests') or
+          raise 'No manifests_path detected. Please specify one in .kitchen.yml'
+      end
+
+      default_config :modules_path do |provisioner|
+        provisioner.calculate_path('modules') or
+          raise 'No modules_path detected. Please specify one in .kitchen.yml'
+      end
+
+      default_config :hiera_data_path do |provisioner|
+        provisioner.calculate_path('hiera')
+      end
+
+      default_config :hiera_config_path do |provisioner|
+        provisioner.calculate_path('hiera.yaml', :file)
+      end
+
+      default_config :puppet_debug, false
+      default_config :puppet_verbose, false
+      default_config :puppet_noop, false
+	  default_config :puppet_platform, ''
+      default_config :update_package_repos, true
+	  default_config :custom_facts, {}
+
+      def install_command
+	    return unless config[:require_puppet_omnibus] or config[:require_puppet_repo]
+		if config[:require_puppet_omnibus]
+		  info("Installing puppet using puppet omnibus")
+          version = if !config[:puppet_version].nil?
+            "-v #{config[:puppet_version]}"
+          else
+            ""
+          end		  
+          <<-INSTALL		
+          if [ ! -d "#{config[:puppet_omnibus_remote_path]}" ]; then
+            echo "-----> Installing Puppet Omnibus"
+            curl -o /tmp/puppet_install.sh #{config[:puppet_omnibus_url]} 
+            #{sudo('sh')} /tmp/puppet_install.sh #{version}
+          fi
+		  #{install_busser}
+          INSTALL
+		else
+         case puppet_platform
+         when "debian", "ubuntu"
+		  info("Installing puppet on #{puppet_platform}")
+          <<-INSTALL
+          if [ ! $(which puppet) ]; then
+            #{sudo('wget')} #{puppet_apt_repo}
+            #{sudo('dpkg')} -i #{puppet_apt_repo_file}
+            #{update_packages_debian_cmd}
+            #{sudo('apt-get')} -y install puppet#{puppet_debian_version}
+          fi
+          #{install_busser}
+          INSTALL
+		 when "redhat", "centos", "fedora"
+		  info("Installing puppet on #{puppet_platform}")
+          <<-INSTALL		
+          if [ ! $(which puppet) ]; then
+            #{sudo('rpm')} -ivh #{puppet_yum_repo}
+ 		    #{update_packages_redhat_cmd}           
+            #{sudo('yum')} -y install puppet#{puppet_redhat_version}
+          fi
+          #{install_busser}
+          INSTALL
+         else
+		  info("Installing puppet, will try to determine platform os")
+          <<-INSTALL
+          if [ ! $(which puppet) ]; then
+		    if [ -f /etc/centos-release ] || [ -f /etc/redhat-release ]; then   
+               #{sudo('rpm')} -ivh #{puppet_yum_repo}
+ 		       #{update_packages_redhat_cmd}           
+               #{sudo('yum')} -y install puppet#{puppet_redhat_version}
+			else
+               #{sudo('wget')} #{puppet_apt_repo}
+               #{sudo('dpkg')} -i #{puppet_apt_repo_file}
+               #{update_packages_debian_cmd}
+               #{sudo('apt-get')} -y install puppet#{puppet_debian_version}
+            fi			
+          fi
+          #{install_busser}
+          INSTALL
+		 end 
+		end  
+      end
+	  
+	  def install_busser
+	      <<-INSTALL
+	      # install chef omnibus so that busser works as this is needed to run tests :(
+          # TODO: work out how to install enough ruby
+          # and set busser: { :ruby_bindir => '/usr/bin/ruby' } so that we dont need the
+          # whole chef client
+          if [ ! -d "/opt/chef" ]
+          then
+            echo "-----> Installing Chef Omnibus to install busser to run tests"
+            curl -o /tmp/install.sh #{chef_url} 
+            #{sudo('sh')} /tmp/install.sh
+          fi
+		  INSTALL
+	  end 	  
+
+        def init_command
+          dirs = %w{modules manifests hiera hiera.yaml}.
+            map { |dir| File.join(config[:root_path], dir) }.join(" ")
+          cmd = "#{sudo('rm')} -rf #{dirs} #{hiera_data_remote_path} /etc/hiera.yaml /etc/puppet/hiera.yaml; mkdir -p #{config[:root_path]}"
+          debug(cmd)
+          cmd
+        end
+
+        def create_sandbox
+          super
+          debug("Creating local sandbox in #{sandbox_path}")
+
+          yield if block_given?
+
+          prepare_modules
+          prepare_manifests
+          prepare_hiera_config
+          prepare_hiera_data
+          info('Finished Preparing files for transfer')
+
+        end
+
+        def cleanup_sandbox
+          return if sandbox_path.nil?
+          debug("Cleaning up local sandbox in #{sandbox_path}")
+          FileUtils.rmtree(sandbox_path)
+        end
+
+        def prepare_command
+          commands = []
+
+          if hiera_config
+            commands << [
+              sudo('cp'), File.join(config[:root_path],'hiera.yaml'), '/etc/',
+            ].join(' ')
+
+            commands << [
+              sudo('cp'), File.join(config[:root_path],'hiera.yaml'), '/etc/puppet/',
+            ].join(' ')
+          end
+
+          if hiera_data and hiera_data_remote_path == '/var/lib/hiera'
+            commands << [
+              sudo('cp -r'), File.join(config[:root_path], 'hiera'), '/var/lib/'
+            ].join(' ')
+          end
+		  
+          if hiera_data and hiera_data_remote_path != '/var/lib/hiera'
+            commands << [
+              sudo('mkdir -p'), hiera_data_remote_path
+            ].join(' ')
+			commands << [
+              sudo('cp -r'), File.join(config[:root_path], 'hiera/*'), hiera_data_remote_path
+            ].join(' ')
+          end
+		  
+          command = commands.join(' && ')
+          debug(command)
+          command
+        end
+
+        def run_command
+          [
+            custom_facts,
+            sudo('puppet'),
+            'apply',
+            File.join(config[:root_path], 'manifests', manifest),
+            "--modulepath=#{File.join(config[:root_path], 'modules')}",
+            "--manifestdir=#{File.join(config[:root_path], 'manifests')}",
+            puppet_noop_flag,
+            puppet_verbose_flag,
+            puppet_debug_flag,
+          ].join(" ")
+        end
+
+        protected
+
+        def load_needed_dependencies!
+          if File.exists?(puppetfile)
+            debug("Puppetfile found at #{puppetfile}, loading Librarian-Puppet")
+            Puppet::Librarian.load!(logger)
+          end
+        end
+
+        def tmpmodules_dir
+          File.join(sandbox_path, 'modules')
+        end
+
+        def puppetfile
+          File.join(config[:kitchen_root], 'Puppetfile')
+        end
+
+        def manifest
+          config[:manifest]
+        end
+
+        def manifests
+          config[:manifests_path]
+        end
+
+        def modules
+          config[:modules_path]
+        end
+
+        def hiera_config
+          config[:hiera_config_path]
+        end
+
+        def hiera_data
+          config[:hiera_data_path]
+        end
+
+        def hiera_data_remote_path
+          config[:hiera_data_remote_path]
+        end		
+		
+        def puppet_debian_version
+          config[:puppet_version] ? "=#{config[:puppet_version]}" : nil
+		end
+		  
+ 		def puppet_redhat_version
+          config[:puppet_version] ? "-#{config[:puppet_version]}" : nil
+        end
+
+        def puppet_noop_flag
+          config[:puppet_noop] ? '--noop' : nil
+        end
+
+        def puppet_debug_flag
+          config[:puppet_debug] ? '-d' : nil
+        end
+
+        def puppet_verbose_flag
+          config[:puppet_verbose] ? '-v' : nil
+        end
+		
+        def puppet_platform
+          config[:puppet_platform].to_s.downcase
+        end		
+
+        def update_packages_debian_cmd
+          config[:update_package_repos] ? "#{sudo('apt-get')} update" : nil  
+        end
+		
+		def update_packages_redhat_cmd
+          config[:update_package_repos] ? "#{sudo('yum')} makecache" : nil
+ 		end
+
+        def custom_facts
+          return nil if config[:custom_facts].none?
+          bash_vars = config[:custom_facts].map { |k,v| "FACTER_#{k}=#{v}" }.join(" ")
+          bash_vars = "export #{bash_vars};"
+          debug(bash_vars)
+          bash_vars
+        end
+
+        def puppet_apt_repo
+          config[:puppet_apt_repo]
+        end
+
+        def puppet_apt_repo_file
+          config[:puppet_apt_repo].split('/').last
+        end
+
+        def puppet_yum_repo
+          config[:puppet_yum_repo]
+        end
+		
+        def chef_url
+          config[:chef_bootstrap_url]
+        end	
+		
+        def prepare_manifests
+          info('Preparing manifests')
+          debug("Using manifests from #{manifests}")
+
+          tmp_manifests_dir = File.join(sandbox_path, 'manifests')
+          FileUtils.mkdir_p(tmp_manifests_dir)
+          FileUtils.cp_r(Dir.glob("#{manifests}/*"), tmp_manifests_dir)
+        end
+
+        def prepare_modules
+          info('Preparing modules')
+          if File.exists?(puppetfile)
+            resolve_with_librarian
+          end
+          debug("Using modules from #{modules}")
+
+          tmp_modules_dir = File.join(sandbox_path, 'modules')
+          FileUtils.mkdir_p(tmp_modules_dir)
+          FileUtils.cp_r(Dir.glob("#{modules}/*"), tmp_modules_dir)
+        end
+
+        def prepare_hiera_config
+          return unless hiera_config
+
+          info('Preparing hiera')
+          debug("Using hiera from #{hiera_config}")
+
+          FileUtils.cp_r(hiera_config, File.join(sandbox_path, 'hiera.yaml'))
+        end
+
+        def prepare_hiera_data
+          return unless hiera_data
+          info('Preparing hiera data')
+          debug("Using hiera data from #{hiera_data}")
+
+          tmp_hiera_dir = File.join(sandbox_path, 'hiera')
+          FileUtils.mkdir_p(tmp_hiera_dir)
+          FileUtils.cp_r(Dir.glob("#{hiera_data}/*"), tmp_hiera_dir)
+        end
+
+        def resolve_with_librarian
+          Kitchen.mutex.synchronize do
+            Puppet::Librarian.new(puppetfile, tmpmodules_dir, logger).resolve
+          end
+        end
+    end
+  end
+end

--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -15,7 +15,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#   
+#
 # See https://github.com/neillturner/kitchen-puppet/blob/master/provisioner_options.md
 # for documentation configuration parameters with puppet_apply provisioner.  
 #
@@ -35,14 +35,14 @@ module Kitchen
       default_config :require_puppet_omnibus, false
       # TODO use something like https://github.com/fnichol/omnibus-puppet
       default_config :puppet_omnibus_url, nil
-	  default_config :puppet_omnibus_remote_path, '/opt/puppet'
+      default_config :puppet_omnibus_remote_path, '/opt/puppet'
       default_config :puppet_version, nil
-	  default_config :require_puppet_repo, true
+      default_config :require_puppet_repo, true
       default_config :puppet_apt_repo, "http://apt.puppetlabs.com/puppetlabs-release-precise.deb"
-	  default_config :puppet_yum_repo, "https://yum.puppetlabs.com/puppetlabs-release-el-6.noarch.rpm"
-	  default_config :chef_bootstrap_url, "https://www.getchef.com/chef/install.sh"
+      default_config :puppet_yum_repo, "https://yum.puppetlabs.com/puppetlabs-release-el-6.noarch.rpm"
+      default_config :chef_bootstrap_url, "https://www.getchef.com/chef/install.sh"
 
-	  default_config :hiera_data_remote_path, '/var/lib/hiera' 
+      default_config :hiera_data_remote_path, '/var/lib/hiera' 
       default_config :manifest, 'site.pp'
 
       default_config :manifests_path do |provisioner|
@@ -66,31 +66,31 @@ module Kitchen
       default_config :puppet_debug, false
       default_config :puppet_verbose, false
       default_config :puppet_noop, false
-	  default_config :puppet_platform, ''
+      default_config :puppet_platform, ''
       default_config :update_package_repos, true
-	  default_config :custom_facts, {}
+      default_config :custom_facts, {}
 
       def install_command
-	    return unless config[:require_puppet_omnibus] or config[:require_puppet_repo]
-		if config[:require_puppet_omnibus]
-		  info("Installing puppet using puppet omnibus")
+        return unless config[:require_puppet_omnibus] or config[:require_puppet_repo]
+        if config[:require_puppet_omnibus]
+          info("Installing puppet using puppet omnibus")
           version = if !config[:puppet_version].nil?
             "-v #{config[:puppet_version]}"
           else
             ""
-          end		  
-          <<-INSTALL		
+          end             
+          <<-INSTALL            
           if [ ! -d "#{config[:puppet_omnibus_remote_path]}" ]; then
             echo "-----> Installing Puppet Omnibus"
             curl -o /tmp/puppet_install.sh #{config[:puppet_omnibus_url]} 
             #{sudo('sh')} /tmp/puppet_install.sh #{version}
           fi
-		  #{install_busser}
+          #{install_busser}
           INSTALL
-		else
-         case puppet_platform
-         when "debian", "ubuntu"
-		  info("Installing puppet on #{puppet_platform}")
+        else
+          case puppet_platform
+          when "debian", "ubuntu"
+          info("Installing puppet on #{puppet_platform}")
           <<-INSTALL
           if [ ! $(which puppet) ]; then
             #{sudo('wget')} #{puppet_apt_repo}
@@ -100,40 +100,40 @@ module Kitchen
           fi
           #{install_busser}
           INSTALL
-		 when "redhat", "centos", "fedora"
-		  info("Installing puppet on #{puppet_platform}")
-          <<-INSTALL		
+                 when "redhat", "centos", "fedora"
+                  info("Installing puppet on #{puppet_platform}")
+          <<-INSTALL            
           if [ ! $(which puppet) ]; then
             #{sudo('rpm')} -ivh #{puppet_yum_repo}
- 		    #{update_packages_redhat_cmd}           
+                    #{update_packages_redhat_cmd}           
             #{sudo('yum')} -y install puppet#{puppet_redhat_version}
           fi
           #{install_busser}
           INSTALL
          else
-		  info("Installing puppet, will try to determine platform os")
+          info("Installing puppet, will try to determine platform os")
           <<-INSTALL
           if [ ! $(which puppet) ]; then
-		    if [ -f /etc/centos-release ] || [ -f /etc/redhat-release ]; then   
+            if [ -f /etc/centos-release ] || [ -f /etc/redhat-release ]; then   
                #{sudo('rpm')} -ivh #{puppet_yum_repo}
- 		       #{update_packages_redhat_cmd}           
+               #{update_packages_redhat_cmd}           
                #{sudo('yum')} -y install puppet#{puppet_redhat_version}
-			else
+            else
                #{sudo('wget')} #{puppet_apt_repo}
                #{sudo('dpkg')} -i #{puppet_apt_repo_file}
                #{update_packages_debian_cmd}
                #{sudo('apt-get')} -y install puppet#{puppet_debian_version}
-            fi			
+            fi                  
           fi
           #{install_busser}
           INSTALL
-		 end 
-		end  
+         end 
+        end  
       end
-	  
-	  def install_busser
-	      <<-INSTALL
-	      # install chef omnibus so that busser works as this is needed to run tests :(
+          
+      def install_busser
+          <<-INSTALL
+          # install chef omnibus so that busser works as this is needed to run tests :(
           # TODO: work out how to install enough ruby
           # and set busser: { :ruby_bindir => '/usr/bin/ruby' } so that we dont need the
           # whole chef client
@@ -143,8 +143,8 @@ module Kitchen
             curl -o /tmp/install.sh #{chef_url} 
             #{sudo('sh')} /tmp/install.sh
           fi
-		  INSTALL
-	  end 	  
+          INSTALL
+          end     
 
         def init_command
           dirs = %w{modules manifests hiera hiera.yaml}.
@@ -192,16 +192,16 @@ module Kitchen
               sudo('cp -r'), File.join(config[:root_path], 'hiera'), '/var/lib/'
             ].join(' ')
           end
-		  
+                  
           if hiera_data and hiera_data_remote_path != '/var/lib/hiera'
             commands << [
               sudo('mkdir -p'), hiera_data_remote_path
             ].join(' ')
-			commands << [
+                        commands << [
               sudo('cp -r'), File.join(config[:root_path], 'hiera/*'), hiera_data_remote_path
             ].join(' ')
           end
-		  
+                  
           command = commands.join(' && ')
           debug(command)
           command
@@ -260,13 +260,13 @@ module Kitchen
 
         def hiera_data_remote_path
           config[:hiera_data_remote_path]
-        end		
-		
+        end             
+                
         def puppet_debian_version
           config[:puppet_version] ? "=#{config[:puppet_version]}" : nil
-		end
-		  
- 		def puppet_redhat_version
+        end
+                  
+        def puppet_redhat_version
           config[:puppet_version] ? "-#{config[:puppet_version]}" : nil
         end
 
@@ -281,18 +281,18 @@ module Kitchen
         def puppet_verbose_flag
           config[:puppet_verbose] ? '-v' : nil
         end
-		
+                
         def puppet_platform
           config[:puppet_platform].to_s.downcase
-        end		
+        end             
 
         def update_packages_debian_cmd
           config[:update_package_repos] ? "#{sudo('apt-get')} update" : nil  
         end
-		
-		def update_packages_redhat_cmd
+                
+        def update_packages_redhat_cmd
           config[:update_package_repos] ? "#{sudo('yum')} makecache" : nil
- 		end
+        end
 
         def custom_facts
           return nil if config[:custom_facts].none?
@@ -313,11 +313,11 @@ module Kitchen
         def puppet_yum_repo
           config[:puppet_yum_repo]
         end
-		
+                
         def chef_url
           config[:chef_bootstrap_url]
-        end	
-		
+        end     
+                
         def prepare_manifests
           info('Preparing manifests')
           debug("Using manifests from #{manifests}")


### PR DESCRIPTION
It useful to delete the chef repo and the all the /tmp/kitchen files after a chef run so the server is clean and can be use for other purposes after the chef run. This way the server will not contain the chef repo and maybe configuration info on the server which you might want to keep secret. 