### PR TITLE
Fix sudo dependency

### DIFF
--- a/lib/kitchen/provisioner/base.rb
+++ b/lib/kitchen/provisioner/base.rb
@@ -205,10 +205,18 @@ module Kitchen
       # Conditionally prefixes a command with a sudo command.
       #
       # @param command [String] command to be prefixed
-      # @return [String] the command, conditionaly prefixed with sudo
+      # @return [String] the command, conditionally prefixed with sudo
       # @api private
       def sudo(script)
-        config[:sudo] ? "#{config[:sudo_command]} #{script}" : script
+        "#{sudo_command} #{script}".lstrip
+      end
+
+      # Returns the sudo command to use or empty string if sudo is not configured
+      #
+      # @return [String] the sudo command if sudo config is true
+      # @api private
+      def sudo_command
+        config[:sudo] ? config[:sudo_command].to_s : ''
       end
 
       # Conditionally prefixes a command with a command prefix.

--- a/lib/kitchen/provisioner/base.rb
+++ b/lib/kitchen/provisioner/base.rb
@@ -216,7 +216,7 @@ module Kitchen
       # @return [String] the sudo command if sudo config is true
       # @api private
       def sudo_command
-        config[:sudo] ? config[:sudo_command].to_s : ''
+        config[:sudo] ? config[:sudo_command].to_s : ""
       end
 
       # Conditionally prefixes a command with a command prefix.

--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -155,7 +155,8 @@ module Kitchen
         {
           :omnibus_url => config[:chef_omnibus_url],
           :project => project.nil? ? nil : project[1],
-          :install_flags => config[:chef_omnibus_install_options]
+          :install_flags => config[:chef_omnibus_install_options],
+          :sudo_command => sudo_command
         }.tap do |opts|
           opts[:root] = config[:chef_omnibus_root] if config.key? :chef_omnibus_root
           opts[:http_proxy] = config[:http_proxy] if config.key? :http_proxy

--- a/spec/kitchen/provisioner/base_spec.rb
+++ b/spec/kitchen/provisioner/base_spec.rb
@@ -330,6 +330,39 @@ describe Kitchen::Provisioner::Base do
     end
   end
 
+  describe "#sudo_command" do
+
+    describe "with :sudo set" do
+
+      before { config[:sudo] = true }
+
+      it "returns the default sudo_command" do
+        provisioner.send(:sudo_command).must_equal("sudo -E")
+      end
+
+      it "returns the custom sudo_command" do
+        config[:sudo_command] = "mysudo"
+
+        provisioner.send(:sudo_command).must_equal("mysudo")
+      end
+    end
+
+    describe "with :sudo falsey" do
+
+      before { config[:sudo] = false }
+
+      it "returns empty string for default sudo_command" do
+        provisioner.send(:sudo_command).must_equal("")
+      end
+
+      it "returns empty string for custom sudo_command" do
+        config[:sudo_command] = "mysudo"
+
+        provisioner.send(:sudo_command).must_equal("")
+      end
+    end
+  end
+
   describe "#prefix_command" do
 
     describe "with :command_prefix set" do

--- a/spec/kitchen/provisioner/chef_base_spec.rb
+++ b/spec/kitchen/provisioner/chef_base_spec.rb
@@ -150,8 +150,8 @@ describe Kitchen::Provisioner::ChefBase do
 
     let(:install_opts) {
       { :omnibus_url => "https://www.chef.io/chef/install.sh",
-        :project => nil, :install_flags => nil, :http_proxy => nil,
-        :https_proxy => nil }
+        :project => nil, :install_flags => nil, :sudo_command => 'sudo -E',
+        :http_proxy => nil, :https_proxy => nil }
     }
 
     it "returns nil if :require_chef_omnibus is falsey" do
@@ -323,17 +323,21 @@ describe Kitchen::Provisioner::ChefBase do
       it "prepends sudo for sh commands when :sudo is set" do
         config[:sudo] = true
         config[:sudo_command] = "my_sudo_command"
+        install_opts_clone = install_opts.clone
+        install_opts_clone[:sudo_command]=config[:sudo_command]
 
         Mixlib::Install.expects(:new).
