### PR TITLE
Adding support for a command prefix

### DIFF
--- a/lib/kitchen/transport/ssh.rb
+++ b/lib/kitchen/transport/ssh.rb
@@ -108,7 +108,7 @@ module Kitchen
         def execute(command)
           return if command.nil?
 
-          command = [ command_prefix, command ].compact.join(' ')
+          command = [command_prefix, command].compact.join(" ")
           logger.debug("[SSH] #{self} (#{command})")
 
           exit_code = execute_with_exit_code(command)

--- a/lib/kitchen/transport/ssh.rb
+++ b/lib/kitchen/transport/ssh.rb
@@ -48,6 +48,7 @@ module Kitchen
       default_config :connection_retries, 5
       default_config :connection_retry_sleep, 1
       default_config :max_wait_until_ready, 600
+      default_config :command_prefix, nil
 
       default_config :ssh_key, nil
       expand_path_for :ssh_key
@@ -106,7 +107,10 @@ module Kitchen
         # (see Base::Connection#execute)
         def execute(command)
           return if command.nil?
+
+          command = [ command_prefix, command ].compact.join(' ')
           logger.debug("[SSH] #{self} (#{command})")
+
           exit_code = execute_with_exit_code(command)
 
           if exit_code != 0
@@ -197,6 +201,10 @@ module Kitchen
         # @api private
         attr_reader :port
 
+        # @return [String] prefix for each executed command
+        # @api private
+        attr_reader :command_prefix
+
         # Establish an SSH session on the remote host.
         #
         # @param opts [Hash] retry options
@@ -268,6 +276,7 @@ module Kitchen
           @connection_retries     = @options.delete(:connection_retries)
           @connection_retry_sleep = @options.delete(:connection_retry_sleep)
           @max_wait_until_ready   = @options.delete(:max_wait_until_ready)
+          @command_prefix         = @options.delete(:command_prefix)
         end
 
         # Returns a connection session, or establishes one when invoked the
@@ -315,7 +324,8 @@ module Kitchen
           :timeout                => data[:connection_timeout],
           :connection_retries     => data[:connection_retries],
           :connection_retry_sleep => data[:connection_retry_sleep],
-          :max_wait_until_ready   => data[:max_wait_until_ready]
+          :max_wait_until_ready   => data[:max_wait_until_ready],
+          :command_prefix         => data[:command_prefix]
         }
 
         opts[:keys_only] = true                     if data[:ssh_key]

--- a/lib/kitchen/transport/winrm.rb
+++ b/lib/kitchen/transport/winrm.rb
@@ -88,7 +88,7 @@ module Kitchen
         def execute(command)
           return if command.nil?
 
-          command = [ command_prefix, command ].compact.join(' ')
+          command = [command_prefix, command].compact.join(" ")
           logger.debug("[WinRM] #{self} (#{command})")
 
           if command.length > MAX_COMMAND_SIZE

--- a/lib/kitchen/transport/winrm.rb
+++ b/lib/kitchen/transport/winrm.rb
@@ -51,6 +51,7 @@ module Kitchen
       default_config :connection_retries, 5
       default_config :connection_retry_sleep, 1
       default_config :max_wait_until_ready, 600
+      default_config :command_prefix, nil
 
       # (see Base#connection)
       def connection(state, &block)
@@ -86,6 +87,8 @@ module Kitchen
         # (see Base::Connection#execute)
         def execute(command)
           return if command.nil?
+
+          command = [ command_prefix, command ].compact.join(' ')
           logger.debug("[WinRM] #{self} (#{command})")
 
           if command.length > MAX_COMMAND_SIZE
@@ -190,6 +193,10 @@ module Kitchen
         # @api private
         attr_reader :winrm_transport
 
+        # @return [String] prefix for each executed command
+        # @api private
+        attr_reader :command_prefix
+
         # Writes an RDP document to the local file system.
         #
         # @param opts [Hash] file options
@@ -271,6 +278,7 @@ module Kitchen
           @connection_retries = @options.delete(:connection_retries)
           @connection_retry_sleep = @options.delete(:connection_retry_sleep)
           @max_wait_until_ready   = @options.delete(:max_wait_until_ready)
+          @command_prefix         = @options.delete(:command_prefix)
         end
 
         # Logs formatted standard error output at the warning level.
