### PR TITLE
Running the chef_base provisioner install_command via sudo, and command_prefix support

### DIFF
--- a/lib/kitchen/provisioner/base.rb
+++ b/lib/kitchen/provisioner/base.rb
@@ -44,6 +44,8 @@ module Kitchen
         provisioner.windows_os? ? nil : "sudo -E"
       end
 
+      default_config :command_prefix, nil
+
       expand_path_for :test_base_path
 
       # Constructs a new provisioner by providing a configuration hash.
@@ -207,6 +209,19 @@ module Kitchen
       # @api private
       def sudo(script)
         config[:sudo] ? "#{config[:sudo_command]} #{script}" : script
+      end
+
+      # Conditionally prefixes a command with a command prefix.
+      # This should generally be done after a command has been
+      # conditionally prefixed by #sudo as certain platforms, such as
+      # Cisco Nexus, require all commands to be run with a prefix to
+      # obtain outbound network access.
+      #
+      # @param command [String] command to be prefixed
+      # @return [String] the command, conditionally prefixed with the configured prefix
+      # @api private
+      def prefix_command(script)
+        config[:command_prefix] ? "#{config[:command_prefix]} #{script}" : script
       end
     end
   end

--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -102,7 +102,7 @@ module Kitchen
           init_command_vars_for_bourne(dirs)
         end
 
-        shell_code_from_file(vars, "chef_base_init_command")
+        prefix_command(shell_code_from_file(vars, "chef_base_init_command"))
       end
 
       # (see Base#install_command)
@@ -118,7 +118,7 @@ module Kitchen
 
         installer = Mixlib::Install.new(version, powershell_shell?, install_options)
         config[:chef_omnibus_root] = installer.root
-        installer.install_command
+        prefix_command(sudo(installer.install_command))
       end
 
       private
@@ -131,8 +131,8 @@ module Kitchen
           :omnibus_url => config[:chef_omnibus_url],
           :project => project.nil? ? nil : project[1],
           :install_flags => config[:chef_omnibus_install_options],
-          :use_sudo => config[:sudo],
-          :sudo_command => config[:sudo_command]
+          :use_sudo => false,
+          :sudo_command => nil
         }.tap do |opts|
           opts[:root] = config[:chef_omnibus_root] if config.key? :chef_omnibus_root
           opts[:http_proxy] = config[:http_proxy] if config.key? :http_proxy

--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -130,9 +130,7 @@ module Kitchen
         {
           :omnibus_url => config[:chef_omnibus_url],
           :project => project.nil? ? nil : project[1],
-          :install_flags => config[:chef_omnibus_install_options],
-          :use_sudo => false,
-          :sudo_command => nil
+          :install_flags => config[:chef_omnibus_install_options]
         }.tap do |opts|
           opts[:root] = config[:chef_omnibus_root] if config.key? :chef_omnibus_root
           opts[:http_proxy] = config[:http_proxy] if config.key? :http_proxy

--- a/lib/kitchen/provisioner/chef_solo.rb
+++ b/lib/kitchen/provisioner/chef_solo.rb
@@ -46,7 +46,7 @@ module Kitchen
       end
 
       # (see Base#run_command)
-      def run_command
+      def run_command # rubocop:disable Metrics/AbcSize
         level = config[:log_level] == :info ? :auto : config[:log_level]
 
         cmd = sudo(config[:chef_solo_path]).dup.
@@ -60,10 +60,12 @@ module Kitchen
         ]
         args << "--logfile #{config[:log_file]}" if config[:log_file]
 
-        wrap_shell_code(
-          [cmd, *args].join(" ").
-          tap { |str| str.insert(0, reload_ps1_path) if windows_os? }
+        prefix_command(
+          wrap_shell_code(
+            [cmd, *args].join(" ").
+            tap { |str| str.insert(0, reload_ps1_path) if windows_os? }
         )
+      )
       end
 
       private

--- a/lib/kitchen/provisioner/chef_zero.rb
+++ b/lib/kitchen/provisioner/chef_zero.rb
@@ -66,16 +66,18 @@ module Kitchen
           shell_var("gem", sudo(gem_bin))
         ].join("\n").concat("\n")
 
