### PR TITLE
Don't require dev dependencies to build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,7 @@
 .bundle
 .config
 .yardoc
-bin
-!bin/kitchen
+binstubs
 Gemfile*.lock
 InstalledFiles
 _yardoc


### PR DESCRIPTION
if I run non-bundled `rake install` I’d like it to work—it makes my job easier when building (that way I don’t have to `bundle install` each dir before rake installing, which could end up with us taking extra unnecessary deps into the build)

`rake` should act as normal when running with a full bundle, but if you `—without` some stuff, the tasks will get disabled instead of the rakefile failing to compile