### PR TITLE
add support for ETIMEDOUT to winrm transport

### DIFF
--- a/lib/kitchen/transport/winrm.rb
+++ b/lib/kitchen/transport/winrm.rb
@@ -136,7 +136,7 @@ module Kitchen
 
         RESCUE_EXCEPTIONS_ON_ESTABLISH = lambda do
           [
-            Errno::EACCES, Errno::EADDRINUSE, Errno::ECONNREFUSED,
+            Errno::EACCES, Errno::EADDRINUSE, Errno::ECONNREFUSED, Errno::ETIMEDOUT,
             Errno::ECONNRESET, Errno::ENETUNREACH, Errno::EHOSTUNREACH,
             ::WinRM::WinRMHTTPTransportError, ::WinRM::WinRMAuthorizationError,
             HTTPClient::KeepAliveDisconnected,

--- a/spec/kitchen/transport/winrm_spec.rb
+++ b/spec/kitchen/transport/winrm_spec.rb
@@ -700,7 +700,7 @@ MSG
     end
 
     [
-      Errno::EACCES, Errno::EADDRINUSE, Errno::ECONNREFUSED,
+      Errno::EACCES, Errno::EADDRINUSE, Errno::ECONNREFUSED, Errno::ETIMEDOUT,
       Errno::ECONNRESET, Errno::ENETUNREACH, Errno::EHOSTUNREACH,
       ::WinRM::WinRMHTTPTransportError, ::WinRM::WinRMAuthorizationError,
       HTTPClient::KeepAliveDisconnected, HTTPClient::ConnectTimeoutError


### PR DESCRIPTION
This PR addresses https://github.com/test-kitchen/test-kitchen/issues/855 by adding ETIMEDOUT to RESCUE_EXCEPTIONS_ON_ESTABLISH.

@smurawski 