### PR TITLE
Add support for --profile-ruby

### DIFF
--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -45,6 +45,7 @@ module Kitchen
       default_config :attributes, {}
       default_config :config_path, nil
       default_config :log_file, nil
+      default_config :profile_ruby, false
       default_config :cookbook_files_glob, %w[
         README.* metadata.{json,rb}
         attributes/**/* definitions/**/* files/**/* libraries/**/*

--- a/lib/kitchen/provisioner/chef_solo.rb
+++ b/lib/kitchen/provisioner/chef_solo.rb
@@ -59,6 +59,7 @@ module Kitchen
           "--json-attributes #{remote_path_join(config[:root_path], "dna.json")}"
         ]
         args << "--logfile #{config[:log_file]}" if config[:log_file]
+        args << "--profile-ruby" if config[:profile_ruby]
 
         prefix_command(
           wrap_shell_code(

--- a/lib/kitchen/provisioner/chef_zero.rb
+++ b/lib/kitchen/provisioner/chef_zero.rb
@@ -88,6 +88,7 @@ module Kitchen
       #
       # @param args [Array<String>] array of flags
       # @api private
+      # rubocop:disable Metrics/CyclomaticComplexity
       def add_optional_chef_client_args!(args)
         if config[:json_attributes]
           json = remote_path_join(config[:root_path], "dna.json")
@@ -106,7 +107,11 @@ module Kitchen
         if config[:chef_zero_port]
           args << "--chef-zero-port #{config[:chef_zero_port]}"
         end
+        if config[:profile_ruby]
+          args << "--profile-ruby"
+        end
       end
+      # rubocop:enable Metrics/CyclomaticComplexity
 
       # Returns an Array of command line arguments for the chef client.
       #

--- a/spec/kitchen/provisioner/chef_solo_spec.rb
+++ b/spec/kitchen/provisioner/chef_solo_spec.rb
@@ -424,6 +424,19 @@ describe Kitchen::Provisioner::ChefSolo do
 
         cmd.must_match regexify(" --logfile /a/out.log", :partial_line)
       end
+
+      it "sets profile-ruby flag when config element is set" do
+        config[:profile_ruby] = true
+
+        cmd.must_match regexify(
+          " --profile-ruby", :partial_line)
+      end
+
+      it "does not set profile-ruby flag when config element is falsey" do
+        config[:profile_ruby] = false
+
+        cmd.wont_match regexify(" --profile-ruby", :partial_line)
+      end
     end
 
     describe "for powershell shells on windows os types" do

--- a/spec/kitchen/provisioner/chef_zero_spec.rb
+++ b/spec/kitchen/provisioner/chef_zero_spec.rb
@@ -686,6 +686,19 @@ describe Kitchen::Provisioner::ChefZero do
 
           cmd.wont_match regexify(" --chef-zero-port ", :partial_line)
         end
+
+        it "sets profile-ruby flag when config element is set" do
+          config[:profile_ruby] = true
+
+          cmd.must_match regexify(
+            " --profile-ruby", :partial_line)
+        end
+
+        it "does not set profile-ruby flag when config element is falsey" do
+          config[:profile_ruby] = false
+
+          cmd.wont_match regexify(" --profile-ruby", :partial_line)
+        end
       end
       # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 


### PR DESCRIPTION
Add a special option to the chef provisioners (both solo and zero) for supporting the new --profile-ruby argument [added in 12.6.0](https://github.com/chef/chef/blob/master/CHANGELOG.md#1260) to the chef client. This is extremely useful for profiling Chef when doing development.