### PR TITLE
Fix Berkshelf load test

### DIFF
--- a/spec/kitchen/provisioner/chef_base_spec.rb
+++ b/spec/kitchen/provisioner/chef_base_spec.rb
@@ -905,6 +905,9 @@ describe Kitchen::Provisioner::ChefBase do
         end
 
         it "raises a UserError if Berkshelf library can't be loaded" do
+          Kitchen::Provisioner::Chef::Berkshelf.stubs(:load_berkshelf!).with do
+            raise Kitchen::UserError, "Load failed"
+          end
           proc { provisioner }.must_raise Kitchen::UserError
         end
 


### PR DESCRIPTION
This fixes a test breakage which was testing for an error being raised when trying to load Berkshelf. Since Berkshelf is now in the test-kitchen Gemfile, this test fails. The change adds a new stub to make the test succeed.

@tyler-ball @mwrock