### PR TITLE
run integration tests on travis and appveyor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ tmp
 .kitchen/
 .kitchen.yml
 .kitchen.local.yml
+Berksfile.lock

--- a/.kitchen.ci.yml
+++ b/.kitchen.ci.yml
@@ -1,0 +1,23 @@
+---
+driver:
+  name: proxy
+  host: localhost
+  reset_command: "exit 0"
+  port: <%= ENV["machine_port"] %>
+  username: <%= ENV["machine_user"] %>
+  password: <%= ENV["machine_pass"] %>
+
+provisioner:
+  name: chef_zero
+
+platforms:
+  - name: ubuntu-14.04
+  - name: windows-2012R2
+
+verifier:
+  name: inspec
+
+suites:
+  - name: default
+    run_list:
+      - recipe[mercurial]

--- a/.kitchen.proxy.yml
+++ b/.kitchen.proxy.yml
@@ -1,0 +1,27 @@
+---
+driver:
+  name: proxy
+  host: localhost
+  reset_command: "echo hello"
+  port: <%= ENV["machine_port"] %>
+  username: <%= ENV["machine_user"] %>
+  password: <%= ENV["machine_pass"] %>
+
+provisioner:
+  name: chef_zero
+
+platforms:
+  - name: ubuntu-14.04
+
+verifier:
+  name: busser
+
+suites:
+  # We run a different test based upon the configuration - basically each TK
+  # test asserts that the expected configuration is transfered to the target
+  # machine
+  - name: default
+    run_list:
+      - recipe[test::tk_<%= ENV['TK_SUITE_NAME'] %>_test]
+  # TODO a machine which doesn't setup squid and doesn't copy across
+  # proxy settings

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,38 +3,55 @@ language: ruby
 rvm:
   - 2.2.4
   - 2.1.8
-  - 2.0.0
   - ruby-head
 
+env:
+  - global:
+    - machine_user=travis
+    - machine_pass=travis
+    - machine_port=22
+
+dist: trusty
+sudo: required
+
 before_install:
+  - sudo usermod -p `openssl passwd -1 'travis'` travis
   - gem --version
 
-bundler_args: --without guard
+bundler_args: --without guard integration
 
-sudo: false
+script:
+  - bundle exec rake
+  - bundle install --with integration
+  - export KITCHEN_YAML=.kitchen.ci.yml
+  - bundle exec kitchen verify ubuntu
+
+branches:
+  only:
+  - master
 
 matrix:
   include:
     - rvm: 2.2.4
-      sudo: required
-      dist: trusty
       # To run the proxy tests we need additional gems than what Test Kitchen normally uses
       # for testing
       gemfile: Gemfile.proxy_tests
       before_install:
+        - sudo usermod -p `openssl passwd -1 'travis'` travis
         - gem install bundler
         - sudo apt-get update
         - sudo apt-get -y install squid3 git curl
       env:
-        # ENV['AWS_ACCESS_KEY_ID'], ENV['AWS_SECRET_ACCESS_KEY']
-        - secure: "E7h427Y8z6Nx5sdrA4Ye9gO9pDGpe4jxfhJdM4HPJIM/FSkEJM0ZDPdvhQ6QAQ1S1AHja/JhQUFaNP5NzKhRkVqGCzunBBC6RVb7pp1Qo16EMhJkg7LEsExiSsjQykAzt2w6K/71V+mIlMKxCPYdpu6PT/8w/jZFgBqLEHXuogU="
         - global:
+          - machine_user=travis
+          - machine_pass=travis
+          - machine_port=22
           - PROXY_TESTS_DIR=proxy_tests/files/default/scripts
           - PROXY_TESTS_REPO=$PROXY_TESTS_DIR/repo
+          - KITCHEN_YAML=/home/travis/build/test-kitchen/test-kitchen/.kitchen.proxy.yml
 
       script:
         - bundle exec kitchen --version
-        # TODO switch to master when https://github.com/chef/proxy_tests/pull/12 is merged
         - git clone https://github.com/chef/proxy_tests.git
         - rvmsudo -E bundle exec bash $PROXY_TESTS_DIR/run_tests.sh kitchen \* \* /tmp/out.txt
       after_script:

--- a/Berksfile
+++ b/Berksfile
@@ -1,0 +1,3 @@
+source "https://supermarket.chef.io"
+
+cookbook "mercurial"

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,11 @@ group :guard do
   gem "guard-yard"
 end
 
+group :integration do
+  gem "berkshelf", "~> 4.3"
+  gem "kitchen-inspec", "~> 0.12.5"
+end
+
 group :test do
   gem "codeclimate-test-reporter", :require => nil
 end

--- a/Gemfile.proxy_tests
+++ b/Gemfile.proxy_tests
@@ -1,5 +1,4 @@
 # -*- encoding: utf-8 -*-
 eval_gemfile File.join(File.dirname(__FILE__), "Gemfile")
 
-gem "kitchen-ec2"
 gem "chef-config"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,12 +1,18 @@
 version: "master-{build}"
 
-os: Windows Server 2012
+os: Windows Server 2012 R2
 platform:
   - x64
 
 environment:
+  machine_user: test_user
+  machine_pass: Pass@word1
+  machine_port: 5985
+  KITCHEN_YAML: .kitchen.ci.yml
+  SSL_CERT_FILE: c:\projects\test_kitchen\certs.pem
+
   matrix:
-    - ruby_version: "200"
+    - ruby_version: "21"
 
 clone_folder: c:\projects\test_kitchen
 clone_depth: 1
@@ -17,18 +23,22 @@ branches:
     - master
 
 install:
-  - winrm quickconfig -q
-  - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%
-  - echo %PATH%
+  - ps: net user /add $env:machine_user $env:machine_pass
+  - ps: net localgroup administrators $env:machine_user /add
+  - ps: $env:PATH="C:\Ruby$env:ruby_version\bin;$env:PATH"
+  - ps: gem install bundler --quiet --no-ri --no-rdoc
+  - ps: Invoke-WebRequest -Uri http://curl.haxx.se/ca/cacert.pem -OutFile c:\projects\test_kitchen\certs.pem
+  - ps: Write-Host $env:path
   - ruby --version
   - gem --version
-  - gem install bundler --quiet --no-ri --no-rdoc
   - bundler --version
 
 build_script:
-  - bundle install || bundle install || bundle install
+  - bundle install --without guard integration
 
 test_script:
   - SET SPEC_OPTS=--format progress
   - bundle exec rake unit
   - bundle exec rake quality
+  - bundle install --with integration
+  - bundle exec kitchen verify windows

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -1,0 +1,3 @@
+describe command("hg") do
+  it { should exist }
+end


### PR DESCRIPTION
This is a stab at removing the AWS based tests and instead tunning kitchen on the travis and appveyor instances. Its blogged [here](http://www.hurryupandwait.io/blog/run-kitchen-tests-in-travis-and-appveyor-using-the-kitchen-machine-driver) and we use this in the [Windows cookbook](https://github.com/chef-cookbooks/windows/blob/master/appveyor.yml) too.