### PR TITLE
added users_path for provisioning users in chefzero

### DIFF
--- a/lib/kitchen/provisioner/chef/common_sandbox.rb
+++ b/lib/kitchen/provisioner/chef/common_sandbox.rb
@@ -54,6 +54,7 @@ module Kitchen
           prepare(:nodes)
           prepare(:roles)
           prepare(:clients)
+          prepare(:users)
           prepare(
             :secret,
             :type => :file,

--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -78,6 +78,11 @@ module Kitchen
       end
       expand_path_for :clients_path
 
+      default_config :users_path do |provisioner|
+        provisioner.calculate_path("users")
+      end
+      expand_path_for :users_path
+
       default_config :encrypted_data_bag_secret_key_path do |provisioner|
         provisioner.calculate_path("encrypted_data_bag_secret_key", :type => :file)
       end
@@ -92,7 +97,7 @@ module Kitchen
       # (see Base#init_command)
       def init_command
         dirs = %w[
-          cookbooks data data_bags environments roles clients
+          cookbooks data data_bags environments roles clients users
           encrypted_data_bag_secret
         ].sort.map { |dir| remote_path_join(config[:root_path], dir) }
 


### PR DESCRIPTION
Hi,

I've been playing around with test-kitchen and chef-vault. In order to set up a chef-vault administrator in the chef_vault_secret, there needs to be a user (or client) in chef-zero.

The example under https://github.com/chef-cookbooks/chef-vault/tree/master/test/fixtures uses a client, but to make the test more realistic, I wanted to add an administrator as well.

```
chef_vault_secret 'myapp-vault' do
  data_bag 'myapp'
  raw_data('keystorepass.dev' => 'chef12345')
  admins 'quickedw'
  clients 'role:myapp'
  search '*:*'
end
```

I have created the following user under ~/chef/cookbooks/myapp/test/fixtures/users

```
jenkins@buildhost $ pwd
/home/jenkins/chef/cookbooks/myapp/test/fixtures/
jenkins@buildhost $ ls
clients  cookbooks  users
jenkins@buildhost $ ls users
quickedw.json  quickedw.pem
jenkins@buildhost $ cat quickedw.json
{
  "name": "quickedw",
  "public_key": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAroTVtRfhrIp8HsDgWOQ6\nwPSR/trQhCJy0izY8cSHK2tlg0H6tH326qXn+cPtdyxKm5y21+z5/Ap2o4Y2Z/xa\nyMPbWUENPCnNgva8dAPQ71+IzbnQTN9SWL6yBEBtC0Ap1mDM8/H1w4xseIAU2pSf\n+ul0Ly8k5LEhyIYxoo+/7FyUJN0J28Tj+tFlSDJtWAuRryvdKRrIODg1tiaCuOkm\nOSM2djB/oyy5xtMky/4iZCaKZO6C37Z1qGOKrU7cZf3eDJxjUjp3MWrWniCOjiha\nbI86ToKsN/Dh4MSXUjvSp7PQRMEZoVNcVb1K6BSNq4FAjadFhR6wfLTV0gYCz5gE\nuwIDAQAB\n-----END PUBLIC KEY-----\n",
  "admin": true,
  "chef_type": "user"
}
```

and using the patch in my PR, this creates /tmp/kitchen/users on the provisioned host and copies over the json user above. 

As you can see below it now adds the client and user keys to the vault_keys file.

```
root@kitchenhost # pwd
/tmp/kitchen/data_bags/myapp
root@kitchenhost # cat myapp-vault_keys.json
{
  "id": "myapp-vault_keys",
  "admins": [
    "quickedw"
  ],
  "clients": [
    "tomcat6-rhel6"
  ],
  "search_query": "*:*",
  "tomcat6-rhel6": "ehs4FEVyyE+/c6AaYwNQbwSNM7L9RWvBDhAMvELGYQndYfCGC/0Ha0IFtpRA\nGb7kqh3RZX9nm6t+uSjKCm2LMD2BtH9ckxEMSrHuO/kzYkY9cB12mFTxLWJc\nHm3RlPyAJ216ufhBeUIy3cjuZa2poV/+RzvGkDlAcfj0qSU6Zp5YkQM++tbG\n+mx0AQLMXwcrTvxbztb6hPcmHk9rZLEN3y7pBQcD6uaRomgJxyGDSuu10RGf\nWJBgBZKyttlQj1ErNN4W9Z+UkzetZLOOYmoz0NUpuhNp54qGJmHy6Q6nDoGZ\nlCbqyzV2YsWmA9LdIaIEFTZpVVT7I3+7jqUpnaHh/A==\n",
  "quickedw": "UlkJDn/9jvZg8fOaT+LvV1dT+pDVGH9jiZoiYeN7dH5JSggXh6xx/U/LHho3\nJvwdhXdC4QRsWbDStONSy4n5+ECaCM6BmKV+3Qch99fPm99IC2EmePYUIFO2\n8cQfav7rtSKurXeFEFnqL/RA8OdDVCeliaMO85xnuoBdgkLXEZQ7j2Wx8PTd\nogwVd0C/3f2GiYd7Bo+1iUjB0gqfiSv9WCpAQVTV+pjSl5YFLRUbjvsrJJ4A\nxVsbl1z+C9NQ2dMFsky01wEirH2swKCA+dW20g0Sw4QC6YgJ0o37PgQT1CzN\nHwcClC4hSLyAx1lV4dQLP+VkpN9xS/Yvo86rx/4R4Q==\n"
```
