### PR TITLE
Fixes busser install for older omnibus windows installs

### DIFF
--- a/lib/kitchen/configurable.rb
+++ b/lib/kitchen/configurable.rb
@@ -248,6 +248,17 @@ module Kitchen
       instance ? instance.logger : Kitchen.logger
     end
 
+    # @return [String] a powershell command to reload the `PATH` environment
+    #   variable, only to be used to support old Omnibus Chef packages that
+    #   require `PATH` to find the `ruby.exe` binary
+    # @api private
+    def reload_ps1_path
+      [
+        %{$env:PATH},
+        %{[System.Environment]::GetEnvironmentVariable("PATH","Machine")\n\n}
+      ].join(" = ")
+    end
+
     # Builds a shell environment variable assignment string for the
     # required shell type.
     #

--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -273,17 +273,6 @@ module Kitchen
         end
       end
 
-      # @return [String] a powershell command to reload the `PATH` environment
-      #   variable, only to be used to support old Omnibus Chef packages that
-      #   require `PATH` to find the `ruby.exe` binary
-      # @api private
-      def reload_ps1_path
-        [
-          %{$env:PATH},
-          %{[System.Environment]::GetEnvironmentVariable("PATH","Machine")\n\n}
-        ].join(" = ")
-      end
-
       # @return [String] contents of the install script
       # @api private
       def install_script_contents

--- a/lib/kitchen/verifier/busser.rb
+++ b/lib/kitchen/verifier/busser.rb
@@ -151,7 +151,8 @@ module Kitchen
           shell_env_var("GEM_HOME", gem_home),
           shell_env_var("GEM_PATH", gem_path),
           shell_env_var("GEM_CACHE", gem_cache)
-        ].join("\n")
+        ].join("\n").
+          tap { |str| str.insert(0, reload_ps1_path) if windows_os? }
       end
 
       # Determines whether or not a local workstation file exists under a


### PR DESCRIPTION
This fixes https://github.com/test-kitchen/busser/issues/25

Older (chef 11) omnibus installs on Windows do not propogate the the changes to the path so commands made in the same kitchen run will not have the chef embedded bin on the path. This is exacerbated by older versions of rubygems like the one that ships with chef 11 where the binstubs do not include an absolute path to the ruby interpreter. As a result he busser installer cannot find ruby.exe.

This was fixed for the provisioners in [this commit](https://github.com/test-kitchen/test-kitchen/commit/6443145951340887e0ccd4952654b42e46022d8e), but alas, the busser still breaks.

This pr centralizes the `reload_ps1_path` method and uses it in the busser installer.