### PR TITLE
Set version to 1.5.0

### DIFF
--- a/lib/kitchen/version.rb
+++ b/lib/kitchen/version.rb
@@ -17,6 +17,5 @@
 # limitations under the License.
 
 module Kitchen
-
-  VERSION = "1.5.0.rc.1"
+  VERSION = "1.5.0"
 end


### PR DESCRIPTION
Having a non-RC version is important to make bundle installs in omnibus work (in the chef-dk). We will not *release* 1.5.0 until we actually tag it.