### PR TITLE
Deprecating winrm-tansport and winrm-s gems

### DIFF
--- a/test-kitchen.gemspec
+++ b/test-kitchen.gemspec
@@ -33,8 +33,8 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "pry"
   gem.add_development_dependency "pry-byebug"
   gem.add_development_dependency "pry-stack_explorer"
-  gem.add_development_dependency "winrm-transport", "~> 1.0", ">= 1.0.3"
-  gem.add_development_dependency "winrm-s", "~> 0.3"
+  gem.add_development_dependency "winrm", "~> 1.6"
+  gem.add_development_dependency "winrm-fs", "~> 0.3"
 
   gem.add_development_dependency "bundler",   "~> 1.3"
   gem.add_development_dependency "rake"

--- a/testing_windows.md
+++ b/testing_windows.md
@@ -21,6 +21,8 @@ platforms:
       box: mwrock/Windows2012R2
 ```
 
+For other windows OS versions, you can spin up instances in your favorite cloud provider or create your own vagrant box. The windows packer templates found in the [boxcutter repo](https://github.com/boxcutter/windows) provide a good place to start here.
+
 ### `bundle install`
 
 From the root of your cookbook directory run `bundle install`

--- a/testing_windows.md
+++ b/testing_windows.md
@@ -6,10 +6,11 @@ The [windows cookbook](https://github.com/chef-cookbooks/windows) is a grand cho
 ### Edit the `Gemfile` 
 Ensure that the cookbook's root directory includes a `Gemfile` that includes your local test-kitchen repo on the branch you would like to test as well as required windows-only needed gems:
 ```
-gem 'test-kitchen', path: '../test-kitchen'
+gem 'test-kitchen', git: 'https://github.com/mwrock/test-kitchen', branch: 'winrm-fs'
 gem 'winrm', '~> 1.6'
 gem 'winrm-fs', '~> 0.3'
 ```
+The above would target the `winrm-fs` branch in mwrock's test-kitchen repo.
 
 ### Finding a windows image
 Make sure you have a windows test image handy. You can use your favorite cloud or hypervisor. An easy vagrant option is `mwrock/Windows2012R2` which is publicly available on atlas. To use that, edit your cookbook's `.kitchen.yml` to include:

--- a/testing_windows.md
+++ b/testing_windows.md
@@ -4,7 +4,7 @@
 The [windows cookbook](https://github.com/chef-cookbooks/windows) is a grand choice.
 
 ### Edit the `Gemfile` 
-Ensure that the cookbook's root directory includes a `Gemfile` that includes your local test-kitchen repo as well as required windows-only needed gems:
+Ensure that the cookbook's root directory includes a `Gemfile` that includes your local test-kitchen repo on the branch you would like to test as well as required windows-only needed gems:
 ```
 gem 'test-kitchen', path: '../test-kitchen'
 gem 'winrm', '~> 1.6'
@@ -16,7 +16,7 @@ Make sure you have a windows test image handy. You can use your favorite cloud o
 ```
 platforms:
   - name: win2012r2-standard
-    driver_config:
+    driver:
       box: mwrock/Windows2012R2
 ```
 

--- a/testing_windows.md
+++ b/testing_windows.md
@@ -1,0 +1,34 @@
+## Testing test-kitchen contributions against windows test instances
+
+### Choose a windows based cookbook
+The [windows cookbook](https://github.com/chef-cookbooks/windows) is a grand choice.
+
+### Edit the `Gemfile` 
+Ensure that the cookbook's root directory includes a `Gemfile` that includes your local test-kitchen repo as well as required windows-only needed gems:
+```
+gem 'test-kitchen', path: '../test-kitchen'
+gem 'winrm', '~> 1.6'
+gem 'winrm-fs', '~> 0.3'
+```
+
+### Finding a windows image
+Make sure you have a windows test image handy. You can use your favorite cloud or hypervisor. An easy vagrant option is `mwrock/Windows2012R2` which is publicly available on atlas. To use that, edit your cookbook's `.kitchen.yml` to include:
+```
+platforms:
+  - name: win2012r2-standard
+    driver_config:
+      box: mwrock/Windows2012R2
+```
+
+### `bundle install`
+
+From the root of your cookbook directory run `bundle install`
+
+### Converge and test!
+
+Now run `bundle exec kitchen verify`.
+
+If your cookbook has multiple suites (like the windows cookbook), you likely just want to run one:
+```
+bundle exec kitchen verify feature
+```


### PR DESCRIPTION
The winrm-transport gem is being deprecated (see https://github.com/test-kitchen/winrm-transport/issues/16) and its behavior is being merged into the winrm (see pr https://github.com/WinRb/WinRM/pull/167) and winrm-fs (see pr https://github.com/WinRb/winrm-fs/pull/28) gems.

In addition to the winrm-transport, some of the logic in `Kitchen::Transport::WinRM` was also moved to the core winrm gem.