### PR TITLE
allow non-busser verifier to work with legacy drivers

### DIFF
--- a/lib/kitchen/driver/ssh_base.rb
+++ b/lib/kitchen/driver/ssh_base.rb
@@ -123,6 +123,10 @@ module Kitchen
         raise ClientError, "#{self.class}#destroy must be implemented"
       end
 
+      def legacy_state(state)
+        backcompat_merged_state(state)
+      end
+
       # (see Base#login_command)
       def login_command(state)
         instance.transport.connection(backcompat_merged_state(state)).

--- a/lib/kitchen/instance.rb
+++ b/lib/kitchen/instance.rb
@@ -400,12 +400,13 @@ module Kitchen
       banner "Verifying #{to_str}..."
       elapsed = action(:verify) do |state|
         # use special handling for busser
-        if (
-          legacy_ssh_base_driver? &&
-          !defined?(Kitchen::Verifier::Busser).nil? &&
-          verifier.is_a?(Kitchen::Verifier::Busser)
-        )
-           legacy_ssh_base_verify(state)
+        if legacy_ssh_base_driver? &&
+            (
+              (!defined?(Kitchen::Verifier::Busser).nil? &&
+                verifier.is_a?(Kitchen::Verifier::Busser)
+              ) || verifier.is_a?(Kitchen::Verifier::Dummy)
+            )
+          legacy_ssh_base_verify(state)
         elsif legacy_ssh_base_driver?
           # read ssh options from legacy driver
           verifier.call(driver.legacy_state(state))

--- a/lib/kitchen/instance.rb
+++ b/lib/kitchen/instance.rb
@@ -399,8 +399,16 @@ module Kitchen
     def verify_action
       banner "Verifying #{to_str}..."
       elapsed = action(:verify) do |state|
-        if legacy_ssh_base_driver?
-          legacy_ssh_base_verify(state)
+        # use special handling for busser
+        if (
+          legacy_ssh_base_driver? &&
+          !defined?(Kitchen::Verifier::Busser).nil? &&
+          verifier.is_a?(Kitchen::Verifier::Busser)
+        )
+           legacy_ssh_base_verify(state)
+        elsif legacy_ssh_base_driver?
+          # read ssh options from legacy driver
+          verifier.call(driver.legacy_state(state))
         else
           verifier.call(state)
         end

--- a/lib/kitchen/instance.rb
+++ b/lib/kitchen/instance.rb
@@ -391,24 +391,30 @@ module Kitchen
       self
     end
 
+    # returns true, if the verifier is busser
+    def verifier_busser?(verifier)
+      !defined?(Kitchen::Verifier::Busser).nil? && verifier.is_a?(Kitchen::Verifier::Busser)
+    end
+
+    # returns true, if the verifier is dummy
+    def verifier_dummy?(verifier)
+      !defined?(Kitchen::Verifier::Dummy).nil? && verifier.is_a?(Kitchen::Verifier::Dummy)
+    end
+
+    def use_legacy_ssh_verifier?(verifier)
+      verifier_busser?(verifier) || verifier_dummy?(verifier)
+    end
+
     # Perform the verify action.
     #
     # @see Driver::Base#verify
     # @return [self] this instance, used to chain actions
     # @api private
-    def verify_action # rubocop:disable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
+    def verify_action
       banner "Verifying #{to_str}..."
       elapsed = action(:verify) do |state|
-        # use special handling for busser
-        if legacy_ssh_base_driver? &&
-            (
-              (!defined?(Kitchen::Verifier::Busser).nil? &&
-                verifier.is_a?(Kitchen::Verifier::Busser)
-              ) || (
-               !defined?(Kitchen::Verifier::Dummy).nil? &&
-                verifier.is_a?(Kitchen::Verifier::Dummy)
-              )
-            )
+        # use special handling for legacy driver
+        if legacy_ssh_base_driver? && use_legacy_ssh_verifier?(verifier)
           legacy_ssh_base_verify(state)
         elsif legacy_ssh_base_driver?
           # read ssh options from legacy driver

--- a/lib/kitchen/instance.rb
+++ b/lib/kitchen/instance.rb
@@ -396,7 +396,7 @@ module Kitchen
     # @see Driver::Base#verify
     # @return [self] this instance, used to chain actions
     # @api private
-    def verify_action
+    def verify_action # rubocop:disable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
       banner "Verifying #{to_str}..."
       elapsed = action(:verify) do |state|
         # use special handling for busser
@@ -404,7 +404,10 @@ module Kitchen
             (
               (!defined?(Kitchen::Verifier::Busser).nil? &&
                 verifier.is_a?(Kitchen::Verifier::Busser)
-              ) || verifier.is_a?(Kitchen::Verifier::Dummy)
+              ) || (
+               !defined?(Kitchen::Verifier::Dummy).nil? &&
+                verifier.is_a?(Kitchen::Verifier::Dummy)
+              )
             )
           legacy_ssh_base_verify(state)
         elsif legacy_ssh_base_driver?


### PR DESCRIPTION
This allows to `kitchen-inspec` to work with multiple legacy drivers that use ssh as a transport.