### PR TITLE
Fixes constant error when using recent net-ssh

### DIFF
--- a/lib/kitchen/transport/ssh.rb
+++ b/lib/kitchen/transport/ssh.rb
@@ -18,6 +18,7 @@
 
 require "kitchen"
 
+require "timeout"
 require "net/ssh"
 require "net/scp"
 


### PR DESCRIPTION
Following the changes in #802, depending on the ruby / gems environnement the ssh transport doesn't work anymore. Here is the exact error, as seen in a Ruby 2.1.2 environment with Kitchen 1.4.2 and net-ssh 2.10.0beta2:

```
-----> Starting Kitchen (v1.4.2)
------Exception-------
Class: Kitchen::ClientError
Message: Could not load the 'ssh' transport from the load path. Please ensure that your transport is installed as a gem or included in your Gemfile if using Bundler.
---Nested Exception---
Class: NameError
Message: uninitialized constant Kitchen::Transport::Ssh::Connection::Timeout
```

This quick fix ensures the *Timeout* constant is known by the system.