### PR TITLE
package driver command

### DIFF
--- a/lib/kitchen/cli.rb
+++ b/lib/kitchen/cli.rb
@@ -224,6 +224,13 @@ module Kitchen
       perform("login", "login", args)
     end
 
+    desc "package INSTANCE|REGEXP", "package an instance"
+    log_options
+    def package(*args)
+      update_config!
+      perform("package", "package", args)
+    end
+
     desc "exec INSTANCE|REGEXP -c REMOTE_COMMAND",
       "Execute command on one or more instance"
     method_option :command,

--- a/lib/kitchen/command/package.rb
+++ b/lib/kitchen/command/package.rb
@@ -1,0 +1,36 @@
+# -*- encoding: utf-8 -*-
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "kitchen/command"
+
+module Kitchen
+
+  module Command
+
+    # Execute command on remote instance.
+    #
+    class Package < Kitchen::Command::Base
+
+      # Invoke the command.
+      def call
+        results = parse_subcommand(args.first)
+        results.each do |instance|
+          banner "Package on #{instance.name}."
+          instance.package_action
+        end
+      end
+    end
+  end
+end

--- a/lib/kitchen/driver/base.rb
+++ b/lib/kitchen/driver/base.rb
@@ -52,6 +52,13 @@ module Kitchen
       def destroy(state) # rubocop:disable Lint/UnusedMethodArgument
       end
 
+      # Package an instance.
+      #
+      # @param state [Hash] mutable instance and driver state
+      # @raise [ActionFailed] if the action could not be completed
+      def package(state) # rubocop:disable Lint/UnusedMethodArgument
+      end
+
       class << self
         # @return [Array<Symbol>] an array of action method names that cannot
         #   be run concurrently and must be run in serial via a shared mutex

--- a/lib/kitchen/driver/ssh_base.rb
+++ b/lib/kitchen/driver/ssh_base.rb
@@ -123,6 +123,12 @@ module Kitchen
         raise ClientError, "#{self.class}#destroy must be implemented"
       end
 
+      # Package an instance.
+      #
+      # (see Base#package)
+      def package(state) # rubocop:disable Lint/UnusedMethodArgument
+      end
+
       # (see Base#login_command)
       def login_command(state)
         instance.transport.connection(backcompat_merged_state(state)).

--- a/lib/kitchen/instance.rb
+++ b/lib/kitchen/instance.rb
@@ -229,6 +229,13 @@ module Kitchen
       end
     end
 
+    # Perform package.
+    #
+    def package_action
+      banner "Packaging remote instance"
+      driver.package(state_file.read)
+    end
+
     # Returns a Hash of configuration and other useful diagnostic information.
     #
     # @return [Hash] a diagnostic hash


### PR DESCRIPTION
Add a new command package that runs a package driver command on the instance. 
The vision is that test-kitchen will allow packaging of the provisioner server. 
kitchen-ec2 driver can implement code to create an image on AWS.
kitchen-docker could write code to implement creating a docker image in a docker registry. 
This works in conjunction with the clean command which deletes the remote sandbox containing the chef repo so when a package command is run then the images does not contain the chef repo. 