### PR TITLE
Updating to the latest release of net-ssh to consume https://github.com/net-ssh/net-ssh/pull/280

### DIFF
--- a/test-kitchen.gemspec
+++ b/test-kitchen.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "mixlib-shellout", ">= 1.2", "< 3.0"
   gem.add_dependency "net-scp",         "~> 1.1"
-  gem.add_dependency "net-ssh",         "~> 2.7", "< 2.10"
+  gem.add_dependency "net-ssh",         "~> 3.0"
   gem.add_dependency "safe_yaml",       "~> 1.0"
   gem.add_dependency "thor",            "~> 0.18"
   gem.add_dependency "mixlib-install",  "~> 0.7"


### PR DESCRIPTION
\cc @fnichol @sersut

Merging this to master here helps fix a lot of our dependency issues in the ChefDK build.  Then we can test it in the ChefDK current channel builds before releasing it in 1.5.0