### PR TITLE
Fixing garbled output for chef_zero provisioner

### DIFF
--- a/lib/kitchen/provisioner/chef_zero.rb
+++ b/lib/kitchen/provisioner/chef_zero.rb
@@ -113,7 +113,7 @@ module Kitchen
       # @return [Array<String>] an array of command line arguments
       # @api private
       def chef_client_args
-        level = config[:log_level] == :info ? :auto : config[:log_level]
+        level = config[:log_level] == :info ? :warn : config[:log_level]
         args = [
           "--config #{remote_path_join(config[:root_path], "client.rb")}",
           "--log_level #{level}",

--- a/spec/kitchen/provisioner/chef_zero_spec.rb
+++ b/spec/kitchen/provisioner/chef_zero_spec.rb
@@ -588,8 +588,8 @@ describe Kitchen::Provisioner::ChefZero do
           " --config #{custom_base}client.rb", :partial_line)
       end
 
-      it "sets log level flag on chef-client to auto by default" do
-        cmd.must_match regexify(" --log_level auto", :partial_line)
+      it "sets log level flag on chef-client to warn by default" do
+        cmd.must_match regexify(" --log_level warn", :partial_line)
       end
 
       it "set log level flag for custom level" do


### PR DESCRIPTION
- We always want to specify the WARN level, as chef-client
  behaves differently if on a TTY or not.