### PR TITLE
Make chef-config an optional dependency.

### DIFF
--- a/lib/kitchen/command/driver_discover.rb
+++ b/lib/kitchen/command/driver_discover.rb
@@ -40,7 +40,9 @@ module Kitchen
         # We are introducing the idea of using the Chef configuration as a
         # unified config for all the ChefDK tools.  The first practical
         # implementation of this is 1 location to setup proxy configurations.
-        ChefConfig::WorkstationConfigLoader.new(options[:chef_config_path]).load if defined?(ChefConfig::WorkstationConfigLoader)
+        if defined?(ChefConfig::WorkstationConfigLoader)
+          ChefConfig::WorkstationConfigLoader.new(options[:chef_config_path]).load
+        end
         ChefConfig::Config.export_proxies if defined?(ChefConfig::Config.export_proxies)
 
         specs = fetch_gem_specs.sort { |x, y| x[0] <=> y[0] }

--- a/lib/kitchen/command/driver_discover.rb
+++ b/lib/kitchen/command/driver_discover.rb
@@ -19,8 +19,12 @@
 require "kitchen/command"
 
 require "rubygems/spec_fetcher"
-require "chef-config/config"
-require "chef-config/workstation_config_loader"
+begin
+  require "chef-config/config"
+  require "chef-config/workstation_config_loader"
+rescue LoadError
+  # This space left intentionally blank.
+end
 
 module Kitchen
 
@@ -36,8 +40,8 @@ module Kitchen
         # We are introducing the idea of using the Chef configuration as a
         # unified config for all the ChefDK tools.  The first practical
         # implementation of this is 1 location to setup proxy configurations.
-        ChefConfig::WorkstationConfigLoader.new(options[:chef_config_path]).load
-        ChefConfig::Config.export_proxies
+        ChefConfig::WorkstationConfigLoader.new(options[:chef_config_path]).load if defined?(ChefConfig::WorkstationConfigLoader)
+        ChefConfig::Config.export_proxies if defined?(ChefConfig::Config.export_proxies)
 
         specs = fetch_gem_specs.sort { |x, y| x[0] <=> y[0] }
         specs = specs[0, 49].push(["...", "..."]) if specs.size > 49

--- a/lib/kitchen/command/driver_discover.rb
+++ b/lib/kitchen/command/driver_discover.rb
@@ -22,7 +22,7 @@ require "rubygems/spec_fetcher"
 begin
   require "chef-config/config"
   require "chef-config/workstation_config_loader"
-rescue LoadError
+rescue LoadError # rubocop:disable Lint/HandleExceptions
   # This space left intentionally blank.
 end
 

--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -29,7 +29,7 @@ require "mixlib/install"
 begin
   require "chef-config/config"
   require "chef-config/workstation_config_loader"
-rescue LoadError
+rescue LoadError # rubocop:disable Lint/HandleExceptions
   # This space left intentionally blank.
 end
 

--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -26,8 +26,12 @@ require "kitchen/provisioner/chef/common_sandbox"
 require "kitchen/provisioner/chef/librarian"
 require "kitchen/util"
 require "mixlib/install"
-require "chef-config/config"
-require "chef-config/workstation_config_loader"
+begin
+  require "chef-config/config"
+  require "chef-config/workstation_config_loader"
+rescue LoadError
+  # This space left intentionally blank.
+end
 
 module Kitchen
 
@@ -96,10 +100,10 @@ module Kitchen
       def initialize(config = {})
         super(config)
 
-        ChefConfig::WorkstationConfigLoader.new(config[:config_path]).load
+        ChefConfig::WorkstationConfigLoader.new(config[:config_path]).load if defined?(ChefConfig::WorkstationConfigLoader)
         # This exports any proxy config present in the Chef config to
         # appropriate environment variables, which Test Kitchen respects
-        ChefConfig::Config.export_proxies
+        ChefConfig::Config.export_proxies if defined?(ChefConfig::Config.export_proxies)
       end
 
       # (see Base#create_sandbox)

--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -100,7 +100,9 @@ module Kitchen
       def initialize(config = {})
         super(config)
 
-        ChefConfig::WorkstationConfigLoader.new(config[:config_path]).load if defined?(ChefConfig::WorkstationConfigLoader)
+        if defined?(ChefConfig::WorkstationConfigLoader)
+          ChefConfig::WorkstationConfigLoader.new(config[:config_path]).load
+        end
         # This exports any proxy config present in the Chef config to
         # appropriate environment variables, which Test Kitchen respects
         ChefConfig::Config.export_proxies if defined?(ChefConfig::Config.export_proxies)

--- a/test-kitchen.gemspec
+++ b/test-kitchen.gemspec
@@ -29,7 +29,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency "safe_yaml",       "~> 1.0"
   gem.add_dependency "thor",            "~> 0.18"
   gem.add_dependency "mixlib-install",  "~> 0.7"
-  gem.add_dependency "chef-config",     ">= 12.5.1"
 
   gem.add_development_dependency "pry"
   gem.add_development_dependency "pry-byebug"


### PR DESCRIPTION
This helps with working with older versions of Chef or using Test Kitchen in a non-Chef environment.

Ping @cheeseplus for review.