### PR TITLE
add cli option to set the test path

### DIFF
--- a/lib/kitchen/cli.rb
+++ b/lib/kitchen/cli.rb
@@ -166,6 +166,9 @@ module Kitchen
           Run a #{action} against all matching instances concurrently.
         DESC
       log_options
+      method_option :test_base_path,
+        :aliases => "-t",
+        :desc => "Set the base path of the tests"
       define_method(action) do |*args|
         update_config!
         perform(action, "action", args)
@@ -337,6 +340,10 @@ module Kitchen
       end
       unless options[:log_overwrite].nil?
         @config.log_overwrite = options[:log_overwrite]
+      end
+
+      if options[:test_base_path]
+        @config.test_base_path = options[:test_base_path]
       end
 
       # Now that we have required configs, lets create our file logger

--- a/lib/kitchen/cli.rb
+++ b/lib/kitchen/cli.rb
@@ -93,6 +93,14 @@ module Kitchen
         :type => :boolean
     end
 
+    # Sets the test_base_path method_options
+    # @api private
+    def self.test_base_path
+      method_option :test_base_path,
+        :aliases => "-t",
+        :desc => "Set the base path of the tests"
+    end
+
     desc "list [INSTANCE|REGEXP|all]", "Lists one or more instances"
     method_option :bare,
       :aliases => "-b",
@@ -165,10 +173,8 @@ module Kitchen
           [Future DEPRECATION, use --concurrency]
           Run a #{action} against all matching instances concurrently.
         DESC
+      test_base_path
       log_options
-      method_option :test_base_path,
-        :aliases => "-t",
-        :desc => "Set the base path of the tests"
       define_method(action) do |*args|
         update_config!
         perform(action, "action", args)
@@ -213,6 +219,7 @@ module Kitchen
       :type => :boolean,
       :default => false,
       :desc => "Invoke init command if .kitchen.yml is missing"
+    test_base_path
     log_options
     def test(*args)
       update_config!

--- a/lib/kitchen/cli.rb
+++ b/lib/kitchen/cli.rb
@@ -350,7 +350,8 @@ module Kitchen
       end
 
       if options[:test_base_path]
-        @config.test_base_path = options[:test_base_path]
+        # ensure we have an absolute path
+        @config.test_base_path = File.absolute_path(options[:test_base_path])
       end
 
       # Now that we have required configs, lets create our file logger

--- a/lib/kitchen/config.rb
+++ b/lib/kitchen/config.rb
@@ -77,6 +77,10 @@ module Kitchen
     # @api private
     attr_accessor :log_overwrite
 
+    # @return [String] an absolute path to the directory containing test suites
+    # @api private
+    attr_accessor :test_base_path
+
     # Creates a new configuration, representing a particular testing
     # configuration for a project.
     #


### PR DESCRIPTION
allows you to run tests from a different directory via `kitchen verify -t /path/to default-centos-7`

Related issues:
* #377
* #814