### PR TITLE
Run chef-client twice in chef-zero provisioner

### DIFF
--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -151,6 +151,10 @@ module Kitchen
 
       private
 
+      def last_exit_code
+        "; exit $LastExitCode" if powershell_shell?
+      end
+
       # @return [Hash] an option hash for the install commands
       # @api private
       def install_options

--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -393,7 +393,6 @@ module Kitchen
         end
 
         prepare_config_idempotency_check if config[:enforce_idempotency]
-
       end
 
       # Writes a configuration file to the sandbox directory

--- a/lib/kitchen/provisioner/chef_solo.rb
+++ b/lib/kitchen/provisioner/chef_solo.rb
@@ -39,10 +39,15 @@ module Kitchen
           tap { |path| path.concat(".bat") if provisioner.windows_os? }
       end
 
+      # (see Base#config_filename)
+      def config_filename
+        "solo.rb"
+      end
+
       # (see Base#create_sandbox)
       def create_sandbox
         super
-        prepare_solo_rb
+        prepare_config_rb
       end
 
       def modern?
@@ -66,8 +71,20 @@ module Kitchen
         config[:log_level] = "info" if !modern? && config[:log_level] = "auto"
         cmd = sudo(config[:chef_solo_path]).dup.
           tap { |str| str.insert(0, "& ") if powershell_shell? }
