### PR TITLE
Socksify

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,13 @@ More verbose logging (for both test-kitchen and the chef-solo/chef-zero provisio
 $ kitchen test -l debug
 ```
 
+## Using Test Kitchen from behind a SOCKS proxy
+
+You can specify the following parameters to use Test Kitchen with remote hosts (e.g. EC2) from behind a firewall:
+socks_version = The SOCKS version supported by the server (either 4 or 5)
+socks_server  = The DNS name or IP of the SOCKS server
+socks_port    = The port of the SOCKS server
+
 ## Documentation
 
 Documentation is being added on the Test Kitchen [website][website]. Please

--- a/test-kitchen.gemspec
+++ b/test-kitchen.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "safe_yaml",       "~> 1.0"
   gem.add_dependency "thor",            "~> 0.18"
   gem.add_dependency "mixlib-install",  "~> 0.7"
+  gem.add_dependency "socksify",        "~> 1.5"
 
   gem.add_development_dependency "pry"
   gem.add_development_dependency "pry-byebug"


### PR DESCRIPTION
Replacing PR #463 

This pull request adds SOCKS support to Test Kitchen, so that you can spin up EC2 instances from behind a firewall.

This is only a 'partial' pull request, it'll need Pull Request #426 to be included, which adds the ability to add a ProxyCommand argument to the SSH command. That pull request won't work with EC2, unless the changes in this pull request are included as well.

This does introduce a dependency on 'socksify'.

Please let me know if this is a viable pull request. We, along with many others in big enterprise land live behind firewalls. Without this, Test Kitchen is not really all that usable to us.
