### PR TITLE
Add ssh_tgz transport mechanism that compresses files (with tar-gzip)

### DIFF
--- a/lib/kitchen/tgz.rb
+++ b/lib/kitchen/tgz.rb
@@ -1,0 +1,176 @@
+# -*- encoding: utf-8 -*-
+#
+# Author:: Peter Smith (<peter@petersmith.net>)
+#
+# Copyright (C) 2015, Peter Smith
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "tempfile"
+require "zlib"
+require "rubygems/package"
+
+module Kitchen
+  #
+  # Error thrown if the Tgz has an invalid format.
+  #
+  class GzipFormatError < StandardError; end
+
+  #
+  # Represents a Tar-Gzip file, allowing multiple files to be combined
+  # into a single file. This is useful for transmitting a large number
+  # of files across high-latency networks.
+  #
+  class Tgz
+    #
+    # @return [String] the file system path of the generated tar-gzip file.
+    #
+    attr_reader :path
+
+    #
+    # Create a new Tgz object, in preparation for adding files to the
+    # tar-gzip archive.
+    #
+    # @param tgz_file_name [String, nil] The output file name, in
+    #   tar-gzipped format. If not specified, a temporary file name will be generated.
+    #
+    def initialize(tgz_file_name = nil)
+      if tgz_file_name
+        # user-provided output file name
+        @tgz_file = File.open(tgz_file_name, "wb+")
+        @path = tgz_file_name
+      else
+        # auto-generated output file name
+        @tgz_file = Tempfile.new("tgz")
+        @tgz_file.binmode
+        @path = @tgz_file.path
+      end
+
+      #
+      # Intermediate file for writing the 'tar' content (which will then be
+      # gzipped into the output 'tgz' file)
+      #
+      @tar_file = Tempfile.new("tar")
+      @tar_file.binmode
+      @tar_writer = Gem::Package::TarWriter.new(@tar_file)
+    end
+
+    #
+    # Add a set of files or directories into the Tgz archive. Directories will
+    # be traversed, with all files and subdirectories being added (symlinks are ignored).
+    #
+    # For example:
+    #
+    #     tgz.add_files('/home/me/my_dir', ['fileA', 'dirA/fileB'])
+    #
+    # @param dir [String] the directory containing the files/sub-dirs to archive.
+    # @param files [Array<String>] the files/sub-directories to be added, specified
+    #   relative to the containing directory (dir).
+    #
+    def add_files(dir, files)
+      files.each do |file_name|
+        full_path = "#{dir}/#{file_name}"
+        next if File.symlink?(full_path)
+        if File.directory?(full_path)
+          add_directory_to_tar(dir, file_name, full_path)
+        else
+          add_file_to_tar(full_path, file_name)
+        end
+      end
+    end
+
+    #
+    # Close the Tgz object, generating the tgz file (from the tar file), and ensuring
+    # that it's flushed to disk.
+    #
+    def close
+      # ensure tar_writer flushes everything to our temporary 'tar' file.
+      @tar_writer.close
+
+      # proceed to convert the 'tar' file into a 'tgz' file.
+      @tar_file.rewind
+      create_tgz_file(@tar_file, @tgz_file)
+      @tar_file.close
+    end
+
+    #
+    # Class-methods
+    #
+    class << self
+      #
+      # Return the original size of the uncompressed file.
+      #
+      # @param file_name [String] name of the compressed file, in .tgz format.
+      # @return [Integer] the original (uncompressed) file's size
+      # @raise [GzipFormatError] if the file is not a valid Gzip file.
+      #
+      def original_size(file_name)
+        File.open(file_name, "r") do |file|
+          # the first three bytes of a gzip file must be 0x1f, 0x8b, 0x08
+          fail unless (file.readbyte == 0x1f) && (file.readbyte == 0x8b) &&
+              (file.readbyte == 0x08)
+          return original_file_length_field(file)
+        end
+      rescue
+        raise GzipFormatError, "Gzip file could not be opened, or has invalid format: #{file_name}"
+      end
+
+      private
+
+      #
+      # Gzip files have their original/uncompressed length in the last 4 bytes
+      # (little endian format)
+      #
+      def original_file_length_field(file)
+        file.seek(-4, IO::SEEK_END)
+        (file.readbyte) | (file.readbyte << 8) | (file.readbyte << 16) | (file.readbyte << 24)
+      end
+    end
+
+    private
+
+    #
+    # Recursively traverse/add a sub-directory to the tar-gzip file.
+    #
+    def add_directory_to_tar(dir, file_name, full_path)
+      entries = Dir.entries(full_path)
+      entries.delete(".")
+      entries.delete("..")
+      add_files(dir, entries.map { |entry| "#{file_name}/#{entry}" })
+    end
+
+    #
+    # Add a single file to the tar-gzip file.
+    #
+    def add_file_to_tar(full_path, file_name)
+      stat = File.stat(full_path)
+      @tar_writer.add_file(file_name, stat.mode) do |file|
+        File.open(full_path, "rb") do |input|
+          while (buff = input.read(4096))
+            file.write(buff)
+          end
+        end
+      end
+    end
+
+    #
+    # The temporary tar file has been fully populated, so run the compress operation
+    # to generate the final tar-gzip file.
+    #
+    def create_tgz_file(source_file, dest_file)
+      Zlib::GzipWriter.wrap(dest_file) do |gzip_writer|
+        FileUtils.copy_stream(source_file, gzip_writer)
+      end
+    end
+  end
+end

