### PR TITLE
Support Empty Proxy Settings

### DIFF
--- a/.cane
+++ b/.cane
@@ -3,5 +3,6 @@
 --abc-exclude Kitchen::ThorTasks#define
 --abc-exclude Kitchen::Driver::SSHBase#converge
 --abc-exclude Kitchen::Driver::SSHBase#verify
+--abc-exclude Kitchen::Configurable#wrap_shell_code
 --style-exclude lib/vendor/**/*.rb
 --doc-exclude lib/vendor/**/.rb

--- a/lib/kitchen/configurable.rb
+++ b/lib/kitchen/configurable.rb
@@ -299,19 +299,19 @@ module Kitchen
     # rubocop:disable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
     def wrap_shell_code(code)
       env = []
-      if config[:http_proxy]
+      if config[:http_proxy] && !config[:http_proxy].empty?
         env << shell_env_var("http_proxy", config[:http_proxy])
         env << shell_env_var("HTTP_PROXY", config[:http_proxy])
       else
         export_proxy(env, "http")
       end
-      if config[:https_proxy]
+      if config[:https_proxy] && !config[:https_proxy].empty?
         env << shell_env_var("https_proxy", config[:https_proxy])
         env << shell_env_var("HTTPS_PROXY", config[:https_proxy])
       else
         export_proxy(env, "https")
       end
-      if config[:ftp_proxy]
+      if config[:ftp_proxy] && !config[:ftp_proxy].empty?
         env << shell_env_var("ftp_proxy", config[:ftp_proxy])
         env << shell_env_var("FTP_PROXY", config[:ftp_proxy])
       else

--- a/spec/kitchen/configurable_spec.rb
+++ b/spec/kitchen/configurable_spec.rb
@@ -834,7 +834,7 @@ describe Kitchen::Configurable do
       end
 
       it "does not export http_proxy or HTTP_PROXY when :http_proxy is empty" do
-        config[:http_proxy] = ''
+        config[:http_proxy] = ""
 
         cmd.must_equal(outdent!(<<-CODE.chomp))
           sh -c '
@@ -845,7 +845,7 @@ describe Kitchen::Configurable do
       end
 
       it "does not export https_proxy or HTTPS_PROXY when :https_proxy is empty" do
-        config[:https_proxy] = ''
+        config[:https_proxy] = ""
 
         cmd.must_equal(outdent!(<<-CODE.chomp))
           sh -c '
@@ -869,7 +869,7 @@ describe Kitchen::Configurable do
       end
 
       it "does not export ftp_proxy or FTP_PROXY when :ftp_proxy is empty" do
-        config[:ftp_proxy] = ''
+        config[:ftp_proxy] = ""
 
         cmd.must_equal(outdent!(<<-CODE.chomp))
           sh -c '

--- a/spec/kitchen/configurable_spec.rb
+++ b/spec/kitchen/configurable_spec.rb
@@ -833,6 +833,28 @@ describe Kitchen::Configurable do
         CODE
       end
 
+      it "does not export http_proxy or HTTP_PROXY when :http_proxy is empty" do
+        config[:http_proxy] = ''
+
+        cmd.must_equal(outdent!(<<-CODE.chomp))
+          sh -c '
+
+          mkdir foo
+          '
+        CODE
+      end
+
+      it "does not export https_proxy or HTTPS_PROXY when :https_proxy is empty" do
+        config[:https_proxy] = ''
+
+        cmd.must_equal(outdent!(<<-CODE.chomp))
+          sh -c '
+
+          mkdir foo
+          '
+        CODE
+      end
+
       it "exports ftp_proxy & FTP_PROXY from workstation when :ftp_proxy isn't set" do
         ENV["ftp_proxy"] = "ftp://proxy"
         ENV["FTP_PROXY"] = "ftp://proxy"
@@ -841,6 +863,17 @@ describe Kitchen::Configurable do
           sh -c '
           ftp_proxy="ftp://proxy"; export ftp_proxy
           FTP_PROXY="ftp://proxy"; export FTP_PROXY
+          mkdir foo
+          '
+        CODE
+      end
+
+      it "does not export ftp_proxy or FTP_PROXY when :ftp_proxy is empty" do
+        config[:ftp_proxy] = ''
+
+        cmd.must_equal(outdent!(<<-CODE.chomp))
+          sh -c '
+
           mkdir foo
           '
         CODE


### PR DESCRIPTION
When empty config values are provided for http_proxy, https_proxy or ftp_proxy do not export local environment values for those keys to the test system.

Fixes #934