@@ -435,7 +443,8 @@ module Kitchen
           :rdp_port               => data[:rdp_port],
           :connection_retries     => data[:connection_retries],
           :connection_retry_sleep => data[:connection_retry_sleep],
-          :max_wait_until_ready   => data[:max_wait_until_ready]
+          :max_wait_until_ready   => data[:max_wait_until_ready],
+          :command_prefix         => data[:command_prefix]
         }
 
         opts

--- a/spec/kitchen/transport/ssh_spec.rb
+++ b/spec/kitchen/transport/ssh_spec.rb
@@ -907,7 +907,7 @@ describe Kitchen::Transport::Ssh::Connection do
       end
     end
 
-    describe 'for a connection with a command prefix' do
+    describe "for a connection with a command prefix" do
 
       before do
         story do |script|
@@ -922,10 +922,10 @@ describe Kitchen::Transport::Ssh::Connection do
         end
       end
 
-      it 'logger displays command containing prefix on debug' do
-        connection.stubs(:command_prefix).returns('test_prefix')
+      it "logger displays command containing prefix on debug" do
+        connection.stubs(:command_prefix).returns("test_prefix")
 
-        assert_scripted { connection.execute('doit') }
+        assert_scripted { connection.execute("doit") }
 
         logged_output.string.must_match debug_line(
           "[SSH] me@foo<{:port=>22}> (test_prefix doit)"

--- a/spec/kitchen/transport/ssh_spec.rb
+++ b/spec/kitchen/transport/ssh_spec.rb
@@ -907,6 +907,32 @@ describe Kitchen::Transport::Ssh::Connection do
       end
     end
 
+    describe 'for a connection with a command prefix' do
+
+      before do
+        story do |script|
+          channel = script.opens_channel
+          channel.sends_request_pty
+          channel.sends_exec("test_prefix doit")
+          channel.gets_data("ok\n")
+          channel.gets_extended_data("some stderr stuffs\n")
+          channel.gets_exit_status(0)
+          channel.gets_close
+          channel.sends_close
+        end
+      end
+
+      it 'logger displays command containing prefix on debug' do
+        connection.stubs(:command_prefix).returns('test_prefix')
+
+        assert_scripted { connection.execute('doit') }
+
+        logged_output.string.must_match debug_line(
+          "[SSH] me@foo<{:port=>22}> (test_prefix doit)"
+        )
+      end
+    end
+
     describe "for a nil command" do
 
       it "does not log on debug" do

--- a/spec/kitchen/transport/winrm_spec.rb
+++ b/spec/kitchen/transport/winrm_spec.rb
@@ -739,6 +739,32 @@ MSG
       end
     end
 
+    describe 'for a connection with a command prefix' do
+      let(:response) do
+        o = WinRM::Output.new
+        o[:exitcode] = 0
+        o[:data].concat([
+          { :stdout => "ok\r\n" },
+          { :stderr => "congrats\r\n" }
+        ])
+        o
+      end
+
+      before do
+        executor.expects(:open).returns("shell-123")
+        executor.expects(:run_powershell_script).
+          with("test_prefix doit").yields("ok\n", nil).returns(response)
+      end
+
+      it "logger displays command on debug" do
+        connection.stubs(:command_prefix).returns('test_prefix')
+        connection.execute("doit")
+
+        logged_output.string.must_match debug_line(
+          "[WinRM] #{info} (test_prefix doit)")
+      end
+    end
+
     describe "for a nil command" do
 
       it "does not log on debug" do

--- a/spec/kitchen/transport/winrm_spec.rb
+++ b/spec/kitchen/transport/winrm_spec.rb
@@ -739,7 +739,7 @@ MSG
       end
     end
 
-    describe 'for a connection with a command prefix' do
+    describe "for a connection with a command prefix" do
       let(:response) do
         o = WinRM::Output.new
         o[:exitcode] = 0
@@ -757,7 +757,7 @@ MSG
       end
 
       it "logger displays command on debug" do
-        connection.stubs(:command_prefix).returns('test_prefix')
+        connection.stubs(:command_prefix).returns("test_prefix")
         connection.execute("doit")
 
         logged_output.string.must_match debug_line(


### PR DESCRIPTION
Some platforms, such as Cisco devices, require commands to be
prefixed with a command to force the execution to take place within
a VRF. This allows the command to be configured in the .kitchen.yml.