### PR TITLE
Adding a username method to the SSH and WinRM transport classes

### DIFF
--- a/lib/kitchen/transport/ssh.rb
+++ b/lib/kitchen/transport/ssh.rb
@@ -75,6 +75,15 @@ module Kitchen
         self
       end
 
+      # Returns the configured username. This is occassionally needed
+      # by an instance's driver to perform other tasks, such as a
+      # password reset for the transport user on a GCE Windows instance.
+      #
+      # @return [String] Configured username for the transport
+      def username
+        config[:username]
+      end
+
       # (see Base#connection)
       def connection(state, &block)
         options = connection_options(config.to_hash.merge(state))

--- a/lib/kitchen/transport/winrm.rb
+++ b/lib/kitchen/transport/winrm.rb
@@ -74,6 +74,15 @@ module Kitchen
         end
       end
 
+      # Returns the configured username. This is occassionally needed
+      # by an instance's driver to perform other tasks, such as a
+      # password reset for the transport user on a GCE Windows instance.
+      #
+      # @return [String] Configured username for the transport
+      def username
+        config[:username]
+      end
+
       # A Connection instance can be generated and re-generated, given new
       # connection details such as connection port, hostname, credentials, etc.
       # This object is responsible for carrying out the actions on the remote

--- a/spec/kitchen/transport/ssh_spec.rb
+++ b/spec/kitchen/transport/ssh_spec.rb
@@ -209,6 +209,14 @@ describe Kitchen::Transport::Ssh do
     end
   end
 
+  describe "#username" do
+    it "returns the configured username" do
+      config[:username] = "my_user"
+
+      transport.username.must_equal "my_user"
+    end
+  end
+
   describe "#connection" do
 
     let(:klass) { Kitchen::Transport::Ssh::Connection }

--- a/spec/kitchen/transport/winrm_spec.rb
+++ b/spec/kitchen/transport/winrm_spec.rb
@@ -110,6 +110,14 @@ describe Kitchen::Transport::Winrm do
     end
   end
 
+  describe "#username" do
+    it "returns the configured username" do
+      config[:username] = "my_user"
+
+      transport.username.must_equal "my_user"
+    end
+  end
+
   describe "#connection" do
 
     let(:klass) { Kitchen::Transport::Winrm::Connection }


### PR DESCRIPTION
In some cases, an instance's driver might need knowledge of the
transport username in order to perform a task, such as resetting
the password for the user on a GCE Windows instance.

This change exposes the username via a public method to avoid
such hacks as accessing the `#config` private method.