### PR TITLE
fix chef install on non-windows

### DIFF
--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -132,7 +132,7 @@ module Kitchen
         # Passing "true" to mixlib-install currently breaks the windows metadata_url
         # TODO: remove this line once https://github.com/chef/mixlib-install/pull/22
         # is accepted and released
-        version = "" if version == "true"
+        version = "" if version == "true" && powershell_shell?
 
         installer = Mixlib::Install.new(version, powershell_shell?, install_options)
         config[:chef_omnibus_root] = installer.root

--- a/spec/kitchen/provisioner/chef_base_spec.rb
+++ b/spec/kitchen/provisioner/chef_base_spec.rb
@@ -27,7 +27,7 @@ describe Kitchen::Provisioner::ChefBase do
   let(:logger)          { Logger.new(logged_output) }
   let(:platform)        { stub(:os_type => nil) }
   let(:suite)           { stub(:name => "fries") }
-  let(:default_version) { "" }
+  let(:default_version) { "true" }
 
   let(:config) do
     { :test_base_path => "/basist", :kitchen_root => "/rooty" }
@@ -348,7 +348,7 @@ describe Kitchen::Provisioner::ChefBase do
 
       it "sets the powershell flag for Mixlib::Install" do
         Mixlib::Install.expects(:new).
-          with(default_version, true, install_opts).returns(installer)
+          with("", true, install_opts).returns(installer)
         cmd
       end
     end


### PR DESCRIPTION
It appears that my commit https://github.com/test-kitchen/test-kitchen/commit/7318fa5bb93319b68303b0f93302f1c35bb8e562 added a hack to fix windows chef installs due to an issue in mixlib-install but broke non-windows in the process. This PR rectifies breaks non-windows.