-          with(default_version, false, install_opts).returns(installer)
+          with(default_version, false, install_opts_clone).returns(installer)
         cmd.must_equal "my_sudo_command my_install_command"
       end
 
       it "does not sudo for sh commands when :sudo is falsey" do
         config[:sudo] = false
 
+        install_opts_clone = install_opts.clone
+        install_opts_clone[:sudo_command]=''
         Mixlib::Install.expects(:new).
-          with(default_version, false, install_opts).returns(installer)
+          with(default_version, false, install_opts_clone).returns(installer)
         cmd.must_equal "my_install_command"
       end
     end
@@ -347,8 +351,10 @@ describe Kitchen::Provisioner::ChefBase do
       end
 
       it "sets the powershell flag for Mixlib::Install" do
+        install_opts_clone = install_opts.clone
+        install_opts_clone[:sudo_command]=''
         Mixlib::Install.expects(:new).
-          with("", true, install_opts).returns(installer)
+          with("", true, install_opts_clone).returns(installer)
         cmd
       end
     end

--- a/spec/kitchen/provisioner/chef_base_spec.rb
+++ b/spec/kitchen/provisioner/chef_base_spec.rb
@@ -150,7 +150,7 @@ describe Kitchen::Provisioner::ChefBase do
 
     let(:install_opts) {
       { :omnibus_url => "https://www.chef.io/chef/install.sh",
-        :project => nil, :install_flags => nil, :sudo_command => 'sudo -E',
+        :project => nil, :install_flags => nil, :sudo_command => "sudo -E",
         :http_proxy => nil, :https_proxy => nil }
     }
 
@@ -324,7 +324,7 @@ describe Kitchen::Provisioner::ChefBase do
         config[:sudo] = true
         config[:sudo_command] = "my_sudo_command"
         install_opts_clone = install_opts.clone
-        install_opts_clone[:sudo_command]=config[:sudo_command]
+        install_opts_clone[:sudo_command] = config[:sudo_command]
 
         Mixlib::Install.expects(:new).
           with(default_version, false, install_opts_clone).returns(installer)
@@ -335,7 +335,7 @@ describe Kitchen::Provisioner::ChefBase do
         config[:sudo] = false
 
         install_opts_clone = install_opts.clone
-        install_opts_clone[:sudo_command]=''
+        install_opts_clone[:sudo_command] = ""
         Mixlib::Install.expects(:new).
           with(default_version, false, install_opts_clone).returns(installer)
         cmd.must_equal "my_install_command"
@@ -352,7 +352,7 @@ describe Kitchen::Provisioner::ChefBase do
 
       it "sets the powershell flag for Mixlib::Install" do
         install_opts_clone = install_opts.clone
-        install_opts_clone[:sudo_command]=''
+        install_opts_clone[:sudo_command] = ""
         Mixlib::Install.expects(:new).
           with("", true, install_opts_clone).returns(installer)
         cmd


### PR DESCRIPTION
Without this change, an instance without `sudo` installed, throws this converge error:

```bash
$ bundle exec kitchen converge default-centos-6
-----> Starting Kitchen (v1.5.0)
-----> Converging <default-centos-6>...
       Preparing files for transfer
       Preparing dna.json
       Resolving cookbook dependencies with Berkshelf 4.0.1...
       Removing non-cookbook files before transfer
       Preparing validation.pem
       Preparing client.rb
-----> Installing Chef Omnibus (12.5.1)
       Downloading https://www.chef.io/chef/install.sh to file /tmp/install.sh
       Trying curl...
       Download complete.
       sh: line 227: sudo: command not found
>>>>>> Converge failed on instance <default-centos-6>.
>>>>>> Please see .kitchen/logs/default-centos-6.log for more details
>>>>>> ------Exception-------
>>>>>> Class: Kitchen::ActionFailed
>>>>>> Message: SSH exited (127) for command: [sh -c '

chef_omnibus_root="/opt/chef"
chef_omnibus_url="https://www.chef.io/chef/install.sh"
install_flags="-v 12.5.1"
pretty_version="12.5.1"
sudo_sh="sudo -E sh"
version="12.5.1"

tmp_stderr="/tmp/stderr";
---SNIP---
    do_download "$chef_omnibus_url" /tmp/install.sh;
    $sudo_sh /tmp/install.sh $install_flags;
```

With this PR, the `sudo_sh` variable set in the provisioning script respects the `sudo` and `sudo_command` driver configs.