### PR TITLE
Chef's default log level is warn, not info.

### DIFF
--- a/lib/kitchen/provisioner/chef_solo.rb
+++ b/lib/kitchen/provisioner/chef_solo.rb
@@ -47,7 +47,7 @@ module Kitchen
 
       # (see Base#run_command)
       def run_command # rubocop:disable Metrics/AbcSize
-        level = config[:log_level] == :info ? :auto : config[:log_level]
+        level = config[:log_level] == :warn ? :auto : config[:log_level]
 
         cmd = sudo(config[:chef_solo_path]).dup.
           tap { |str| str.insert(0, "& ") if powershell_shell? }


### PR DESCRIPTION
Fixes #529