-        shell_code_from_file(vars, "chef_zero_prepare_command_legacy")
+        prefix_command(shell_code_from_file(vars, "chef_zero_prepare_command_legacy"))
       end
 
       # (see Base#run_command)
       def run_command
         cmd = modern? ? local_mode_command : shim_command
 
-        wrap_shell_code(
-          [cmd, *chef_client_args].join(" ").
-          tap { |str| str.insert(0, reload_ps1_path) if windows_os? }
+        prefix_command(
+          wrap_shell_code(
+            [cmd, *chef_client_args].join(" ").
+            tap { |str| str.insert(0, reload_ps1_path) if windows_os? }
+          )
         )
       end
 

--- a/lib/kitchen/verifier/base.rb
+++ b/lib/kitchen/verifier/base.rb
@@ -50,6 +50,8 @@ module Kitchen
         verifier.windows_os? ? nil : "sudo -E"
       end
 
+      default_config :command_prefix, nil
+
       default_config(:suite_name) { |busser| busser.instance.suite.name }
 
       # Creates a new Verifier object using the provided configuration data
@@ -214,6 +216,19 @@ module Kitchen
       # @api private
       def sudo(script)
         config[:sudo] ? "#{config[:sudo_command]} #{script}" : script
+      end
+
+      # Conditionally prefixes a command with a command prefix.
+      # This should generally be done after a command has been
+      # conditionally prefixed by #sudo as certain platforms, such as
+      # Cisco Nexus, require all commands to be run with a prefix to
+      # obtain outbound network access.
+      #
+      # @param command [String] command to be prefixed
+      # @return [String] the command, conditionally prefixed with the configured prefix
+      # @api private
+      def prefix_command(script)
+        config[:command_prefix] ? "#{config[:command_prefix]} #{script}" : script
       end
     end
   end

--- a/lib/kitchen/verifier/busser.rb
+++ b/lib/kitchen/verifier/busser.rb
@@ -76,7 +76,7 @@ module Kitchen
         cmd = sudo(config[:busser_bin]).dup.
           tap { |str| str.insert(0, "& ") if powershell_shell? }
 
-        wrap_shell_code(Util.outdent!(<<-CMD))
+        prefix_command(wrap_shell_code(Util.outdent!(<<-CMD)))
           #{busser_env}
 
           #{cmd} suite cleanup
@@ -89,7 +89,7 @@ module Kitchen
 
         vars = install_command_vars
 
-        shell_code_from_file(vars, "busser_install_command")
+        prefix_command(shell_code_from_file(vars, "busser_install_command"))
       end
 
       # (see Base#run_command)
@@ -99,7 +99,7 @@ module Kitchen
         cmd = sudo(config[:busser_bin]).dup.
           tap { |str| str.insert(0, "& ") if powershell_shell? }
 
-        wrap_shell_code(Util.outdent!(<<-CMD))
+        prefix_command(wrap_shell_code(Util.outdent!(<<-CMD)))
           #{busser_env}
 
           #{cmd} test

--- a/spec/kitchen/provisioner/base_spec.rb
+++ b/spec/kitchen/provisioner/base_spec.rb
@@ -325,4 +325,25 @@ describe Kitchen::Provisioner::Base do
       end
     end
   end
+
+  describe "#prefix_command" do
+
+    describe "with :command_prefix set" do
+
+      before { config[:command_prefix] = "my_prefix" }
+
+      it "prepends the command with the prefix" do
+        provisioner.send(:prefix_command, "my_command").must_equal("my_prefix my_command")
+      end
+    end
+
+    describe "with :command_prefix unset" do
+
+      before { config[:command_prefix] = nil }
+
+      it "returns an unaltered command" do
+        provisioner.send(:prefix_command, "my_command").must_equal("my_command")
+      end
+    end
+  end
 end

--- a/spec/kitchen/provisioner/chef_base_spec.rb
+++ b/spec/kitchen/provisioner/chef_base_spec.rb
@@ -147,8 +147,7 @@ describe Kitchen::Provisioner::ChefBase do
 
     let(:install_opts) {
       { :omnibus_url => "https://www.chef.io/chef/install.sh",
-        :project => nil, :install_flags => nil, :use_sudo => false,
-        :sudo_command => nil, :http_proxy => nil,
+        :project => nil, :install_flags => nil, :http_proxy => nil,
         :https_proxy => nil }
     }
 

--- a/spec/kitchen/provisioner/chef_base_spec.rb
+++ b/spec/kitchen/provisioner/chef_base_spec.rb
@@ -147,8 +147,8 @@ describe Kitchen::Provisioner::ChefBase do
 
     let(:install_opts) {
       { :omnibus_url => "https://www.chef.io/chef/install.sh",
-        :project => nil, :install_flags => nil, :use_sudo => true,
-        :sudo_command => "sudo -E", :http_proxy => nil,
+        :project => nil, :install_flags => nil, :use_sudo => false,
+        :sudo_command => nil, :http_proxy => nil,
         :https_proxy => nil }
     }
 
@@ -279,26 +279,39 @@ describe Kitchen::Provisioner::ChefBase do
         Mixlib::Install.any_instance.expects(:initialize).with(default_version, false, install_opts)
         cmd
       end
+
+      it "prefixs the whole command with the command_prefix if set" do
+        config[:command_prefix] = "my_prefix"
+
+        cmd.must_match(/\Amy_prefix /)
+      end
+
+      it "does not prefix the command if command_prefix is not set" do
+        config[:command_prefix] = nil
+
+        cmd.wont_match(/\Amy_prefix /)
+      end
     end
 
     describe "for bourne shells" do
       before do
         Mixlib::Install.any_instance.expects(:root).at_least_once.returns("/opt/chef")
-        Mixlib::Install.any_instance.expects(:install_command)
+        Mixlib::Install.any_instance.expects(:install_command).returns("my_install_command")
       end
+
       it "prepends sudo for sh commands when :sudo is set" do
         config[:sudo] = true
+        config[:sudo_command] = "my_sudo_command"
 
         Mixlib::Install.any_instance.expects(:initialize).with(default_version, false, install_opts)
-        cmd
+        cmd.must_equal "my_sudo_command my_install_command"
       end
 
       it "does not sudo for sh commands when :sudo is falsey" do
         config[:sudo] = false
-        install_opts[:use_sudo] = false
 
         Mixlib::Install.any_instance.expects(:initialize).with(default_version, false, install_opts)
-        cmd
+        cmd.must_equal "my_install_command"
       end
     end
 
@@ -311,8 +324,6 @@ describe Kitchen::Provisioner::ChefBase do
       end
 
       it "sets the powershell flag for Mixlib::Install" do
-        install_opts[:use_sudo] = nil
-        install_opts[:sudo_command] = nil
         Mixlib::Install.any_instance.expects(:initialize).with(default_version, true, install_opts)
         cmd
       end
@@ -322,6 +333,23 @@ describe Kitchen::Provisioner::ChefBase do
   describe "#init_command" do
 
     let(:cmd) { provisioner.init_command }
+
+    describe "common behavior" do
+
+      before { platform.stubs(:shell_type).returns("fake") }
+
+      it "prefixs the whole command with the command_prefix if set" do
+        config[:command_prefix] = "my_prefix"
+
+        cmd.must_match(/\Amy_prefix /)
+      end
+
+      it "does not prefix the command if command_prefix is not set" do
+        config[:command_prefix] = nil
+
+        cmd.wont_match(/\Amy_prefix /)
+      end
+    end
 
     describe "for bourne shells" do
 

--- a/spec/kitchen/provisioner/chef_solo_spec.rb
+++ b/spec/kitchen/provisioner/chef_solo_spec.rb
@@ -296,6 +296,23 @@ describe Kitchen::Provisioner::ChefSolo do
 
     let(:cmd) { provisioner.run_command }
 
+    describe "common behavior" do
+
+      before { platform.stubs(:shell_type).returns("fake") }
+
+      it "prefixs the whole command with the command_prefix if set" do
+        config[:command_prefix] = "my_prefix"
+
+        cmd.must_match(/\Amy_prefix /)
+      end
+
+      it "does not prefix the command if command_prefix is not set" do
+        config[:command_prefix] = nil
+
+        cmd.wont_match(/\Amy_prefix /)
+      end
+    end
+
     describe "for bourne shells" do
 
       before { platform.stubs(:shell_type).returns("bourne") }

--- a/spec/kitchen/provisioner/chef_zero_spec.rb
+++ b/spec/kitchen/provisioner/chef_zero_spec.rb
@@ -634,6 +634,18 @@ describe Kitchen::Provisioner::ChefZero do
       it "does not set logfile flag by default" do
         cmd.wont_match regexify(" --logfile ", :partial_line)
       end
+
+      it "prefixs the whole command with the command_prefix if set" do
+        config[:command_prefix] = "my_prefix"
+
+        cmd.must_match(/\Amy_prefix /)
+      end
+
+      it "does not prefix the command if command_prefix is not set" do
+        config[:command_prefix] = nil
+
+        cmd.wont_match(/\Amy_prefix /)
+      end
     end
     # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 

--- a/spec/kitchen/verifier/base_spec.rb
+++ b/spec/kitchen/verifier/base_spec.rb
@@ -334,4 +334,25 @@ describe Kitchen::Verifier::Base do
       end
     end
   end
+
+  describe "#prefix_command" do
+
+    describe "with :command_prefix set" do
+
+      before { config[:command_prefix] = "my_prefix" }
+
+      it "prepends the command with the prefix" do
+        verifier.send(:prefix_command, "my_command").must_equal("my_prefix my_command")
+      end
+    end
+
+    describe "with :command_prefix unset" do
+
+      before { config[:command_prefix] = nil }
+
+      it "returns an unaltered command" do
+        verifier.send(:prefix_command, "my_command").must_equal("my_command")
+      end
+    end
+  end
 end

--- a/spec/kitchen/verifier/busser_spec.rb
+++ b/spec/kitchen/verifier/busser_spec.rb
@@ -212,6 +212,26 @@ describe Kitchen::Verifier::Busser do
 
     describe "with suite test files" do
 
+      describe "common behavior" do
+
+        before do
+          platform.stubs(:shell_type).returns("fake")
+          create_test_files
+        end
+
+        it "prefixs the whole command with the command_prefix if set" do
+          config[:command_prefix] = "my_prefix"
+
+          cmd.must_match(/\Amy_prefix /)
+        end
+
+        it "does not prefix the command if command_prefix is not set" do
+          config[:command_prefix] = nil
+
+          cmd.wont_match(/\Amy_prefix /)
+        end
+      end
+
       describe "for bourne shells" do
 
         before do
@@ -335,6 +355,26 @@ describe Kitchen::Verifier::Busser do
 
     describe "with suite test files" do
 
+      describe "common behavior" do
+
+        before do
+          platform.stubs(:shell_type).returns("fake")
+          create_test_files
+        end
+
+        it "prefixs the whole command with the command_prefix if set" do
+          config[:command_prefix] = "my_prefix"
+
+          cmd.must_match(/\Amy_prefix /)
+        end
+
+        it "does not prefix the command if command_prefix is not set" do
+          config[:command_prefix] = nil
+
+          cmd.wont_match(/\Amy_prefix /)
+        end
+      end
+
       describe "for bourne shells" do
 
         before do
@@ -412,6 +452,26 @@ describe Kitchen::Verifier::Busser do
     end
 
     describe "with suite test files" do
+
+      describe "common behavior" do
+
+        before do
+          platform.stubs(:shell_type).returns("fake")
+          create_test_files
+        end
+
+        it "prefixs the whole command with the command_prefix if set" do
+          config[:command_prefix] = "my_prefix"
+
+          cmd.must_match(/\Amy_prefix /)
+        end
+
+        it "does not prefix the command if command_prefix is not set" do
+          config[:command_prefix] = nil
+
+          cmd.wont_match(/\Amy_prefix /)
+        end
+      end
 
       describe "for bourne shells" do
 


### PR DESCRIPTION
Currently, whether or not to use sudo during the installation of
the omnibus chef package is left up to the install command
generated by Mixlib::Install based on the sudo flag and command
passed to the constructor. Future versions of Mixlib::Install
do not support the sudo option, and some platforms (such as Cisco
Nexus) require the entire process to run with escalated privileges
in order to obtain outbound internet access. This change tells
Mixlib::Install to not care about sudo and instead wrap the entire
install_command with sudo from within the provisioner.

On certain platforms, commands must be prefixed with another
command to work properly, such as on Cisco Nexus where the
user must switch into a management vrf to obtain outbound network
access. Using the sudo_command config parameter is not sufficient
as some commands, such as busser verifier commands and provisioner
init commands, need to run as the non-privileged user.

This change allows the user to configure a string that will be
prepended to provisioner and verifier commands, much like how
sudo_command works, but impacts all commands.