### PR TITLE
Rsync transport for rsync+ssh file transfers

### DIFF
--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -42,6 +42,7 @@ module Kitchen
       default_config :run_list, []
       default_config :attributes, {}
       default_config :log_file, nil
+      default_config :clean_files_first, true
       default_config :cookbook_files_glob, %w[
         README.* metadata.{json,rb}
         attributes/**/* definitions/**/* files/**/* libraries/**/*
@@ -102,7 +103,10 @@ module Kitchen
           init_command_vars_for_bourne(dirs)
         end
 
-        shell_code_from_file(vars, "chef_base_init_command")
+        shell_code = []
+        shell_code << shell_code_from_file(vars, "chef_base_clean_command") if config[:clean_files_first]
+        shell_code << shell_code_from_file(vars, "chef_base_init_command")
+        shell_code.join("\n")
       end
 
       # (see Base#install_command)

--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -104,7 +104,9 @@ module Kitchen
         end
 
         shell_code = []
-        shell_code << shell_code_from_file(vars, "chef_base_clean_command") if config[:clean_files_first]
+        if config[:clean_files_first]
+          shell_code << shell_code_from_file(vars, "chef_base_clean_command")
+        end
         shell_code << shell_code_from_file(vars, "chef_base_init_command")
         prefix_command(shell_code.join("\n"))
       end

--- a/lib/kitchen/transport/rsync.rb
+++ b/lib/kitchen/transport/rsync.rb
@@ -1,0 +1,48 @@
+# -*- encoding: utf-8 -*-
+#
+# Author:: Matt Kulka (<mkulka@local-motors.com>)
+#
+# Copyright (C) 2015, Matt Kulka
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "kitchen"
+require "kitchen/transport/ssh"
+
+require "open3"
+
+module Kitchen
+  module Transport
+    class Rsync < Kitchen::Transport::Ssh
+
+      class Connection < Kitchen::Transport::Ssh::Connection
+        def upload(locals, remote)
+          key_args = []
+          Array(options[:keys]).each { |ssh_key| key_args << "-i #{ssh_key}" }
+          cmd = "rsync -rav --delete --exclude=cache -e 'ssh -l #{username} -p #{port} -o StrictHostKeyChecking=no #{key_args.join(' ')}' #{locals.join(' ')} #{hostname}:#{remote}"
+
+          logger.debug("Rsync via command '#{cmd}'")
+          Open3.popen2e(cmd) {|stdin, stdout_stderr, wait_thr|
+            Thread.new do
+              stdout_stderr.each {|l| logger.debug(l.chomp) }
+            end
+
+            stdin.puts("#{options[:password]}\n") if Array(options[:keys]).empty?
+            exit_status = wait_thr.value
+            logger.debug("Rsync returned #{exit_status}")
+          }
+        end
+      end
+    end
+  end
+end

--- a/lib/kitchen/transport/rsync.rb
+++ b/lib/kitchen/transport/rsync.rb
@@ -31,8 +31,8 @@ module Kitchen
         def upload(locals, remote)
           key_args = []
           Array(options[:keys]).each { |ssh_key| key_args << "-i #{ssh_key}" }
-          cmd = "rsync -rav --delete --exclude=cache -e 'ssh -l #{username} -p #{port} " +
-            " -o StrictHostKeyChecking=no #{key_args.join(' ')}' #{locals.join(' ')} " +
+          cmd = "rsync -rav --delete --exclude=cache -e 'ssh -l #{username} -p #{port} " \
+            " -o StrictHostKeyChecking=no #{key_args.join(" ")}' #{locals.join(" ")} " \
             "#{hostname}:#{remote}"
 
           logger.debug("Rsync via command '#{cmd}'")
@@ -42,8 +42,7 @@ module Kitchen
             end
 
             stdin.puts("#{options[:password]}\n") if Array(options[:keys]).empty?
-            exit_status = wait_thr.value
-            logger.debug("Rsync returned #{exit_status}")
+            logger.debug("Rsync returned #{wait_thr.value}")
           }
         end
       end

