### PR TITLE
--format #{config[:format]} in chef-client command

### DIFF
--- a/lib/kitchen/provisioner/chef_zero.rb
+++ b/lib/kitchen/provisioner/chef_zero.rb
@@ -90,6 +90,8 @@ module Kitchen
       # @param args [Array<String>] array of flags
       # @api private
       # rubocop:disable Metrics/CyclomaticComplexity
+      # rubocop:disable Metrics/AbcSize
+      # rubocop:disable Metrics/PerceivedComplexity
       def add_optional_chef_client_args!(args)
         if config[:json_attributes]
           json = remote_path_join(config[:root_path], "dna.json")
@@ -97,6 +99,9 @@ module Kitchen
         end
         if config[:log_file]
           args << "--logfile #{config[:log_file]}"
+        end
+        if config[:format]
+          args << "--format #{config[:format]}"
         end
         return unless modern?
 
@@ -113,6 +118,8 @@ module Kitchen
         end
       end
       # rubocop:enable Metrics/CyclomaticComplexity
+      # rubocop:enable Metrics/AbcSize
+      # rubocop:enable Metrics/PerceivedComplexity
 
       # Returns an Array of command line arguments for the chef client.
       #

--- a/spec/kitchen/provisioner/chef_zero_spec.rb
+++ b/spec/kitchen/provisioner/chef_zero_spec.rb
@@ -635,6 +635,17 @@ describe Kitchen::Provisioner::ChefZero do
         cmd.wont_match regexify(" --logfile ", :partial_line)
       end
 
+      it "sets format flag for custom value" do
+        config[:format] = "min"
+
+        cmd.must_match regexify(
+          " --format min", :partial_line)
+      end
+
+      it "does not set logfile flag by default" do
+        cmd.wont_match regexify(" --format ", :partial_line)
+      end
+
       it "prefixs the whole command with the command_prefix if set" do
         config[:command_prefix] = "my_prefix"
 


### PR DESCRIPTION
The standard doc format has way too much data for a poor human to interpret, especially when running against multiple operating systems in parallel. Allow poor humans to specify the minimal formatter for chef-client.
