### PR TITLE
Stop log_level being copied from base config into provisioner config

### DIFF
--- a/lib/kitchen/data_munger.rb
+++ b/lib/kitchen/data_munger.rb
@@ -82,7 +82,6 @@ module Kitchen
       merged_data_for(:provisioner, suite, platform).tap do |pdata|
         set_kitchen_config_at!(pdata, :kitchen_root)
         set_kitchen_config_at!(pdata, :test_base_path)
-        set_kitchen_config_at!(pdata, :log_level)
         combine_arrays!(pdata, :run_list, :platform, :suite)
       end
     end

--- a/lib/kitchen/provisioner/chef_apply.rb
+++ b/lib/kitchen/provisioner/chef_apply.rb
@@ -99,8 +99,7 @@ module Kitchen
 
       # (see ChefSolo#run_command)
       def run_command
-        level = config[:log_level] == :info ? :auto : config[:log_level]
-
+        level = config[:log_level]
         lines = []
         config[:run_list].map do |recipe|
           cmd = sudo(config[:chef_apply_path]).dup.

--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -51,6 +51,7 @@ module Kitchen
       default_config :attributes, {}
       default_config :config_path, nil
       default_config :log_file, nil
+      default_config :log_level, 'auto'
       default_config :profile_ruby, false
       default_config :cookbook_files_glob, %w[
         README.* metadata.{json,rb}

--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -51,7 +51,7 @@ module Kitchen
       default_config :attributes, {}
       default_config :config_path, nil
       default_config :log_file, nil
-      default_config :log_level, 'auto'
+      default_config :log_level, "auto"
       default_config :profile_ruby, false
       default_config :cookbook_files_glob, %w[
         README.* metadata.{json,rb}

--- a/lib/kitchen/provisioner/chef_solo.rb
+++ b/lib/kitchen/provisioner/chef_solo.rb
@@ -47,8 +47,7 @@ module Kitchen
 
       # (see Base#run_command)
       def run_command # rubocop:disable Metrics/AbcSize
-        level = config[:log_level] == :info ? :auto : config[:log_level]
-
+        level = config[:log_level]
         cmd = sudo(config[:chef_solo_path]).dup.
           tap { |str| str.insert(0, "& ") if powershell_shell? }
         args = [

--- a/lib/kitchen/provisioner/chef_zero.rb
+++ b/lib/kitchen/provisioner/chef_zero.rb
@@ -118,7 +118,7 @@ module Kitchen
       # @return [Array<String>] an array of command line arguments
       # @api private
       def chef_client_args
-        level = config[:log_level] == :info ? :warn : config[:log_level]
+        level = config[:log_level]
         args = [
           "--config #{remote_path_join(config[:root_path], "client.rb")}",
           "--log_level #{level}",

--- a/spec/kitchen/data_munger_spec.rb
+++ b/spec/kitchen/data_munger_spec.rb
@@ -885,7 +885,7 @@ module Kitchen # rubocop:disable Metrics/ModuleLength
 
     describe "kitchen config" do
 
-      [:kitchen_root, :test_base_path, :log_level].each do |key|
+      [:kitchen_root, :test_base_path].each do |key|
 
         describe "for #{key}" do
 
@@ -1049,6 +1049,317 @@ module Kitchen # rubocop:disable Metrics/ModuleLength
                     :name => "chefy",
                     key => "imevil"
                   },
+                  :platforms => [
+                    { :name => "plat" }
+                  ],
+                  :suites => [
+                    { :name => "sweet" }
+                  ]
+                },
+                {}
+              ).provisioner_data_for("sweet", "plat").must_equal(
+                :name => "chefy"
+              )
+            end
+          end
+
+          describe "for #verifier_data_for" do
+
+            it "is returned when provided" do
+              DataMunger.new(
+                {
+                  :verifier => "chefy",
+                  :platforms => [
+                    { :name => "plat" }
+                  ],
+                  :suites => [
+                    { :name => "sweet" }
+                  ]
+                },
+                {
+                  key => "datvalue"
+                }
+              ).verifier_data_for("sweet", "plat").must_equal(
+                :name => "chefy",
+                key => "datvalue"
+              )
+            end
+
+            it "is returned when provided in user data" do
+              DataMunger.new(
+                {
+                  :kitchen => {
+                    key => "datvalue"
+                  },
+                  :verifier => "chefy",
+                  :platforms => [
+                    { :name => "plat" }
+                  ],
+                  :suites => [
+                    { :name => "sweet" }
+                  ]
+                },
+                {}
+              ).verifier_data_for("sweet", "plat").must_equal(
+                :name => "chefy",
+                key => "datvalue"
+              )
+            end
+
+            it "user data value beats provided value" do
+              DataMunger.new(
+                {
+                  :kitchen => {
+                    key => "datvalue"
+                  },
+                  :verifier => "chefy",
+                  :platforms => [
+                    { :name => "plat" }
+                  ],
+                  :suites => [
+                    { :name => "sweet" }
+                  ]
+                },
+                {
+                  key => "ilose"
+                }
+              ).verifier_data_for("sweet", "plat").must_equal(
+                :name => "chefy",
+                key => "datvalue"
+              )
+            end
+
+            it "rejects any value in verifier data" do
+              DataMunger.new(
+                {
+                  :verifier => {
+                    :version => "chefy",
+                    key => "imevil"
+                  },
+                  :platforms => [
+                    { :name => "plat" }
+                  ],
+                  :suites => [
+                    { :name => "sweet" }
+                  ]
+                },
+                {}
+              ).verifier_data_for("sweet", "plat").must_equal(
+                :version => "chefy"
+              )
+            end
+          end
+
+          describe "for #transport_data_for" do
+
+            it "is returned when provided" do
+              DataMunger.new(
+                {
+                  :transport => "pipes",
+                  :platforms => [
+                    { :name => "plat" }
+                  ],
+                  :suites => [
+                    { :name => "sweet" }
+                  ]
+                },
+                {
+                  key => "datvalue"
+                }
+              ).transport_data_for("sweet", "plat").must_equal(
+                :name => "pipes",
+                key => "datvalue"
+              )
+            end
+
+            it "is returned when provided in user data" do
+              DataMunger.new(
+                {
+                  :kitchen => {
+                    key => "datvalue"
+                  },
+                  :transport => "pipes",
+                  :platforms => [
+                    { :name => "plat" }
+                  ],
+                  :suites => [
+                    { :name => "sweet" }
+                  ]
+                },
+                {}
+              ).transport_data_for("sweet", "plat").must_equal(
+                :name => "pipes",
+                key => "datvalue"
+              )
+            end
+
+            it "user data value beats provided value" do
+              DataMunger.new(
+                {
+                  :kitchen => {
+                    key => "datvalue"
+                  },
+                  :transport => "pipes",
+                  :platforms => [
+                    { :name => "plat" }
+                  ],
+                  :suites => [
+                    { :name => "sweet" }
+                  ]
+                },
+                {
+                  key => "ilose"
+                }
+              ).transport_data_for("sweet", "plat").must_equal(
+                :name => "pipes",
+                key => "datvalue"
+              )
+            end
+
+            it "rejects any value in transport data" do
+              DataMunger.new(
+                {
+                  :transport => {
+                    :name => "pipes",
+                    key => "imevil"
+                  },
+                  :platforms => [
+                    { :name => "plat" }
+                  ],
+                  :suites => [
+                    { :name => "sweet" }
+                  ]
+                },
+                {}
+              ).transport_data_for("sweet", "plat").must_equal(
+                :name => "pipes"
+              )
+            end
+          end
+        end
+      end
+
+      [:log_level].each do |key|
+
+        describe "for #{key}" do
+
+          describe "for #driver_data_for" do
+
+            it "is returned when provided" do
+              DataMunger.new(
+                {
+                  :driver => "chefy",
+                  :platforms => [
+                    { :name => "plat" }
+                  ],
+                  :suites => [
+                    { :name => "sweet" }
+                  ]
+                },
+                {
+                  key => "datvalue"
+                }
+              ).driver_data_for("sweet", "plat").must_equal(
+                :name => "chefy",
+                key => "datvalue"
+              )
+            end
+
+            it "is returned when provided in user data" do
+              DataMunger.new(
+                {
+                  :kitchen => {
+                    key => "datvalue"
+                  },
+                  :driver => "chefy",
+                  :platforms => [
+                    { :name => "plat" }
+                  ],
+                  :suites => [
+                    { :name => "sweet" }
+                  ]
+                },
+                {}
+              ).driver_data_for("sweet", "plat").must_equal(
+                :name => "chefy",
+                key => "datvalue"
+              )
+            end
+
+            it "user data value beats provided value" do
+              DataMunger.new(
+                {
+                  :kitchen => {
+                    key => "datvalue"
+                  },
+                  :driver => "chefy",
+                  :platforms => [
+                    { :name => "plat" }
+                  ],
+                  :suites => [
+                    { :name => "sweet" }
+                  ]
+                },
+                {
+                  key => "ilose"
+                }
+              ).driver_data_for("sweet", "plat").must_equal(
+                :name => "chefy",
+                key => "datvalue"
+              )
+            end
+
+            it "rejects any value in driver data" do
+              DataMunger.new(
+                {
+                  :driver => {
+                    :name => "chefy",
+                    key => "imevil"
+                  },
+                  :platforms => [
+                    { :name => "plat" }
+                  ],
+                  :suites => [
+                    { :name => "sweet" }
+                  ]
+                },
+                {}
+              ).driver_data_for("sweet", "plat").must_equal(
+                :name => "chefy"
+              )
+            end
+          end
+
+          describe "for #provisioner_data_for" do
+
+            it "uses value in provisioner data" do
+              DataMunger.new(
+                {
+                  :provisioner => {
+                    :name => "chefy",
+                    key => "datvalue"
+                  },
+                  :platforms => [
+                    { :name => "plat" }
+                  ],
+                  :suites => [
+                    { :name => "sweet" }
+                  ]
+                },
+                {}
+              ).provisioner_data_for("sweet", "plat").must_equal(
+                :name => "chefy",
+                key => "datvalue"
+              )
+            end
+
+            it "rejects any value in user data" do
+              DataMunger.new(
+                {
+                  :kitchen => {
+                    key => "imevil"
+                  },
+                  :provisioner => "chefy",
                   :platforms => [
                     { :name => "plat" }
                   ],

--- a/spec/kitchen/provisioner/chef_apply_spec.rb
+++ b/spec/kitchen/provisioner/chef_apply_spec.rb
@@ -29,7 +29,7 @@ describe Kitchen::Provisioner::ChefApply do
   let(:suite)           { stub(:name => "fries") }
 
   let(:config) do
-    { :test_base_path => "/b", :kitchen_root => "/r", :log_level => :info }
+    { :test_base_path => "/b", :kitchen_root => "/r" }
   end
 
   let(:instance) do

--- a/spec/kitchen/provisioner/chef_solo_spec.rb
+++ b/spec/kitchen/provisioner/chef_solo_spec.rb
@@ -29,7 +29,7 @@ describe Kitchen::Provisioner::ChefSolo do
   let(:suite)           { stub(:name => "fries") }
 
   let(:config) do
-    { :test_base_path => "/b", :kitchen_root => "/r", :log_level => :info }
+    { :test_base_path => "/b", :kitchen_root => "/r" }
   end
 
   let(:instance) do

--- a/spec/kitchen/provisioner/chef_zero_spec.rb
+++ b/spec/kitchen/provisioner/chef_zero_spec.rb
@@ -29,7 +29,7 @@ describe Kitchen::Provisioner::ChefZero do
   let(:suite)           { stub(:name => "fries") }
 
   let(:config) do
-    { :test_base_path => "/b", :kitchen_root => "/r", :log_level => :info }
+    { :test_base_path => "/b", :kitchen_root => "/r" }
   end
 
   let(:instance) do
@@ -588,8 +588,8 @@ describe Kitchen::Provisioner::ChefZero do
           " --config #{custom_base}client.rb", :partial_line)
       end
 
-      it "sets log level flag on chef-client to warn by default" do
-        cmd.must_match regexify(" --log_level warn", :partial_line)
+      it "sets log level flag on chef-client to auto by default" do
+        cmd.must_match regexify(" --log_level auto", :partial_line)
       end
 
       it "set log level flag for custom level" do


### PR DESCRIPTION
This allows you to override it in the provisioner section of the configfile.  In the chef_base it is then set to default to 'auto'

The next stage to this would be to have a commandline switch to pass data to the provisioner config.