### PR TITLE
bypass execution policy when running powershell script files

### DIFF
--- a/lib/kitchen/transport/winrm.rb
+++ b/lib/kitchen/transport/winrm.rb
@@ -425,7 +425,7 @@ module Kitchen
             target_path = File.join("$env:TEMP", "kitchen")
             upload(script_path, target_path)
 
-            %{& "#{File.join(target_path, script_name)}"}
+            %{powershell -ExecutionPolicy Bypass -File "#{File.join(target_path, script_name)}"}
           ensure
             FileUtils.rmtree(temp_dir)
           end

--- a/spec/kitchen/transport/winrm_spec.rb
+++ b/spec/kitchen/transport/winrm_spec.rb
@@ -742,9 +742,9 @@ describe Kitchen::Transport::Winrm::Connection do
 
       before do
         executor.expects(:open).returns("shell-123")
-        executor.expects(:run_powershell_script).
-          with(%{& "$env:TEMP/kitchen/coolbeans-long_script.ps1"}).
-          yields("ok\n", nil).returns(response)
+        executor.expects(:run_powershell_script).with(
+          %{powershell -ExecutionPolicy Bypass -File "$env:TEMP/kitchen/coolbeans-long_script.ps1"}
+        ).yields("ok\n", nil).returns(response)
       end
 
       it "uploads the long command" do


### PR DESCRIPTION
If a test instance is using the default execution policy, executing unsigned script files will fail. This bypasses that policy just for the files that test-kitchen pushes