### PR TITLE
Test suite maintenance, a.k.a. "Just Dots And Only Dots"

### DIFF
--- a/features/kitchen_init_command.feature
+++ b/features/kitchen_init_command.feature
@@ -3,6 +3,9 @@ Feature: Add Test Kitchen support to an existing project
   As an operator
   I want to run a command to initialize my project
 
+  Background:
+    Given a sandboxed GEM_HOME directory named "kitchen-init"
+
   @spawn
   Scenario: Displaying help
     When I run `kitchen help init`
@@ -15,8 +18,7 @@ Feature: Add Test Kitchen support to an existing project
 
   @spawn
   Scenario: Running init with default values
-    Given a sandboxed GEM_HOME directory named "kitchen-init"
-    And I have a git repository
+    Given I have a git repository
     When I run `kitchen init`
     Then the exit status should be 0
     And a directory named "test/integration/default" should exist

--- a/features/kitchen_init_command.feature
+++ b/features/kitchen_init_command.feature
@@ -175,7 +175,7 @@ Feature: Add Test Kitchen support to an existing project
     """
 
   Scenario: Running without git doesn't make a .gitignore
-    When I successfully run `kitchen init`
+    When I successfully run `kitchen init --no-driver`
     Then the exit status should be 0
     And a file named ".gitignore" should not exist
 

--- a/features/step_definitions/gem_steps.rb
+++ b/features/step_definitions/gem_steps.rb
@@ -10,19 +10,27 @@ Given(/^a sandboxed GEM_HOME directory named "(.*?)"$/) do |name|
   @aruba_timeout_seconds = 30
 
   gem_home = Pathname.new(Dir.mktmpdir(name))
-  ENV["GEM_HOME"] = gem_home.to_s
-  ENV["GEM_PATH"] = [gem_home.to_s, ENV["GEM_PATH"]].join(":")
+  aruba.environment["GEM_HOME"] = gem_home.to_s
+  aruba.environment["GEM_PATH"] = [gem_home.to_s, ENV["GEM_PATH"]].join(":")
   @cleanup_dirs << gem_home
 end
 
 Then(/^a gem named "(.*?)" is installed with version "(.*?)"$/) do |name, version|
   unbundlerize do
-    run_simple(unescape("gem list #{name} --version #{version} -i"), true, nil)
+    run_simple(
+      sanitize_text("gem list #{name} --version #{version} -i"),
+      :fail_on_error => true,
+      :exit_timeout => nil
+     )
   end
 end
 
 Then(/^a gem named "(.*?)" is installed$/) do |name|
   unbundlerize do
-    run_simple(unescape("gem list #{name} -i"), true, nil)
+    run_simple(
+      sanitize_text("gem list #{name} -i"),
+      :fail_on_error => true,
+      :exit_timeout => nil
+     )
   end
 end

--- a/features/step_definitions/git_steps.rb
+++ b/features/step_definitions/git_steps.rb
@@ -1,5 +1,5 @@
 # -*- encoding: utf-8 -*-
 
 Given(/I have a git repository/) do
-  create_dir(".git")
+  create_directory(".git")
 end

--- a/features/step_definitions/output_steps.rb
+++ b/features/step_definitions/output_steps.rb
@@ -1,5 +1,5 @@
 # -*- encoding: utf-8 -*-
 
 Then(/^the stdout should match \/([^\/]*)\/$/) do |expected|
-  assert_matching_output(expected, all_stdout)
+  expect(last_command_started).to have_output_on_stdout(Regexp.new(expected))
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -31,12 +31,12 @@ Before do
   @aruba_timeout_seconds = 15
   @cleanup_dirs = []
 
-  Aruba::Processes::InProcess.main_class = ArubaHelper
-  Aruba.process = Aruba::Processes::InProcess
+  aruba.config.command_launcher = :in_process
+  aruba.config.main_class = ArubaHelper
 end
 
 Before("@spawn") do
-  Aruba.process = Aruba::Processes::SpawnProcess
+  aruba.config.command_launcher = :spawn
 end
 
 After do |s|
@@ -47,25 +47,29 @@ After do |s|
 
   # Restore environment variables to their original settings, if they have
   # been saved off
-  ENV.keys.select { |key| key =~ /^_CUKE_/ }.each do |backup_key|
-    ENV[backup_key.sub(/^_CUKE_/, "")] = ENV.delete(backup_key)
-  end
+  env = aruba.environment
+  env.to_h.keys.select { |key| key =~ /^_CUKE_/ }.
+    each do |backup_key|
+      env[backup_key.sub(/^_CUKE_/, "")] = env[backup_key]
+      env.delete(backup_key)
+    end
 
   @cleanup_dirs.each { |dir| FileUtils.rm_rf(dir) }
 end
 
 def backup_envvar(key)
-  ENV["_CUKE_#{key}"] = ENV[key]
+  aruba.environment["_CUKE_#{key}"] = aruba.environment[key]
 end
 
 def restore_envvar(key)
-  ENV[key] = ENV.delete("_CUKE_#{key}")
+  aruba.environment[key] = aruba.environment["_CUKE_#{key}"]
+  aruba.environment.delete("_CUKE_#{key}")
 end
 
 def unbundlerize
   keys = %w[BUNDLER_EDITOR BUNDLE_BIN_PATH BUNDLE_GEMFILE RUBYOPT]
 
-  keys.each { |key| backup_envvar(key); ENV.delete(key) }
+  keys.each { |key| backup_envvar(key); aruba.environment.delete(key) }
   yield
   keys.each { |key| restore_envvar(key) }
 end

--- a/lib/kitchen/generator/driver_create.rb
+++ b/lib/kitchen/generator/driver_create.rb
@@ -87,8 +87,8 @@ module Kitchen
       # @api private
       def initialize_git
         inside(target_dir) do
-          run("git init")
-          run("git add .")
+          run("git init", :capture => true)
+          run("git add .", :capture => true)
         end
       end
 

--- a/lib/kitchen/verifier/shell.rb
+++ b/lib/kitchen/verifier/shell.rb
@@ -70,10 +70,9 @@ module Kitchen
       # @api private
       def sleep_if_set
         config[:sleep].to_i.times do
-          print "."
+          info(".")
           sleep 1
         end
-        puts
       end
 
       def shellout

--- a/spec/kitchen/provisioner/chef_base_spec.rb
+++ b/spec/kitchen/provisioner/chef_base_spec.rb
@@ -141,7 +141,10 @@ describe Kitchen::Provisioner::ChefBase do
 
     before do
       platform.stubs(:shell_type).returns("bourne")
+      Mixlib::Install.stubs(:new).returns(installer)
     end
+
+    let(:installer) { stub(:root => "/rooty", :install_command => "make_it_so") }
 
     let(:cmd) { provisioner.install_command }
 
@@ -154,19 +157,20 @@ describe Kitchen::Provisioner::ChefBase do
     it "returns nil if :require_chef_omnibus is falsey" do
       config[:require_chef_omnibus] = false
 
-      Mixlib::Install.any_instance.expects(:root).never
-      Mixlib::Install.any_instance.expects(:install_command).never
+      installer.expects(:root).never
+      installer.expects(:install_command).never
       cmd.must_equal nil
     end
 
     describe "common behaviour" do
       before do
-        Mixlib::Install.any_instance.expects(:root).at_least_once.returns("/opt/chef")
-        Mixlib::Install.any_instance.expects(:install_command)
+        installer.expects(:root).at_least_once.returns("/opt/chef")
+        installer.expects(:install_command)
       end
 
       it "passes sensible defaults" do
-        Mixlib::Install.any_instance.expects(:initialize).with(default_version, false, install_opts)
+        Mixlib::Install.expects(:new).
+          with(default_version, false, install_opts).returns(installer)
         cmd
       end
 
@@ -174,7 +178,8 @@ describe Kitchen::Provisioner::ChefBase do
         config[:http_proxy] = "http://proxy"
         install_opts[:http_proxy] = "http://proxy"
 
-        Mixlib::Install.any_instance.expects(:initialize).with(default_version, false, install_opts)
+        Mixlib::Install.expects(:new).
+          with(default_version, false, install_opts).returns(installer)
         cmd
       end
 
@@ -182,7 +187,8 @@ describe Kitchen::Provisioner::ChefBase do
         config[:https_proxy] = "https://proxy"
         install_opts[:https_proxy] = "https://proxy"
 
-        Mixlib::Install.any_instance.expects(:initialize).with(default_version, false, install_opts)
+        Mixlib::Install.expects(:new).
+          with(default_version, false, install_opts).returns(installer)
         cmd
       end
 
@@ -192,7 +198,8 @@ describe Kitchen::Provisioner::ChefBase do
         install_opts[:http_proxy] = "http://proxy"
         install_opts[:https_proxy] = "https://proxy"
 
-        Mixlib::Install.any_instance.expects(:initialize).with(default_version, false, install_opts)
+        Mixlib::Install.expects(:new).
+          with(default_version, false, install_opts).returns(installer)
         cmd
       end
 
@@ -200,57 +207,68 @@ describe Kitchen::Provisioner::ChefBase do
         config[:chef_omnibus_url] = "FROM_HERE"
         install_opts[:omnibus_url] = "FROM_HERE"
 
-        Mixlib::Install.any_instance.expects(:initialize).with(default_version, false, install_opts)
+        Mixlib::Install.expects(:new).
+          with(default_version, false, install_opts).returns(installer)
         cmd
       end
 
       it "will install a specific version of chef, if necessary" do
         config[:require_chef_omnibus] = "1.2.3"
 
-        Mixlib::Install.any_instance.expects(:initialize).with("1.2.3", false, install_opts)
+        Mixlib::Install.expects(:new).
+          with("1.2.3", false, install_opts).returns(installer)
         cmd
       end
 
       it "will install a major/minor version of chef, if necessary" do
         config[:require_chef_omnibus] = "11.10"
 
-        Mixlib::Install.any_instance.expects(:initialize).with("11.10", false, install_opts)
+        Mixlib::Install.expects(:new).
+          with("11.10", false, install_opts).returns(installer)
         cmd
       end
 
       it "will install a major version of chef, if necessary" do
         config[:require_chef_omnibus] = "12"
 
-        Mixlib::Install.any_instance.expects(:initialize).with("12", false, install_opts)
+        Mixlib::Install.expects(:new).
+          with("12", false, install_opts).returns(installer)
         cmd
       end
 
       it "will install a downcaased version string of chef, if necessary" do
         config[:require_chef_omnibus] = "10.1.0.RC.1"
 
-        Mixlib::Install.any_instance.expects(:initialize).with("10.1.0.rc.1", false, install_opts)
+        Mixlib::Install.expects(:new).
+          with("10.1.0.rc.1", false, install_opts).returns(installer)
         cmd
       end
 
       it "will install a nightly, if necessary" do
-        config[:require_chef_omnibus] = "12.5.0-current.0+20150721082808.git.14.c91b337-1"
+        config[:require_chef_omnibus] =
+          "12.5.0-current.0+20150721082808.git.14.c91b337-1"
 
-        Mixlib::Install.any_instance.expects(:initialize).with(
-          "12.5.0-current.0+20150721082808.git.14.c91b337-1", false, install_opts)
+        Mixlib::Install.expects(:new).with(
+          "12.5.0-current.0+20150721082808.git.14.c91b337-1",
+          false,
+          install_opts
+        ).returns(installer)
         cmd
       end
 
       it "will install the latest chef, if necessary" do
         config[:require_chef_omnibus] = "latest"
 
-        Mixlib::Install.any_instance.expects(:initialize).with("latest", false, install_opts)
+        Mixlib::Install.expects(:new).
+          with("latest", false, install_opts).returns(installer)
         cmd
       end
 
       it "will install a version of chef, unless it exists" do
         config[:require_chef_omnibus] = true
 
-        Mixlib::Install.any_instance.expects(:initialize).with(default_version, false, install_opts)
+        Mixlib::Install.expects(:new).
+          with(default_version, false, install_opts).returns(installer)
         cmd
       end
 
@@ -259,7 +277,8 @@ describe Kitchen::Provisioner::ChefBase do
         install_opts[:install_flags] = "-P chefdk"
         install_opts[:project] = "chefdk"
 
-        Mixlib::Install.any_instance.expects(:initialize).with(default_version, false, install_opts)
+        Mixlib::Install.expects(:new).
+          with(default_version, false, install_opts).returns(installer)
         cmd
       end
 
@@ -268,14 +287,17 @@ describe Kitchen::Provisioner::ChefBase do
         config[:chef_omnibus_install_options] = "-d /tmp/place"
         install_opts[:install_flags] = "-d /tmp/place"
 
-        Mixlib::Install.any_instance.expects(:initialize).with("11", false, install_opts)
+        Mixlib::Install.expects(:new).
+          with("11", false, install_opts).returns(installer)
         cmd
       end
 
       it "will set the install root" do
         config[:chef_omnibus_root] = "/tmp/test"
         install_opts[:root] = "/tmp/test"
-        Mixlib::Install.any_instance.expects(:initialize).with(default_version, false, install_opts)
+
+        Mixlib::Install.expects(:new).
+          with(default_version, false, install_opts).returns(installer)
         cmd
       end
 
@@ -294,36 +316,39 @@ describe Kitchen::Provisioner::ChefBase do
 
     describe "for bourne shells" do
       before do
-        Mixlib::Install.any_instance.expects(:root).at_least_once.returns("/opt/chef")
-        Mixlib::Install.any_instance.expects(:install_command).returns("my_install_command")
+        installer.expects(:root).at_least_once.returns("/opt/chef")
+        installer.expects(:install_command).returns("my_install_command")
       end
 
       it "prepends sudo for sh commands when :sudo is set" do
         config[:sudo] = true
         config[:sudo_command] = "my_sudo_command"
 
-        Mixlib::Install.any_instance.expects(:initialize).with(default_version, false, install_opts)
+        Mixlib::Install.expects(:new).
+          with(default_version, false, install_opts).returns(installer)
         cmd.must_equal "my_sudo_command my_install_command"
       end
 
       it "does not sudo for sh commands when :sudo is falsey" do
         config[:sudo] = false
 
-        Mixlib::Install.any_instance.expects(:initialize).with(default_version, false, install_opts)
+        Mixlib::Install.expects(:new).
+          with(default_version, false, install_opts).returns(installer)
         cmd.must_equal "my_install_command"
       end
     end
 
     describe "for powershell shells on windows os types" do
       before do
-        Mixlib::Install.any_instance.expects(:root).at_least_once.returns("/opt/chef")
-        Mixlib::Install.any_instance.expects(:install_command)
+        installer.expects(:root).at_least_once.returns("/opt/chef")
+        installer.expects(:install_command)
         platform.stubs(:shell_type).returns("powershell")
         platform.stubs(:os_type).returns("windows")
       end
 
       it "sets the powershell flag for Mixlib::Install" do
-        Mixlib::Install.any_instance.expects(:initialize).with(default_version, true, install_opts)
+        Mixlib::Install.expects(:new).
+          with(default_version, true, install_opts).returns(installer)
         cmd
       end
     end

--- a/test-kitchen.gemspec
+++ b/test-kitchen.gemspec
@@ -36,10 +36,14 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "bundler",   "~> 1.3"
   gem.add_development_dependency "rake"
 
-  gem.add_development_dependency "aruba",     "~> 0.7.0"
+  gem.add_development_dependency "aruba",     "~> 0.11.1"
   gem.add_development_dependency "fakefs",    "~> 0.4"
   gem.add_development_dependency "minitest",  "~> 5.3"
   gem.add_development_dependency "mocha",     "~> 1.1"
+
+  # cucumber is getting explicit and aggresive version pin as the behavior of
+  # the aruba and cucumber apis are tightly coupled
+  gem.add_development_dependency "cucumber",  "~> 2.1.0"
 
   gem.add_development_dependency "countloc",  "~> 0.4"
   gem.add_development_dependency "maruku",    "~> 0.6"


### PR DESCRIPTION
This change updates the Aruba/Cucumber support to current versions and restores the environment/subshell behavior of the Aruba v0.5.x era. Given the difficulty in gettin this (finally) right, the versions of Aruba and Cucumber are more aggressively restricted in the gemspec file.

Further work was done to restore the unit, features, and style test suites to dot-only output. In other words, there should not be any output when the suites are running. I'd like to propose a quality rule for PR reviews:

> "Nothing stops the dots"

If extra newlines, stderr, or other output starts to creep into the dot stream, then something is not right and should be fixed before the merge to master, at least for the current Ruby/RubyGems matrix pair.

Here's what we're talking about:

```
> bundle exec rake
/Users/fnichol/.rubies/ruby-2.2.3/bin/ruby -I"lib:lib" -I"/Users/fnichol/.rubies/ruby-2.2.3/lib/ruby/2.2.0" "/Users/fnichol/.rubies/ruby-2.2.3/lib/ruby/2.2.0/rake/rake_test_loader.rb" "spec/kitchen/base64_stream_spec.rb" "spec/kitchen/cli_spec.rb" "spec/kitchen/collection_spec.rb" "spec/kitchen/color_spec.rb" "spec/kitchen/config_spec.rb" "spec/kitchen/configurable_spec.rb" "spec/kitchen/data_munger_spec.rb" "spec/kitchen/diagnostic_spec.rb" "spec/kitchen/driver/base_spec.rb" "spec/kitchen/driver/dummy_spec.rb" "spec/kitchen/driver/proxy_spec.rb" "spec/kitchen/driver/ssh_base_spec.rb" "spec/kitchen/driver_spec.rb" "spec/kitchen/errors_spec.rb" "spec/kitchen/instance_spec.rb" "spec/kitchen/lazy_hash_spec.rb" "spec/kitchen/loader/yaml_spec.rb" "spec/kitchen/logger_spec.rb" "spec/kitchen/logging_spec.rb" "spec/kitchen/login_command_spec.rb" "spec/kitchen/metadata_chopper_spec.rb" "spec/kitchen/platform_spec.rb" "spec/kitchen/provisioner/base_spec.rb" "spec/kitchen/provisioner/chef_base_spec.rb" "spec/kitchen/provisioner/chef_solo_spec.rb" "spec/kitchen/provisioner/chef_zero_spec.rb" "spec/kitchen/provisioner/dummy_spec.rb" "spec/kitchen/provisioner/shell_spec.rb" "spec/kitchen/provisioner_spec.rb" "spec/kitchen/shell_out_spec.rb" "spec/kitchen/ssh_spec.rb" "spec/kitchen/state_file_spec.rb" "spec/kitchen/suite_spec.rb" "spec/kitchen/transport/base_spec.rb" "spec/kitchen/transport/ssh_spec.rb" "spec/kitchen/transport/winrm_spec.rb" "spec/kitchen/transport_spec.rb" "spec/kitchen/util_spec.rb" "spec/kitchen/verifier/base_spec.rb" "spec/kitchen/verifier/busser_spec.rb" "spec/kitchen/verifier/dummy_spec.rb" "spec/kitchen/verifier/shell_spec.rb" "spec/kitchen/verifier_spec.rb" "spec/kitchen_spec.rb" "spec/support/powershell_max_size_spec.rb"
Run options: --seed 57704

# Running:

.....................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

Finished in 5.237888s, 401.1159 runs/s, 613.2243 assertions/s.

2101 runs, 3212 assertions, 0 failures, 0 errors, 0 skips

/Users/fnichol/.rubies/ruby-2.2.3/bin/ruby -S bundle exec cucumber features -x --format progress --no-color
......................................................................................................................................................................................................................................................................................................................................................................

63 scenarios (63 passed)
358 steps (358 passed)
0m51.967s
Running RuboCop...
Inspecting 120 files
........................................................................................................................

120 files inspected, no offenses detected

## Production Code Stats
…snipped from output…
```