### PR TITLE
decouple verifier class loading from instantiation

### DIFF
--- a/lib/kitchen/config.rb
+++ b/lib/kitchen/config.rb
@@ -315,7 +315,11 @@ module Kitchen
     # @return [Verifier] a new Verifier object
     # @api private
     def new_verifier(suite, platform)
+      # load verifier class
+      Verifier.load_plugin(data.verifier_name)
+      # fetch verifier configuration
       vdata = data.verifier_data_for(suite.name, platform.name)
+      # create verifier instance
       Verifier.for_plugin(vdata[:name], vdata)
     end
   end

--- a/lib/kitchen/data_munger.rb
+++ b/lib/kitchen/data_munger.rb
@@ -124,6 +124,12 @@ module Kitchen
       end
     end
 
+    def verifier_name
+      vdata = data.fetch(:verifier, {})
+      vdata = { :name => vdata } if vdata.is_a?(String)
+      vdata[:name]
+    end
+
     private
 
     # @return [Hash] the user data hash

--- a/lib/kitchen/verifier.rb
+++ b/lib/kitchen/verifier.rb
@@ -31,25 +31,28 @@ module Kitchen
     # Default verifier to use
     DEFAULT_PLUGIN = "busser".freeze
 
+    def self.load_plugin(verifier_name)
+      require("kitchen/verifier/#{verifier_name}")
+    rescue LoadError, NameError
+      raise ClientError,
+        "Could not load the '#{verifier_name}' verifier from the load path." \
+          " Please ensure that your transport is installed as a gem or" \
+          " included in your Gemfile if using Bundler."
+    end
+
     # Returns an instance of a verifier given a plugin type string.
     #
     # @param plugin [String] a verifier plugin type, to be constantized
     # @param config [Hash] a configuration hash to initialize the verifier
     # @return [Verifier::Base] a verifier instance
     # @raise [ClientError] if a verifier instance could not be created
-    def self.for_plugin(plugin, config)
-      first_load = require("kitchen/verifier/#{plugin}")
-
-      str_const = Thor::Util.camel_case(plugin)
+    def self.for_plugin(verifier_name, config)
+      first_load = load_plugin(verifier_name)
+      str_const = Thor::Util.camel_case(verifier_name)
       klass = const_get(str_const)
       object = klass.new(config)
       object.verify_dependencies if first_load
       object
-    rescue LoadError, NameError
-      raise ClientError,
-        "Could not load the '#{plugin}' verifier from the load path." \
-          " Please ensure that your transport is installed as a gem or" \
-          " included in your Gemfile if using Bundler."
     end
   end
 end


### PR DESCRIPTION
The idea behind this PR is to load the class before test-kitchen tries to load the verifier data. That allows the verifier to extend test-kitchen, if needed.

This implementation allows test-kitchen to be backwards compatible and 'kitchen-inspec' to add required features, since verifiers have not been fully treated as a first-class citizen in the past and have not access to all configuration parameters.

Would love to hear your feedback and other ideas