### PR TITLE
use winrm transport as alternative detection method

### DIFF
--- a/lib/kitchen/platform.rb
+++ b/lib/kitchen/platform.rb
@@ -52,7 +52,9 @@ module Kitchen
     end
 
     def windows?(options)
-      @name.downcase =~ /^win/ || (!options[:transport].nil? && options[:transport][:name] == 'winrm')
+      @name.downcase =~ /^win/ || (
+        !options[:transport].nil? && options[:transport][:name] == "winrm"
+      )
     end
 
     # Returns a Hash of configuration and other useful diagnostic information.

--- a/lib/kitchen/platform.rb
+++ b/lib/kitchen/platform.rb
@@ -44,11 +44,15 @@ module Kitchen
         raise ClientError, "Platform#new requires option :name"
       end
       @os_type = options.fetch(:os_type) do
-        @name.downcase =~ /^win/ ? "windows" : "unix"
+        windows?(options) ? "windows" : "unix"
       end
       @shell_type = options.fetch(:shell_type) do
-        @name.downcase =~ /^win/ ? "powershell" : "bourne"
+        windows?(options) ? "powershell" : "bourne"
       end
+    end
+
+    def windows?(options)
+      @name.downcase =~ /^win/ || (!options[:transport].nil? && options[:transport][:name] == 'winrm')
     end
 
     # Returns a Hash of configuration and other useful diagnostic information.


### PR DESCRIPTION
I use a .kitchen.yml like

```
---
driver:
  name: vagrant

provisioner:
  name: chef_zero
  require_chef_omnibus:  12.6.0

verifier:
  name: inspec

platforms:
  - name: chris/windows-server-2008r2-standard
    transport:
      name: winrm
      username: administrator
  - name: chris/windows-server-2012r2-standard
    transport:
      name: winrm
      username: administrator

suites:
  - name: default
    run_list:
      - recipe[os_prepare]
    attributes:
```

Instead of renaming the vm, I leave the box as is and define the transport details. Defining the transport `winrm` should be enough to know that it is windows.