--- a/lib/kitchen/transport/rsync.rb
+++ b/lib/kitchen/transport/rsync.rb
@@ -25,11 +25,15 @@ module Kitchen
   module Transport
     class Rsync < Kitchen::Transport::Ssh
 
+      # Connection class that inherits from the normal ssh class but
+      # overrides the upload method to call out to rsync.
       class Connection < Kitchen::Transport::Ssh::Connection
         def upload(locals, remote)
           key_args = []
           Array(options[:keys]).each { |ssh_key| key_args << "-i #{ssh_key}" }
-          cmd = "rsync -rav --delete --exclude=cache -e 'ssh -l #{username} -p #{port} -o StrictHostKeyChecking=no #{key_args.join(' ')}' #{locals.join(' ')} #{hostname}:#{remote}"
+          cmd = "rsync -rav --delete --exclude=cache -e 'ssh -l #{username} -p #{port} " +
+            " -o StrictHostKeyChecking=no #{key_args.join(' ')}' #{locals.join(' ')} " +
+            "#{hostname}:#{remote}"
 
           logger.debug("Rsync via command '#{cmd}'")
           Open3.popen2e(cmd) {|stdin, stdout_stderr, wait_thr|

--- a/lib/kitchen/transport/rsync.rb
+++ b/lib/kitchen/transport/rsync.rb
@@ -36,9 +36,9 @@ module Kitchen
             "#{hostname}:#{remote}"
 
           logger.debug("Rsync via command '#{cmd}'")
-          Open3.popen2e(cmd) {|stdin, stdout_stderr, wait_thr|
+          Open3.popen2e(cmd) { |stdin, stdout_stderr, wait_thr|
             Thread.new do
-              stdout_stderr.each {|l| logger.debug(l.chomp) }
+              stdout_stderr.each { |l| logger.debug(l.chomp) }
             end
 
             stdin.puts("#{options[:password]}\n") if Array(options[:keys]).empty?

--- a/lib/kitchen/transport/ssh.rb
+++ b/lib/kitchen/transport/ssh.rb
@@ -340,7 +340,7 @@ module Kitchen
         end
 
         @connection_options = options
-        @connection = Kitchen::Transport::Ssh::Connection.new(options, &block)
+        @connection = self.class::Connection.new(options, &block)
       end
 
       # Return the last saved SSH connection instance.

--- a/support/chef_base_clean_command.ps1
+++ b/support/chef_base_clean_command.ps1
@@ -1,0 +1,7 @@
+Function Delete-AllDirs($dirs) {
+  $dirs | ForEach-Object {
+    if (Test-Path ($path = Unresolve-Path $_)) { Remove-Item $path -Recurse -Force }
+  }
+}
+
+Delete-AllDirs $dirs

--- a/support/chef_base_clean_command.sh
+++ b/support/chef_base_clean_command.sh
@@ -1,0 +1,1 @@
+$sudo_rm -rf $dirs

--- a/support/chef_base_init_command.ps1
+++ b/support/chef_base_init_command.ps1
@@ -1,9 +1,3 @@
-Function Delete-AllDirs($dirs) {
-  $dirs | ForEach-Object {
-    if (Test-Path ($path = Unresolve-Path $_)) { Remove-Item $path -Recurse -Force }
-  }
-}
-
 Function Unresolve-Path($p) {
   if ($p -eq $null) { return $null }
   else { return $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($p) }
@@ -14,5 +8,4 @@ Function Make-RootPath($p) {
   if (-Not (Test-Path $p)) { New-Item $p -ItemType directory | Out-Null }
 }
 
-Delete-AllDirs $dirs
 Make-RootPath $root_path

--- a/support/chef_base_init_command.sh
+++ b/support/chef_base_init_command.sh
@@ -1,2 +1,1 @@
-$sudo_rm -rf $dirs
 mkdir -p $root_path


### PR DESCRIPTION
This is a hack to override the upload method on the Ssh transport to use an external rsync binary to transfer needed files between local and remote. It's not glamorous and I have no idea how to actually write a good spec file for it, but here it is in case it helps anybody.

To use it, in your kitchen.yml specify:
```
transport:
  name: rsync
```

And if you want to preserve files between converges (which will speed up the rsync):
```
provisioner:
  clean_files_first: false
```