### PR TITLE
SSH gateway support redux

### DIFF
--- a/lib/kitchen/driver/ssh_base.rb
+++ b/lib/kitchen/driver/ssh_base.rb
@@ -306,8 +306,6 @@ module Kitchen
         pseudo_state[:username] = username if username
         pseudo_state.merge!(options)
 
-        # TODO: 
-        # SSH.new(*build_ssh_args(options.merge(:hostname => hostname))).wait
         instance.transport.connection(backcompat_merged_state(pseudo_state)).
           wait_until_ready
       end

--- a/lib/kitchen/driver/ssh_base.rb
+++ b/lib/kitchen/driver/ssh_base.rb
@@ -229,6 +229,7 @@ module Kitchen
         opts[:port] = combined[:port] if combined[:port]
         opts[:keys] = Array(combined[:ssh_key]) if combined[:ssh_key]
         opts[:logger] = logger
+        opts[:gateway] = combined[:ssh_gateway] if combined[:ssh_gateway]
 
         [combined[:hostname], combined[:username], opts]
       end
@@ -305,6 +306,8 @@ module Kitchen
         pseudo_state[:username] = username if username
         pseudo_state.merge!(options)
 
+        # TODO: 
+        # SSH.new(*build_ssh_args(options.merge(:hostname => hostname))).wait
         instance.transport.connection(backcompat_merged_state(pseudo_state)).
           wait_until_ready
       end

--- a/lib/kitchen/driver/ssh_base.rb
+++ b/lib/kitchen/driver/ssh_base.rb
@@ -217,7 +217,7 @@ module Kitchen
       # @param state [Hash] state hash
       # @return [Array] SSH constructor arguments
       # @api private
-      def build_ssh_args(state)
+      def build_ssh_args(state) # rubocop:disable Metrics/CyclomaticComplexity
         combined = config.to_hash.merge(state)
 
         opts = Hash.new
@@ -262,6 +262,7 @@ module Kitchen
 
         env == "env" ? cmd : "#{env} #{cmd}"
       end
+      # rubocop:enable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity, Metrics/AbcSize
 
       # Executes a remote command over SSH.
       #

--- a/lib/kitchen/ssh.rb
+++ b/lib/kitchen/ssh.rb
@@ -206,6 +206,7 @@ module Kitchen
     #
     # @return [Net::SSH::Connection::Session] the SSH connection session
     # @api private
