### PR TITLE
The Net::SSH::Extensions were overwriting IO.select agressively, so we scaled this down some

### DIFF
--- a/spec/kitchen/ssh_spec.rb
+++ b/spec/kitchen/ssh_spec.rb
@@ -18,7 +18,6 @@
 
 require_relative "../spec_helper"
 
-require "net/ssh/test"
 require "kitchen/ssh"
 require "tmpdir"
 
@@ -55,7 +54,7 @@ end
 # `IO.select` with a version for testing Net::SSH code. Unfortunetly this
 # impacts other code, so we'll "un-patch" this after each spec and "re-patch"
 # it before the next one.
-
+require "net/ssh/test"
 def depatch_io
   IO.class_exec do
     class << self
@@ -63,6 +62,10 @@ def depatch_io
     end
   end
 end
+# We need to immediately call depatch so that `IO.select` is in a good state
+# _right now_.  The require immediately monkeypatches it and we only want
+# it monkey patched inside each ssh test
+depatch_io
 
 def repatch_io
   IO.class_exec do
@@ -82,7 +85,7 @@ end
 # `LocalPacket` which can deal with the `"pty-req"` type.
 #
 # An upstream patch to Net::SSH will be required to retire this yak shave ;)
-
+require "net/ssh/test/channel"
 module Net
 
   module SSH

--- a/spec/kitchen/transport/ssh_spec.rb
+++ b/spec/kitchen/transport/ssh_spec.rb
@@ -18,8 +18,6 @@
 
 require_relative "../../spec_helper"
 
-require "net/ssh/test"
-
 require "kitchen/transport/ssh"
 
 # Hack to sort results in `Dir.entries` only within the yielded block, to limit
@@ -55,7 +53,7 @@ end
 # `IO.select` with a version for testing Net::SSH code. Unfortunetly this
 # impacts other code, so we'll "un-patch" this after each spec and "re-patch"
 # it before the next one.
-
+require "net/ssh/test"
 def depatch_io
   IO.class_exec do
     class << self
@@ -63,6 +61,10 @@ def depatch_io
     end
   end
 end
+# We need to immediately call depatch so that `IO.select` is in a good state
+# _right now_.  The require immediately monkeypatches it and we only want
+# it monkey patched inside each ssh test
+depatch_io
 
 def repatch_io
   IO.class_exec do
@@ -82,7 +84,7 @@ end
 # `LocalPacket` which can deal with the `"pty-req"` type.
 #
 # An upstream patch to Net::SSH will be required to retire this yak shave ;)
-
+require "net/ssh/test/channel"
 module Net
 
   module SSH

--- a/spec/kitchen/verifier/shell_spec.rb
+++ b/spec/kitchen/verifier/shell_spec.rb
@@ -22,6 +22,7 @@ require "logger"
 require "stringio"
 
 require "kitchen/verifier/shell"
+require "kitchen/transport/ssh"
 
 describe Kitchen::Verifier::Shell do
 


### PR DESCRIPTION
This is a fun one.  Including `net/ssh/test` (which Test Kitchen was already doing) includes an extensions file which was monkeypatching [`IO.select`](https://github.com/net-ssh/net-ssh/blob/v3.0.2/lib/net/ssh/test/extensions.rb#L127) to add some hooks for testing the net-ssh code.  Test kitchen was using this framework to stub out ssh connections for its own test, but was bringing in the monkey patch globally.

There is [existing code](https://github.com/test-kitchen/test-kitchen/blob/815caba8c377111f67da15d387458550e095a8a1/spec/kitchen/ssh_spec.rb#L54-L73) to disable this monkeypatching except in the scope of the tests, but we were still seeing errors like the following:

```
  1) Error:
Kitchen::Verifier::Shell::#run_command#test_0001_execute localy and returns nil:
NoMethodError: undefined method `select_for_read?' for #<IO:fd 9>
    /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/net-ssh-3.0.2/lib/net/ssh/test/extensions.rb:128:in `block in select_for_test'
    /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/net-ssh-3.0.2/lib/net/ssh/test/extensions.rb:128:in `select'
    /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/net-ssh-3.0.2/lib/net/ssh/test/extensions.rb:128:in `select_for_test'
    /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/mixlib-shellout-2.2.6/lib/mixlib/shellout/unix.rb:275:in `attempt_buffer_read'
    /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/mixlib-shellout-2.2.6/lib/mixlib/shellout/unix.rb:141:in `ensure in run_command'
    /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/mixlib-shellout-2.2.6/lib/mixlib/shellout/unix.rb:146:in `run_command'
    /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/mixlib-shellout-2.2.6/lib/mixlib/shellout.rb:259:in `run_command'
    /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/test-kitchen-1.5.0/lib/kitchen/verifier/shell.rb:81:in `shellout'
    /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/test-kitchen-1.5.0/lib/kitchen/verifier/shell.rb:61:in `run_command'
    /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/test-kitchen-1.5.0/spec/kitchen/verifier/shell_spec.rb:149:in `block (3 levels) in 
```

It turns out that this was caused because the depatching/repatching only happened in before and after blocks.  Depending on test execution order (this can be reproduced by supplying a specific seed like `bundle exec rake unit TESTOPTS="--seed=25973"`) the monkeypatch would exist before the before/after block had been called.

So I added a depatch call at the file level to make sure the monkeypatch _only_ exists within the ssh_spec tests.