--- a/lib/kitchen/transport/ssh_tgz.rb
+++ b/lib/kitchen/transport/ssh_tgz.rb
@@ -1,0 +1,139 @@
+# -*- encoding: utf-8 -*-
+#
+# Author:: Peter Smith (<peter@petersmith.net>)
+#
+# Copyright (C) 2015, Peter Smith.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "kitchen"
+require "kitchen/tgz"
+require "kitchen/transport/ssh"
+
+require "net/ssh"
+require "net/scp"
+require "pathname"
+
+module Kitchen
+  module Transport
+    #
+    # A Transport which uses the SSH protocol to execute commands and transfer files.
+    # In addition, files are tar-gzipped to improve performance over high-latency
+    # network links.
+    #
+    # Most of this class reuses functionality from the base Ssh class.
+    #
+    # @author Peter Smith <peter@petersmith.net>
+    #
+    class SshTgz < Kitchen::Transport::Ssh
+
+      #
+      # Manage a connection for the SshTgz transport mechanism. This is essentially
+      # the same as for the Ssh::Connection class, except we compress before
+      # uploading.
+      #
+      class Connection < Kitchen::Transport::Ssh::Connection
+
+        # (see Ssh::Connection#upload)
+        def upload(locals, remote)
+          # attempt tar-gzip upload, to improve performance.
+          return if Array(locals).empty? || upload_via_tgz(Array(locals), remote)
+
+          # if tgz upload fails (e.g. not supported on target platform), fall back to
+          # file-by-file upload.
+          logger.warn("Tgz upload failed. Resorting to file-by-file upload.")
+          super
+        end
+
+        private
+
+        #
+        # Upload a set of files onto the remote machine. Rather than uploading
+        # file by file, we first package all files into a tar-gzip file (.tgz)
+        # and send a single file. This avoids the slow file-copy time we'd
+        # otherwise see over a high-latency network.
+        #
+        # @param locals [Array<String>] array of path names for each of the files to
+        #   be included.
+        # @param remote [String] directory on the remote host into which the files will
+        #   be uploaded.
+        # @return [true, false] true on success, else false.
+        #
+        def upload_via_tgz(locals, remote)
+          # tar-gzip all the input files into a single .tgz file.
+          tgz = create_tgz_file(locals)
+
+          # upload the tar-gzip file to the remote server.
+          session.scp.upload!(tgz.path, "#{remote}/kitchen.tgz", {}) do |_ch, name, sent, total|
+            logger.debug("Uploaded #{name} (#{total} bytes)") if sent == total
+          end
+
+          # extract the tar-gzip file, on the remote, into individual files.
+          untar_file_on_remote(remote)
+          File.unlink(tgz.path)
+
+          # indicate success - the files extracted correctly and won't need to be
+          # uploaded individually.
+          true
+        rescue => e
+          # on any failure, return false to indicate that upload via tgz failed and we
+          # should default to copying individual files.
+          logger.debug(".tgz upload failed. Reason: #{e}")
+          false
+        end
+
+        #
+        # Create a single tar-gzipped file, containing all of the individual files.
+        #
+        # @param locals [Array<String>] array of path names for each of the files to
+        #   be included.
+        # @return [Kitchen::Tgz] the Tgz object, representing the tar-gzip file we created.
+        #
+        def create_tgz_file(locals)
+          tgz = Kitchen::Tgz.new
+          locals.each do |local|
+            pathname = Pathname.new(local)
+            tgz.add_files(pathname.dirname.to_s, [pathname.basename.to_s])
+          end
+          tgz.close
+          tgz
+        end
+
+        #
+        # Untar the tgz file on the remote.
+        #
+        # @param remote [String] file system directory on remote host into which
+        #   the tar-gzip file was uploaded uploaded.
+        # @raise [Kitchen::SSHFailed] if the untar fails for some reason.
+        #
+        def untar_file_on_remote(remote)
+          cmd = "tar -C #{remote} -xmzf #{remote}/kitchen.tgz"
+          session.exec!(cmd) do |_ch, stream, data|
+            raise SSHFailed, "Unable to untar files on remote: #{data}" if stream == :stderr
+          end
+        end
+      end
+
+      # (see Ssh#create_new_connection)
+      def create_new_connection(options, &block)
+        if @connection
+          logger.debug("[SSH] shutting previous connection #{@connection}")
+          @connection.close
+        end
+
+        @connection_options = options
+        @connection = Kitchen::Transport::SshTgz::Connection.new(options, &block)
+      end
+    end
+  end
+end

