### PR TITLE
Pin mixlib-install more strictly

### DIFF
--- a/test-kitchen.gemspec
+++ b/test-kitchen.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "net-ssh",         "~> 2.7", "< 2.10"
   gem.add_dependency "safe_yaml",       "~> 1.0"
   gem.add_dependency "thor",            "~> 0.18"
-  gem.add_dependency "mixlib-install",  "~> 0.7"
+  gem.add_dependency "mixlib-install",  "~> 0.7.0"
 
   gem.add_development_dependency "pry"
   gem.add_development_dependency "winrm-transport", "~> 1.0"


### PR DESCRIPTION
We are doing some work on mixlib-install to extend its functionality and we will be making some compat breaking changes. E.g. https://github.com/chef/mixlib-install/pull/11

We would like to pin it more strictly here until we get the mixlib-install to 1.0.0 stage.