### PR TITLE
Shell verifier should ensure env vars are strings

### DIFF
--- a/lib/kitchen/verifier/shell.rb
+++ b/lib/kitchen/verifier/shell.rb
@@ -92,7 +92,7 @@ module Kitchen
         env_state[:environment]["KITCHEN_PLATFORM"] = instance.platform.name
         env_state[:environment]["KITCHEN_SUITE"] = instance.suite.name
         state.each_pair do |key, value|
-          env_state[:environment]["KITCHEN_" + key.to_s.upcase] = value
+          env_state[:environment]["KITCHEN_" + key.to_s.upcase] = value.to_s
         end
         config[:shellout_opts].merge!(env_state)
       end

--- a/spec/kitchen/verifier/shell_spec.rb
+++ b/spec/kitchen/verifier/shell_spec.rb
@@ -86,9 +86,11 @@ describe Kitchen::Verifier::Shell do
       it "states are set to environment" do
         state[:hostname] = "testhost"
         state[:server_id] = "i-xxxxxx"
+        state[:port] = 22
         verifier.call(state)
         config[:shellout_opts][:environment]["KITCHEN_HOSTNAME"].must_equal "testhost"
         config[:shellout_opts][:environment]["KITCHEN_SERVER_ID"].must_equal "i-xxxxxx"
+        config[:shellout_opts][:environment]["KITCHEN_PORT"].must_equal "22"
         config[:shellout_opts][:environment]["KITCHEN_INSTANCE"].must_equal "coolbeans-fries"
         config[:shellout_opts][:environment]["KITCHEN_PLATFORM"].must_equal "coolbeans"
         config[:shellout_opts][:environment]["KITCHEN_SUITE"].must_equal "fries"


### PR DESCRIPTION
Encountered while using the shell verified along with `kitchen-docker` which sets `KITCHEN_PORT=22` in the verifier state.
However mixlib-shellout throws an exception:

    TypeError: no implicit conversion of Fixnum into String

as it expects the environment to be all strings: https://github.com/chef/mixlib-shellout/blob/master/lib/mixlib/shellout/unix.rb#L174

Therefore, this PR sanitises the env vars which the shell verifier passes to shellout.