--- a/spec/kitchen/tgz_spec.rb
+++ b/spec/kitchen/tgz_spec.rb
@@ -1,0 +1,157 @@
+# -*- encoding: utf-8 -*-
+#
+# Author:: Peter Smith (<peter@petersmith.net>)
+#
+# Copyright (C) 2015, Peter Smith
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative "../spec_helper"
+
+require "tempfile"
+require "fileutils"
+require "kitchen/tgz"
+
+describe Kitchen::Tgz do
+  #
+  # Create a temporary file, of a specified length. The content of the file
+  # will be an increasing sequence of byte values. This ensure that files
+  # will always be created in the exactly the same way in each test run, and
+  # we"ll therefore create predictable Tgz files.
+  #
+  def create_file(path, size)
+    dir_name = File.dirname(path)
+    FileUtils.mkdir_p(dir_name)
+    File.open(path, "wb") do |file|
+      (0...size).each do |i|
+        file.print((i % 256).chr)
+      end
+    end
+  end
+
+  #
+  # Create a temporary directory, populated with files. This directory will
+  # be tar-gzipped in our test cases.
+  #
+  def create_temp_files(files_hash)
+    dir = Dir.mktmpdir("test")
+    files_hash.each_pair { |name, size| create_file("#{dir}/#{name}", size) }
+    dir
+  end
+
+  #
+  # Remove the temporary directory created by
+  #
+  def remove_temp_files(directory)
+    FileUtils.rm_r(directory)
+  end
+
+  #
+  # Test cases
+  #
+  it "can be created with a user-specified output file name" do
+    # create a temporary file, to use as the output file we'll provide to TGZ
+    user_chosen_output_file = Tempfile.new("test")
+    user_chosen_output_file_name = user_chosen_output_file.path
+
+    # create a new Tgz object, with our user-specified output file name.
+    test_tgz = Kitchen::Tgz.new(user_chosen_output_file_name)
+
+    # validate that Tgz is using the correct output path.
+    @tgz_output_path = test_tgz.path
+    test_tgz.path.must_equal user_chosen_output_file_name
+
+    # write the output to disk (with no members in the tgz file)
+    test_tgz.close
+    File.exist?(test_tgz.path).must_equal true
+    user_chosen_output_file.close
+  end
+
+  it "can be created with an auto-generated output file name" do
+    # create a new Tgz object, with an auto-generated output file name.
+    test_tgz = Kitchen::Tgz.new
+    @tgz_output_path = test_tgz.path
+
+    # write the output to disk (with no members in the tgz file)
+    test_tgz.close
+    File.exist?(test_tgz.path).must_equal true
+  end
+
+  it "rejects output file names that are not writable" do
+    proc do
+      Kitchen::Tgz.new("/invalid/missing/path")
+    end.must_raise Errno::ENOENT
+  end
+
+  it "allows files to be archived within a single directory" do
+    test_tgz = Kitchen::Tgz.new
+    @tgz_output_path = test_tgz.path
+
+    # create a number of test files (of varying lengths) into a temporary
+    # directory, add them to the archive, then flush the file to disk.
+    @temp_directory = create_temp_files(
+      "file_A" => 100,
+      "file_B" => 200,
+      "file_C" => 300
+    )
+    test_tgz.add_files(@temp_directory, %w[file_A file_B file_C])
+    test_tgz.close
+
+    Kitchen::Tgz.original_size(@tgz_output_path).must_equal 4096
+  end
+
+  it "allows files to be archived in a directory hierarchy" do
+    test_tgz = Kitchen::Tgz.new
+    @tgz_output_path = test_tgz.path
+
+    # create test files within subdirectories
+    @temp_directory = create_temp_files(
+      "dirA/dirB/file_A" => 1000,
+      "dirA/dirB/file_B" => 2000,
+      "dirA/file_C" => 3000
+    )
+    test_tgz.add_files(@temp_directory, ["dirA"])
+    test_tgz.close
+
+    Kitchen::Tgz.original_size(@tgz_output_path).must_equal 8704
+  end
+
+  it "allows large files to added" do
+    test_tgz = Kitchen::Tgz.new
+    @tgz_output_path = test_tgz.path
+
+    @temp_directory = create_temp_files(
+      "dirA/dirB/file_A" => 1_000_000
+    )
+    test_tgz.add_files(@temp_directory, ["dirA"])
+    test_tgz.close
+
+    Kitchen::Tgz.original_size(@tgz_output_path).must_equal 1001984
+  end
+
+  it "reject member file names that do not exist" do
+    test_tgz = Kitchen::Tgz.new
+    @tgz_output_path = test_tgz.path
+    proc do
+      test_tgz.add_files("/", ["non-existed-file"])
+    end.must_raise Errno::ENOENT
+    test_tgz.close
+  end
+
+  # clean up
+  after(:each) do
+    File.unlink(@tgz_output_path) if @tgz_output_path &&
+        File.exist?(@tgz_output_path)
+    remove_temp_files(@temp_directory) if @temp_directory
+  end
+end