+
+        chef_cmd(cmd)
+      end
+
+      private
+
+      # Returns an Array of command line arguments for the chef client.
+      #
+      # @return [Array<String>] an array of command line arguments
+      # @api private
+      def chef_args(solo_rb_filename)
+        level = config[:log_level] == :info ? :auto : config[:log_level]
         args = [
-          "--config #{remote_path_join(config[:root_path], "solo.rb")}",
+          "--config #{remote_path_join(config[:root_path], solo_rb_filename)}",
           "--log_level #{config[:log_level]}",
           "--no-color",
           "--json-attributes #{remote_path_join(config[:root_path], "dna.json")}"
@@ -77,28 +94,7 @@ module Kitchen
         args << "--profile-ruby" if config[:profile_ruby]
         args << "--legacy-mode" if config[:legacy_mode]
 
-        prefix_command(
-          wrap_shell_code(
-            [cmd, *args].join(" ").
-            tap { |str| str.insert(0, reload_ps1_path) if windows_os? }
-        )
-      )
-      end
-
-      private
-
-      # Writes a solo.rb configuration file to the sandbox directory.
-      #
-      # @api private
-      def prepare_solo_rb
-        data = default_config_rb.merge(config[:solo_rb])
-
-        info("Preparing solo.rb")
-        debug("Creating solo.rb from #{data.inspect}")
-
-        File.open(File.join(sandbox_path, "solo.rb"), "wb") do |file|
-          file.write(format_config_file(data))
-        end
+        args
       end
     end
   end

--- a/lib/kitchen/provisioner/chef_solo.rb
+++ b/lib/kitchen/provisioner/chef_solo.rb
@@ -66,7 +66,6 @@ module Kitchen
       end
 
       # (see Base#run_command)
-      # rubocop:disable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity, Metrics/AbcSize
       def run_command
         config[:log_level] = "info" if !modern? && config[:log_level] = "auto"
         cmd = sudo(config[:chef_solo_path]).dup.
@@ -82,7 +81,6 @@ module Kitchen
       # @return [Array<String>] an array of command line arguments
       # @api private
       def chef_args(solo_rb_filename)
-        level = config[:log_level] == :info ? :auto : config[:log_level]
         args = [
           "--config #{remote_path_join(config[:root_path], solo_rb_filename)}",
           "--log_level #{config[:log_level]}",

--- a/lib/kitchen/provisioner/chef_zero.rb
+++ b/lib/kitchen/provisioner/chef_zero.rb
@@ -94,10 +94,6 @@ module Kitchen
 
       private
 
-      def last_exit_code
-        "; exit $LastExitCode" if powershell_shell?
-      end
-
       # Adds optional flags to a chef-client command, depending on
       # configuration data. Note that this method mutates the incoming Array.
       #

--- a/spec/kitchen/provisioner/chef_solo_spec.rb
+++ b/spec/kitchen/provisioner/chef_solo_spec.rb
@@ -326,14 +326,16 @@ describe Kitchen::Provisioner::ChefSolo do
         cmd.must_match(/'\Z/)
       end
 
-      it "contains a second run if enforce_idempotency is set" do
-        config[:enforce_idempotency] = true
-        cmd.must_match(/chef-solo.*&&.*chef-solo.*client_no_updated_resources.rb/m)
+      it "contains a standard second run if multiple_converge is set to 2" do
+        config[:multiple_converge] = 2
+        cmd.must_match(/chef-solo.*&&.*chef-solo.*/m)
+        cmd.wont_match(/chef-solo.*&&.*chef-solo.*client_no_updated_resources.rb/m)
       end
 
-      it "does not contains a second run if enforce_idempotency is not set" do
-        config[:enforce_idempotency] = false
-        cmd.wont_match(/chef-solo.*&&.*chef-solo.*client_no_updated_resources.rb/m)
+      it "contains a specific second run if enforce_idempotency is set" do
+        config[:multiple_converge] = 2
+        config[:enforce_idempotency] = true
+        cmd.must_match(/chef-solo.*&&.*chef-solo.*client_no_updated_resources.rb/m)
       end
 
       it "exports http_proxy & HTTP_PROXY when :http_proxy is set" do
@@ -478,14 +480,16 @@ describe Kitchen::Provisioner::ChefSolo do
         platform.stubs(:os_type).returns("windows")
       end
 
-      it "contains a second run if enforce_idempotency is set" do
-        config[:enforce_idempotency] = true
-        cmd.must_match(/chef-solo.*;.*chef-solo.*client_no_updated_resources.rb/m)
+      it "contains a standard second run if multiple_converge is set to 2" do
+        config[:multiple_converge] = 2
+        cmd.must_match(/chef-solo.*;.*chef-solo.*/m)
+        cmd.wont_match(/chef-solo.*;.*chef-solo.*client_no_updated_resources.rb/m)
       end
 
-      it "does not contains a second run if enforce_idempotency is not set" do
-        config[:enforce_idempotency] = false
-        cmd.wont_match(/chef-solo.*;.*chef-solo.*client_no_updated_resources.rb/m)
+      it "contains a specific second run if enforce_idempotency is set" do
+        config[:multiple_converge] = 2
+        config[:enforce_idempotency] = true
+        cmd.must_match(/chef-solo.*;.*chef-solo.*client_no_updated_resources.rb/m)
       end
 
       it "exports http_proxy & HTTP_PROXY when :http_proxy is set" do

--- a/spec/kitchen/provisioner/chef_solo_spec.rb
+++ b/spec/kitchen/provisioner/chef_solo_spec.rb
@@ -326,6 +326,16 @@ describe Kitchen::Provisioner::ChefSolo do
         cmd.must_match(/'\Z/)
       end
 
+      it "contains a second run if enforce_idempotency is set" do
+        config[:enforce_idempotency] = true
+        cmd.must_match(/chef-solo.*&&.*chef-solo.*client_no_updated_resources.rb/m)
+      end
+
+      it "does not contains a second run if enforce_idempotency is not set" do
+        config[:enforce_idempotency] = false
+        cmd.wont_match(/chef-solo.*&&.*chef-solo.*client_no_updated_resources.rb/m)
+      end
+
       it "exports http_proxy & HTTP_PROXY when :http_proxy is set" do
         config[:http_proxy] = "http://proxy"
 
@@ -466,6 +476,16 @@ describe Kitchen::Provisioner::ChefSolo do
       before do
         platform.stubs(:shell_type).returns("powershell")
         platform.stubs(:os_type).returns("windows")
+      end
+
+      it "contains a second run if enforce_idempotency is set" do
+        config[:enforce_idempotency] = true
+        cmd.must_match(/chef-solo.*;.*chef-solo.*client_no_updated_resources.rb/m)
+      end
+
+      it "does not contains a second run if enforce_idempotency is not set" do
+        config[:enforce_idempotency] = false
+        cmd.wont_match(/chef-solo.*;.*chef-solo.*client_no_updated_resources.rb/m)
       end
 
       it "exports http_proxy & HTTP_PROXY when :http_proxy is set" do

--- a/spec/kitchen/provisioner/chef_zero_spec.rb
+++ b/spec/kitchen/provisioner/chef_zero_spec.rb
@@ -722,14 +722,16 @@ describe Kitchen::Provisioner::ChefZero do
           cmd.must_match(/'\Z/)
         end
 
-        it "contains a second run if enforce_idempotency is set" do
-          config[:enforce_idempotency] = true
-          cmd.must_match(/chef-client.*&&.*chef-client.*client_no_updated_resources.rb/m)
+        it "contains a standard second run if multiple_converge is set to 2" do
+          config[:multiple_converge] = 2
+          cmd.must_match(/chef-client.*&&.*chef-client.*/m)
+          cmd.wont_match(/chef-client.*&&.*chef-client.*client_no_updated_resources.rb/m)
         end
 
-        it "does not contains a second run if enforce_idempotency is not set" do
-          config[:enforce_idempotency] = false
-          cmd.wont_match(/chef-client.*&&.*chef-client.*client_no_updated_resources.rb/m)
+        it "contains a specific second run if enforce_idempotency is set" do
+          config[:multiple_converge] = 2
+          config[:enforce_idempotency] = true
+          cmd.must_match(/chef-client.*&&.*chef-client.*client_no_updated_resources.rb/m)
         end
 
         it "exports http_proxy & HTTP_PROXY when :http_proxy is set" do
@@ -796,14 +798,16 @@ describe Kitchen::Provisioner::ChefZero do
         common_shell_specs
         common_modern_shell_specs
 
-        it "contains a second run if enforce_idempotency is set" do
-          config[:enforce_idempotency] = true
-          cmd.must_match(/chef-client.*;.*chef-client.*client_no_updated_resources.rb/m)
+        it "contains a standard second run if multiple_converge is set to 2" do
+          config[:multiple_converge] = 2
+          cmd.must_match(/chef-client.*;.*chef-client.*/m)
+          cmd.wont_match(/chef-client.*;.*chef-client.*client_no_updated_resources.rb/m)
         end
 
-        it "does not contains a second run if enforce_idempotency is not set" do
-          config[:enforce_idempotency] = false
-          cmd.wont_match(/chef-client.*;.*chef-client.*client_no_updated_resources.rb/m)
+        it "contains a specific second run if enforce_idempotency is set" do
+          config[:multiple_converge] = 2
+          config[:enforce_idempotency] = true
+          cmd.must_match(/chef-client.*;.*chef-client.*client_no_updated_resources.rb/m)
         end
 
         it "exports http_proxy & HTTP_PROXY when :http_proxy is set" do

--- a/spec/kitchen/provisioner/chef_zero_spec.rb
+++ b/spec/kitchen/provisioner/chef_zero_spec.rb
@@ -722,6 +722,16 @@ describe Kitchen::Provisioner::ChefZero do
           cmd.must_match(/'\Z/)
         end
 
+        it "contains a second run if enforce_idempotency is set" do
+          config[:enforce_idempotency] = true
+          cmd.must_match(/chef-client.*&&.*chef-client.*client_no_updated_resources.rb/m)
+        end
+
+        it "does not contains a second run if enforce_idempotency is not set" do
+          config[:enforce_idempotency] = false
+          cmd.wont_match(/chef-client.*&&.*chef-client.*client_no_updated_resources.rb/m)
+        end
+
         it "exports http_proxy & HTTP_PROXY when :http_proxy is set" do
           config[:http_proxy] = "http://proxy"
 
@@ -785,6 +795,16 @@ describe Kitchen::Provisioner::ChefZero do
 
         common_shell_specs
         common_modern_shell_specs
+
+        it "contains a second run if enforce_idempotency is set" do
+          config[:enforce_idempotency] = true
+          cmd.must_match(/chef-client.*;.*chef-client.*client_no_updated_resources.rb/m)
+        end
+
+        it "does not contains a second run if enforce_idempotency is not set" do
+          config[:enforce_idempotency] = false
+          cmd.wont_match(/chef-client.*;.*chef-client.*client_no_updated_resources.rb/m)
+        end
 
         it "exports http_proxy & HTTP_PROXY when :http_proxy is set" do
           config[:http_proxy] = "http://proxy"

--- a/support/chef-client-fail-if-update-handler.rb
+++ b/support/chef-client-fail-if-update-handler.rb
@@ -1,0 +1,15 @@
+# Handler to kill the run if any resource is updated
+class UpdatedResources < ::Chef::Handler
+  def report
+    if updated_resources.size > 0
+      puts "First chef run should have reached a converged state."
+      puts "Resources updated in a second chef-client run:"
+      updated_resources.each do |r|
+        puts "- #{r}"
+      end
+      # exit 203 # chef handler catch Exception instead of StandardException
+      Process.kill("KILL", Process.pid)
+    end
+  end
+end
+report_handlers << UpdatedResources.new


### PR DESCRIPTION
chef-zero provisioner runs chef-client twice. Second time expect no
resource to be updated. This is a way to enforce idempotency.

This is a proof of concept to fix #874 but it lacks:
- testing
- windows support
- documentation

Could you tell me what you think of the need, this proof of concept ? And also guide me to write relevant testing.
