### PR TITLE
Because net/ssh is no longer including timeout.rb, we need to so that Ruby doesn't think Timeout belongs to the TK class

### DIFF
--- a/lib/kitchen/transport/ssh.rb
+++ b/lib/kitchen/transport/ssh.rb
@@ -20,6 +20,7 @@ require "kitchen"
 
 require "net/ssh"
 require "net/scp"
+require "timeout"
 
 module Kitchen
 


### PR DESCRIPTION
```
E, [2016-01-21T09:18:55.684419 #5666] ERROR -- Kitchen: ---Nested Exception---
E, [2016-01-21T09:18:55.684431 #5666] ERROR -- Kitchen: Class: NameError
E, [2016-01-21T09:18:55.684442 #5666] ERROR -- Kitchen: Message: uninitialized constant Kitchen::Transport::Ssh::Connection::Timeout
E, [2016-01-21T09:18:55.684453 #5666] ERROR -- Kitchen: ------Backtrace-------
E, [2016-01-21T09:18:55.684464 #5666] ERROR -- Kitchen: /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/test-kitchen-1.5.0/lib/kitchen/transport.rb:48:in `rescue in for_plugin'
E, [2016-01-21T09:18:55.684475 #5666] ERROR -- Kitchen: /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/test-kitchen-1.5.0/lib/kitchen/transport.rb:40:in `for_plugin'
E, [2016-01-21T09:18:55.684489 #5666] ERROR -- Kitchen: /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/test-kitchen-1.5.0/lib/kitchen/config.rb:307:in `new_transport'
E, [2016-01-21T09:18:55.684501 #5666] ERROR -- Kitchen: /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/test-kitchen-1.5.0/lib/kitchen/config.rb:248:in `new_instance'
E, [2016-01-21T09:18:55.684512 #5666] ERROR -- Kitchen: /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/test-kitchen-1.5.0/lib/kitchen/config.rb:139:in `block in build_instances'
E, [2016-01-21T09:18:55.684523 #5666] ERROR -- Kitchen: /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/test-kitchen-1.5.0/lib/kitchen/config.rb:138:in `map'
E, [2016-01-21T09:18:55.684556 #5666] ERROR -- Kitchen: /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/test-kitchen-1.5.0/lib/kitchen/config.rb:138:in `with_index'
E, [2016-01-21T09:18:55.684568 #5666] ERROR -- Kitchen: /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/test-kitchen-1.5.0/lib/kitchen/config.rb:138:in `build_instances'
E, [2016-01-21T09:18:55.684583 #5666] ERROR -- Kitchen: /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/test-kitchen-1.5.0/lib/kitchen/config.rb:114:in `instances'
E, [2016-01-21T09:18:55.684595 #5666] ERROR -- Kitchen: /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/test-kitchen-1.5.0/lib/kitchen/command.rb:115:in `filtered_instances'
E, [2016-01-21T09:18:55.684606 #5666] ERROR -- Kitchen: /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/test-kitchen-1.5.0/lib/kitchen/command.rb:145:in `parse_subcommand'
E, [2016-01-21T09:18:55.684617 #5666] ERROR -- Kitchen: /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/test-kitchen-1.5.0/lib/kitchen/command/list.rb:32:in `call'
E, [2016-01-21T09:18:55.684628 #5666] ERROR -- Kitchen: /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/test-kitchen-1.5.0/lib/kitchen/cli.rb:56:in `perform'
E, [2016-01-21T09:18:55.684639 #5666] ERROR -- Kitchen: /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/test-kitchen-1.5.0/lib/kitchen/cli.rb:116:in `list'
E, [2016-01-21T09:18:55.684650 #5666] ERROR -- Kitchen: /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
E, [2016-01-21T09:18:55.684710 #5666] ERROR -- Kitchen: /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
E, [2016-01-21T09:18:55.684723 #5666] ERROR -- Kitchen: /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/test-kitchen-1.5.0/lib/kitchen/cli.rb:321:in `invoke_task'
E, [2016-01-21T09:18:55.684734 #5666] ERROR -- Kitchen: /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
E, [2016-01-21T09:18:55.684745 #5666] ERROR -- Kitchen: /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
E, [2016-01-21T09:18:55.684756 #5666] ERROR -- Kitchen: /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/test-kitchen-1.5.0/bin/kitchen:13:in `block in <top (required)>'
E, [2016-01-21T09:18:55.684767 #5666] ERROR -- Kitchen: /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/test-kitchen-1.5.0/lib/kitchen/errors.rb:154:in `with_friendly_errors'
E, [2016-01-21T09:18:55.684785 #5666] ERROR -- Kitchen: /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/test-kitchen-1.5.0/bin/kitchen:13:in `<top (required)>'
E, [2016-01-21T09:18:55.684798 #5666] ERROR -- Kitchen: /opt/chefdk/bin/kitchen:17:in `load'
E, [2016-01-21T09:18:55.684809 #5666] ERROR -- Kitchen: /opt/chefdk/bin/kitchen:17:in `<main>'
E, [2016-01-21T09:18:55.684820 #5666] ERROR -- Kitchen: ----------------------
```

We were seeing this error in a lot of cookbooks using the current channel ChefDK.  It was caused by the following:

```
[1] pry(Kitchen::Transport)> e2
=> #<NameError: uninitialized constant Kitchen::Transport::Ssh::Connection::Timeout>
[2] pry(Kitchen::Transport)> e2.backtrace
=> ["/opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/test-kitchen-1.5.0/lib/kitchen/transport/ssh.rb:178:in `<class:Connection>'",
 "/opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/test-kitchen-1.5.0/lib/kitchen/transport/ssh.rb:103:in `<class:Ssh>'",
 "/opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/test-kitchen-1.5.0/lib/kitchen/transport/ssh.rb:37:in `<module:Transport>'",
 "/opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/test-kitchen-1.5.0/lib/kitchen/transport/ssh.rb:26:in `<module:Kitchen>'",
 "/opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/test-kitchen-1.5.0/lib/kitchen/transport/ssh.rb:24:in `<top (required)>'",
 "/opt/chefdk/embedded/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:54:in `require'",
 "/opt/chefdk/embedded/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:54:in `require'",
 "/opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/test-kitchen-1.5.0/lib/kitchen/transport.rb:40:in `for_plugin'",
 "/opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/test-kitchen-1.5.0/lib/kitchen/config.rb:307:in `new_transport'",
 "/opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/test-kitchen-1.5.0/lib/kitchen/config.rb:248:in `new_instance'",
 "/opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/test-kitchen-1.5.0/lib/kitchen/config.rb:139:in `block in build_instances'",
 "/opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/test-kitchen-1.5.0/lib/kitchen/config.rb:138:in `map'",
 "/opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/test-kitchen-1.5.0/lib/kitchen/config.rb:138:in `with_index'",
 "/opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/test-kitchen-1.5.0/lib/kitchen/config.rb:138:in `build_instances'",
 "/opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/test-kitchen-1.5.0/lib/kitchen/config.rb:114:in `instances'",
 "/opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/test-kitchen-1.5.0/lib/kitchen/command.rb:115:in `filtered_instances'",
 "/opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/test-kitchen-1.5.0/lib/kitchen/command.rb:145:in `parse_subcommand'",
 "/opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/test-kitchen-1.5.0/lib/kitchen/command/list.rb:32:in `call'",
 "/opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/test-kitchen-1.5.0/lib/kitchen/cli.rb:56:in `perform'",
 "/opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/test-kitchen-1.5.0/lib/kitchen/cli.rb:116:in `list'",
 "/opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'",
 "/opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'",
 "/opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/test-kitchen-1.5.0/lib/kitchen/cli.rb:321:in `invoke_task'",
 "/opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'",
 "/opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'",
 "/opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/test-kitchen-1.5.0/bin/kitchen:13:in `block in <top (required)>'",
 "/opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/test-kitchen-1.5.0/lib/kitchen/errors.rb:154:in `with_friendly_errors'",
 "/opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/test-kitchen-1.5.0/bin/kitchen:13:in `<top (required)>'",
 "/opt/chefdk/bin/kitchen:17:in `load'",
 "/opt/chefdk/bin/kitchen:17:in `<main>'"]
```

This is a followup to https://github.com/test-kitchen/test-kitchen/pull/912.  We weren't seeing it in unit test failures because I'm sure something else was including `timeout` during the unit tests runs.

\cc @tas50 @cheeseplus @smurawski @adamleff 