--- a/spec/kitchen/transport/ssh_tgz_spec.rb
+++ b/spec/kitchen/transport/ssh_tgz_spec.rb
@@ -1,0 +1,88 @@
+# -*- encoding: utf-8 -*-
+#
+# Author:: Peter Smith (<peter@petersmith.net>)
+#
+# Copyright (C) 2015, Peter Smith
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative "../../spec_helper"
+
+require "kitchen/transport/ssh_tgz"
+
+describe Kitchen::Transport::SshTgz do
+
+  #
+  # Create temporary files, of a given size/content. Used as test
+  # files for tar-gzipping.
+  #
+  def make_temp_file(content, size)
+    file = Tempfile.new("file")
+    file.write(content * size)
+    file.close
+    file.path
+  end
+
+  let(:file_A)          { make_temp_file("A", 100) }
+  let(:file_B)          { make_temp_file("B", 200) }
+  let(:file_C)          { make_temp_file("C", 300) }
+
+  #
+  # Create a mock SCP session, so we capture the arguments and return values that would be passed to
+  # the upload! method.
+  #
+  let(:mock_session)    { mock("session") }
+  let(:mock_scp)        { mock("scp") }
+
+  before do
+    Kitchen::Transport::SshTgz::Connection.any_instance.stubs(:session).returns(mock_session)
+    mock_session.stubs(:scp).returns(mock_scp)
+  end
+
+  it "does not upload anything, if no files are provided" do
+    #
+    # No uploading or exec'ing should take place.
+    #
+    mock_scp.expects(:upload!).never
+    mock_session.expects(:exec!).never
+
+    #
+    # Run the test...
+    #
+    connection = Kitchen::Transport::SshTgz::Connection.new
+    connection.upload([], "/tmp/remote")
+  end
+
+  it "compresses multiple files into a single upload" do
+    #
+    # the tgz file must first be uploaded. Exactly one upload will occur.
+    #
+    mock_scp.expects(:upload!).once.with do |source_file, dest_file, _|
+      # compressed file sizes can vary slightly, since tar files contain date stamps,
+      # which compress unpredictably.
+      size = Kitchen::Tgz.original_size(source_file)
+      dest_file == "/tmp/remote/kitchen.tgz" && size == 4096
+    end
+
+    #
+    # then, the tgz file must be extracted on the remote host.
+    #
+    mock_session.expects(:exec!).once.with("tar -C /tmp/remote -xmzf /tmp/remote/kitchen.tgz")
+
+    #
+    # Run the test...
+    #
+    connection = Kitchen::Transport::SshTgz::Connection.new
+    connection.upload([file_A, file_B, file_C], "/tmp/remote")
+  end
+end


### PR DESCRIPTION
This drastically improves performance of uploading cookbooks, when working over high-latency network links. This fixes Issue #657. I understand that there's another PR open for this same problem, but it seems to have stalled.

To make my solution work, you need to add:

```
transport:
  name: ssh_tgz
```

I added the tar-gzip feature to a separate transport, so that it's optional, rather than being integrated into the `ssh` transport. It also falls-back to using regular ssh (file-by-file upload) if anything goes wrong.
