### PR TITLE
fix winrm transport run_from_file_command

### DIFF
--- a/lib/kitchen/transport/winrm.rb
+++ b/lib/kitchen/transport/winrm.rb
@@ -346,10 +346,10 @@ module Kitchen
               file.write(command)
             end
 
-            target_path = File.join("$env:TEMP", "kitchen")
+            target_path = File.join("$env:TEMP", "kitchen", script_name)
             upload(script_path, target_path)
 
-            %{powershell -ExecutionPolicy Bypass -File "#{File.join(target_path, script_name)}"}
+            %{powershell -ExecutionPolicy Bypass -File "#{target_path}"}
           ensure
             FileUtils.rmtree(temp_dir)
           end


### PR DESCRIPTION
the script file was written to the directory name, instead of the scrip file within the directory, which it executes after the uploading. this fixes this by writing to the correct target_path before executing this same path.