### PR TITLE
Retrofit to use fixed winrm-fs release

### DIFF
--- a/lib/kitchen/transport/winrm.rb
+++ b/lib/kitchen/transport/winrm.rb
@@ -346,10 +346,10 @@ module Kitchen
               file.write(command)
             end
 
-            target_path = File.join("$env:TEMP", "kitchen")
+            target_path = File.join("$env:TEMP", script_name)
             upload(script_path, target_path)
 
-            %{powershell -ExecutionPolicy Bypass -File "#{File.join(target_path, script_name)}"}
+            %{powershell -ExecutionPolicy Bypass -File "#{target_path}"}
           ensure
             FileUtils.rmtree(temp_dir)
           end
@@ -359,7 +359,7 @@ module Kitchen
       private
 
       WINRM_SPEC_VERSION = ["~> 1.6"].freeze
-      WINRM_FS_SPEC_VERSION = ["~> 0.3"].freeze
+      WINRM_FS_SPEC_VERSION = ["~> 0.4"].freeze
 
       # Builds the hash of options needed by the Connection object on
       # construction.

--- a/lib/kitchen/transport/winrm.rb
+++ b/lib/kitchen/transport/winrm.rb
@@ -359,7 +359,7 @@ module Kitchen
       private
 
       WINRM_SPEC_VERSION = ["~> 1.6"].freeze
-      WINRM_FS_SPEC_VERSION = ["~> 0.4"].freeze
+      WINRM_FS_SPEC_VERSION = ["~> 0.4.0"].freeze
 
       # Builds the hash of options needed by the Connection object on
       # construction.

--- a/spec/kitchen/transport/winrm_spec.rb
+++ b/spec/kitchen/transport/winrm_spec.rb
@@ -675,7 +675,7 @@ describe Kitchen::Transport::Winrm::Connection do
 
       before do
         executor.expects(:run_powershell_script).with(
-          %{powershell -ExecutionPolicy Bypass -File "$env:TEMP/kitchen/coolbeans-long_script.ps1"}
+          %{powershell -ExecutionPolicy Bypass -File "$env:TEMP/coolbeans-long_script.ps1"}
         ).yields("ok\n", nil).returns(response)
       end
 

--- a/test-kitchen.gemspec
+++ b/test-kitchen.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "pry-byebug"
   gem.add_development_dependency "pry-stack_explorer"
   gem.add_development_dependency "winrm", "~> 1.6"
-  gem.add_development_dependency "winrm-fs", "~> 0.4"
+  gem.add_development_dependency "winrm-fs", "~> 0.4.0"
 
   gem.add_development_dependency "bundler",   "~> 1.3"
   gem.add_development_dependency "rake", "~> 10.0"

--- a/test-kitchen.gemspec
+++ b/test-kitchen.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "pry-byebug"
   gem.add_development_dependency "pry-stack_explorer"
   gem.add_development_dependency "winrm", "~> 1.6"
-  gem.add_development_dependency "winrm-fs", "~> 0.3"
+  gem.add_development_dependency "winrm-fs", "~> 0.4"
 
   gem.add_development_dependency "bundler",   "~> 1.3"
   gem.add_development_dependency "rake", "~> 10.0"

--- a/testing_windows.md
+++ b/testing_windows.md
@@ -8,7 +8,7 @@ Ensure that the cookbook's root directory includes a `Gemfile` that includes you
 ```
 gem 'test-kitchen', git: 'https://github.com/mwrock/test-kitchen', branch: 'winrm-fs'
 gem 'winrm', '~> 1.6'
-gem 'winrm-fs', '~> 0.4'
+gem 'winrm-fs', '~> 0.4.0'
 ```
 The above would target the `winrm-fs` branch in mwrock's test-kitchen repo.
 

--- a/testing_windows.md
+++ b/testing_windows.md
@@ -8,7 +8,7 @@ Ensure that the cookbook's root directory includes a `Gemfile` that includes you
 ```
 gem 'test-kitchen', git: 'https://github.com/mwrock/test-kitchen', branch: 'winrm-fs'
 gem 'winrm', '~> 1.6'
-gem 'winrm-fs', '~> 0.3'
+gem 'winrm-fs', '~> 0.4'
 ```
 The above would target the `winrm-fs` branch in mwrock's test-kitchen repo.
 


### PR DESCRIPTION
winrm-fs 0.4.0 is released. This fixes a bug with uploading encrypted data bags on windows.