### PR TITLE
Added try/catch around main and set error action to stop

### DIFF
--- a/support/chef_base_install_command.ps1
+++ b/support/chef_base_install_command.ps1
@@ -1,3 +1,5 @@
+$ErrorActionPreference = "stop"
+
 Function Check-UpdateChef($root, $version) {
   if (-Not (Test-Path $root)) { return $true }
   elseif ("$version" -eq "true") { return $false }
@@ -66,13 +68,18 @@ Function Unresolve-Path($p) {
   else { return $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($p) }
 }
 
-$chef_omnibus_root = Unresolve-Path $chef_omnibus_root
-$msi = Unresolve-Path $msi
+Try {
+  $chef_omnibus_root = Unresolve-Path $chef_omnibus_root
+  $msi = Unresolve-Path $msi
 
-if (Check-UpdateChef $chef_omnibus_root $version) {
-  Write-Host "-----> Installing Chef Omnibus ($pretty_version)`n"
-  Download-Chef "$chef_metadata_url" $msi
-  Install-Chef $msi
-} else {
-  Write-Host "-----> Chef Omnibus installation detected ($pretty_version)`n"
+  if (Check-UpdateChef $chef_omnibus_root $version) {
+    Write-Host "-----> Installing Chef Omnibus ($pretty_version)`n"
+    Download-Chef "$chef_metadata_url" $msi
+    Install-Chef $msi
+  } else {
+    Write-Host "-----> Chef Omnibus installation detected ($pretty_version)`n"
+}
+Catch {
+  Write-Error ($_ | ft -Property * | out-string) -ErrorAction Continue
+  exit 1
 }


### PR DESCRIPTION
Added a try/catch around main and set the ErrorActionPreference to stop from the default value continue. It's confusing to troubleshoot an exception when a script continues to run through non terminating errors. In my case I had a malformed chef_metadata_url text file but the script continued to run until it tried to install an MSI that didn’t exist. See following gist for an example of the difference in error output https://gist.github.com/mcallb/6aa219b8ebcbb536edc0.