### PR TITLE
The netssh 3.0 update returns a different error on connection timeout than 2.9.2 did, adding it to the retry list

### DIFF
--- a/Gemfile.proxy_tests
+++ b/Gemfile.proxy_tests
@@ -2,5 +2,4 @@
 eval_gemfile File.join(File.dirname(__FILE__), "Gemfile")
 
 gem "kitchen-ec2"
-# TODO when this is released in Chef 12.6.0 we need to depend on that
-gem "chef-config", github: "chef/chef", submodules: true
+gem "chef-config"

--- a/lib/kitchen/ssh.rb
+++ b/lib/kitchen/ssh.rb
@@ -192,7 +192,7 @@ module Kitchen
       rescue_exceptions = [
         Errno::EACCES, Errno::EADDRINUSE, Errno::ECONNREFUSED,
         Errno::ECONNRESET, Errno::ENETUNREACH, Errno::EHOSTUNREACH,
-        Net::SSH::Disconnect, Net::SSH::AuthenticationFailed
+        Net::SSH::Disconnect, Net::SSH::AuthenticationFailed, Net::SSH::ConnectionTimeout
       ]
       retries = options[:ssh_retries] || 3
 

--- a/lib/kitchen/transport/ssh.rb
+++ b/lib/kitchen/transport/ssh.rb
@@ -165,7 +165,8 @@ module Kitchen
         RESCUE_EXCEPTIONS_ON_ESTABLISH = [
           Errno::EACCES, Errno::EADDRINUSE, Errno::ECONNREFUSED, Errno::ETIMEDOUT,
           Errno::ECONNRESET, Errno::ENETUNREACH, Errno::EHOSTUNREACH,
-          Net::SSH::Disconnect, Net::SSH::AuthenticationFailed, Timeout::Error
+          Net::SSH::Disconnect, Net::SSH::AuthenticationFailed, Net::SSH::ConnectionTimeout,
+          Timeout::Error
         ].freeze
 
         # @return [Integer] how many times to retry when failing to execute

--- a/spec/kitchen/ssh_spec.rb
+++ b/spec/kitchen/ssh_spec.rb
@@ -138,7 +138,7 @@ describe Kitchen::SSH do
     [
       Errno::EACCES, Errno::EADDRINUSE, Errno::ECONNREFUSED,
       Errno::ECONNRESET, Errno::ENETUNREACH, Errno::EHOSTUNREACH,
-      Net::SSH::Disconnect, Net::SSH::AuthenticationFailed
+      Net::SSH::Disconnect, Net::SSH::AuthenticationFailed, Net::SSH::ConnectionTimeout
     ].each do |klass|
       describe "raising #{klass}" do
 

--- a/spec/kitchen/transport/ssh_spec.rb
+++ b/spec/kitchen/transport/ssh_spec.rb
@@ -668,7 +668,8 @@ describe Kitchen::Transport::Ssh::Connection do
     [
       Errno::EACCES, Errno::EADDRINUSE, Errno::ECONNREFUSED, Errno::ETIMEDOUT,
       Errno::ECONNRESET, Errno::ENETUNREACH, Errno::EHOSTUNREACH,
-      Net::SSH::Disconnect, Net::SSH::AuthenticationFailed, Timeout::Error
+      Net::SSH::Disconnect, Net::SSH::AuthenticationFailed, Net::SSH::ConnectionTimeout,
+      Timeout::Error
     ].each do |klass|
       describe "raising #{klass}" do
 


### PR DESCRIPTION
\cc @cheeseplus 