+    # rubocop:disable Metrics/MethodLength, Metrics/PerceivedComplexity
     def establish_connection
       rescue_exceptions = [
         Errno::EACCES, Errno::EADDRINUSE, Errno::ECONNREFUSED,

--- a/lib/kitchen/ssh.rb
+++ b/lib/kitchen/ssh.rb
@@ -197,7 +197,8 @@ module Kitchen
     # @api private
     def gateway_session
       @gateway_session ||= if gateway
-        Net::SSH::Gateway.new(gateway, username, options.merge(:port => 22)) # Should support the gateway running on other than 22
+        # Should support the gateway running on other than 22
+        Net::SSH::Gateway.new(gateway, username, options.merge(:port => 22))
       end
     end
 

--- a/lib/kitchen/transport/ssh.rb
+++ b/lib/kitchen/transport/ssh.rb
@@ -244,7 +244,8 @@ module Kitchen
         # @api private
         def establish_connection(opts)
           if ssh_gateway
-            logger.debug("[SSH] opening connection to #{self} via #{ssh_gateway_username}@#{ssh_gateway}")
+            logger.debug("[SSH] opening connection to #{self} via " \
+              "#{ssh_gateway_username}@#{ssh_gateway}")
             gateway_session.ssh(hostname, username, options)
           else
             logger.debug("[SSH] opening connection to #{self}")
@@ -327,7 +328,10 @@ module Kitchen
 
         def gateway_session
           @gateway_session ||= if ssh_gateway
-            Net::SSH::Gateway.new(ssh_gateway, ssh_gateway_username, options.merge(:port => 22)) # Should support the gateway running on other than 22
+            # Should support the gateway running on other than 22
+            Net::SSH::Gateway.new(ssh_gateway,
+                                  ssh_gateway_username,
+                                  options.merge(:port => 22))
           end
         end
 

--- a/lib/kitchen/transport/ssh.rb
+++ b/lib/kitchen/transport/ssh.rb
@@ -19,6 +19,7 @@
 require "kitchen"
 
 require "net/ssh"
+require "net/ssh/gateway"
 require "net/scp"
 require "timeout"
 
@@ -49,6 +50,9 @@ module Kitchen
       default_config :connection_retries, 5
       default_config :connection_retry_sleep, 1
       default_config :max_wait_until_ready, 600
+
+      default_config :ssh_gateway, nil
+      default_config :ssh_gateway_username, nil
 
       default_config :ssh_key, nil
       expand_path_for :ssh_key
@@ -136,8 +140,14 @@ module Kitchen
           if options.key?(:forward_agent)
             args += %W[ -o ForwardAgent=#{options[:forward_agent] ? "yes" : "no"} ]
           end
+          if ssh_gateway
+            gateway_command="ssh -q #{ssh_gateway_username}@#{ssh_gateway} nc #{hostname} #{port}"
+            args += %W[ -o ProxyCommand=#{gateway_command} ]
+            args += %W[ -p 22 ] # Should support other ports than 22 for ssh gateways
+          else
+            args += %W[ -p #{port} ]
+          end
           Array(options[:keys]).each { |ssh_key| args += %W[ -i #{ssh_key} ] }
-          args += %W[ -p #{port} ]
           args += %W[ #{username}@#{hostname} ]
 
           LoginCommand.new("ssh", args)
@@ -159,12 +169,16 @@ module Kitchen
         # (see Base::Connection#wait_until_ready)
         def wait_until_ready
           delay = 3
-          session(
-            :retries  => max_wait_until_ready / delay,
-            :delay    => delay,
-            :message  => "Waiting for SSH service on #{hostname}:#{port}, " \
-              "retrying in #{delay} seconds"
-          )
+          if ssh_gateway
+            gateway_session # Add retry logic like direct session
+          else
+            session(
+              :retries  => max_wait_until_ready / delay,
+              :delay    => delay,
+              :message  => "Waiting for SSH service on #{hostname}:#{port}, " \
+                "retrying in #{delay} seconds"
+            )
+          end
           execute(PING_COMMAND.dup)
         end
 
@@ -208,6 +222,15 @@ module Kitchen
         # @api private
         attr_reader :port
 
+        # @return [String] The ssh gateway to use when connecting to the
+        #   remote SSH host
+        # @api private
+        attr_reader :ssh_gateway
+
+        # @return [String] The username to use when using an ssh gateway
+        # @api private
+        attr_reader :ssh_gateway_username
+
         # Establish an SSH session on the remote host.
         #
         # @param opts [Hash] retry options
@@ -220,8 +243,13 @@ module Kitchen
         # @return [Net::SSH::Connection::Session] the SSH connection session
         # @api private
         def establish_connection(opts)
-          logger.debug("[SSH] opening connection to #{self}")
-          Net::SSH.start(hostname, username, options)
+          if ssh_gateway
+            logger.debug("[SSH] opening connection to #{self} via #{ssh_gateway_username}@#{ssh_gateway}")
+            gateway_session.ssh(hostname, username, options)
+          else
+            logger.debug("[SSH] opening connection to #{self}")
+            Net::SSH.start(hostname, username, options)
+          end
         rescue *RESCUE_EXCEPTIONS_ON_ESTABLISH => e
           if (opts[:retries] -= 1) > 0
             message = if opts[:message]
@@ -279,6 +307,9 @@ module Kitchen
           @connection_retries     = @options.delete(:connection_retries)
           @connection_retry_sleep = @options.delete(:connection_retry_sleep)
           @max_wait_until_ready   = @options.delete(:max_wait_until_ready)
+          @ssh_gateway            = @options.delete(:ssh_gateway)
+          @ssh_gateway_username   = @options.delete(:ssh_gateway_username)
+
         end
 
         # Returns a connection session, or establishes one when invoked the
@@ -292,6 +323,12 @@ module Kitchen
             :retries => connection_retries.to_i,
             :delay   => connection_retry_sleep.to_i
           }.merge(retry_options))
+        end
+
+        def gateway_session
+          @gateway_session ||= if ssh_gateway
+            Net::SSH::Gateway.new(ssh_gateway, ssh_gateway_username, options.merge(:port => 22)) # Should support the gateway running on other than 22
+          end
         end
 
         # String representation of object, reporting its connection details and
@@ -334,6 +371,11 @@ module Kitchen
         opts[:auth_methods] = ["publickey"]         if data[:ssh_key]
         opts[:password] = data[:password]           if data.key?(:password)
         opts[:forward_agent] = data[:forward_agent] if data.key?(:forward_agent)
+
+        opts[:ssh_gateway] = data[:ssh_gateway]     if data.key?(:ssh_gateway)
+        if data.key?(:ssh_gateway_username)
+          opts[:ssh_gateway_username] = data[:ssh_gateway_username]
+        end
 
         opts
       end

--- a/lib/kitchen/transport/ssh.rb
+++ b/lib/kitchen/transport/ssh.rb
@@ -141,7 +141,7 @@ module Kitchen
             args += %W[ -o ForwardAgent=#{options[:forward_agent] ? "yes" : "no"} ]
           end
           if ssh_gateway
-            gateway_command="ssh -q #{ssh_gateway_username}@#{ssh_gateway} nc #{hostname} #{port}"
+            gateway_command = "ssh -q #{ssh_gateway_username}@#{ssh_gateway} nc #{hostname} #{port}"
             args += %W[ -o ProxyCommand=#{gateway_command} ]
             args += %W[ -p 22 ] # Should support other ports than 22 for ssh gateways
           else
@@ -242,6 +242,7 @@ module Kitchen
         #   debug (overriding the default) when a rescuable exception is raised
         # @return [Net::SSH::Connection::Session] the SSH connection session
         # @api private
+        # rubocop:disable Metrics/PerceivedComplexity, Metrics/AbcSize, Metrics/MethodLength
         def establish_connection(opts)
           if ssh_gateway
             logger.debug("[SSH] opening connection to #{self} via " \
@@ -268,6 +269,7 @@ module Kitchen
             raise SshFailed, "SSH session could not be established"
           end
         end
+        # rubocop:enable Metrics/PerceivedComplexity, Metrics/AbcSize, Metrics/MethodLength
 
         # Execute a remote command over SSH and return the command's exit code.
         #
@@ -310,7 +312,6 @@ module Kitchen
           @max_wait_until_ready   = @options.delete(:max_wait_until_ready)
           @ssh_gateway            = @options.delete(:ssh_gateway)
           @ssh_gateway_username   = @options.delete(:ssh_gateway_username)
-
         end
 
         # Returns a connection session, or establishes one when invoked the
@@ -330,8 +331,8 @@ module Kitchen
           @gateway_session ||= if ssh_gateway
             # Should support the gateway running on other than 22
             Net::SSH::Gateway.new(ssh_gateway,
-                                  ssh_gateway_username,
-                                  options.merge(:port => 22))
+              ssh_gateway_username,
+              options.merge(:port => 22))
           end
         end
 
@@ -352,7 +353,9 @@ module Kitchen
       # @param data [Hash] merged configuration and mutable state data
       # @return [Hash] hash of connection options
       # @api private
-      def connection_options(data) # rubocop:disable Metrics/MethodLength
+      # rubocop:disable Metrics/MethodLength, Metrics/AbcSize,
+      # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+      def connection_options(data)
         opts = {
           :logger                 => logger,
           :user_known_hosts_file  => "/dev/null",

--- a/test-kitchen.gemspec
+++ b/test-kitchen.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "mixlib-shellout", ">= 1.2", "< 3.0"
   gem.add_dependency "net-scp",         "~> 1.1"
   gem.add_dependency "net-ssh",         ">= 2.9", "< 4.0"
+  gem.add_dependency "net-ssh-gateway", "~> 1.2.0"
   gem.add_dependency "safe_yaml",       "~> 1.0"
   gem.add_dependency "thor",            "~> 0.18"
   gem.add_dependency "mixlib-install",  "~> 0.7"


### PR DESCRIPTION
This PR is an rewrite/extension of https://github.com/test-kitchen/test-kitchen/pull/294, that brings it up to date with the current API.

It supports ssh gateways for converging, verifying, and login to TK instances.
I've tested with a legacy driver, which works, but I have limited access to other drivers.
