### PR TITLE
Provide the option to run all winrm commands through a scheduled task

### DIFF
--- a/.kitchen.ci.yml
+++ b/.kitchen.ci.yml
@@ -13,6 +13,9 @@ provisioner:
 platforms:
   - name: ubuntu-14.04
   - name: windows-2012R2
+    transport:
+      name: winrm
+      elevated: true
 
 verifier:
   name: inspec

--- a/test-kitchen.gemspec
+++ b/test-kitchen.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "pry-byebug"
   gem.add_development_dependency "pry-stack_explorer"
   gem.add_development_dependency "winrm", "~> 1.6"
+  gem.add_development_dependency "winrm-elevated", "~> 0.4.0"
   gem.add_development_dependency "winrm-fs", "~> 0.4.1"
 
   gem.add_development_dependency "bundler",   "~> 1.3"

--- a/testing_windows.md
+++ b/testing_windows.md
@@ -9,6 +9,7 @@ Ensure that the cookbook's root directory includes a `Gemfile` that includes you
 gem 'test-kitchen', git: 'https://github.com/mwrock/test-kitchen', branch: 'winrm-fs'
 gem 'winrm', '~> 1.6'
 gem 'winrm-fs', '~> 0.4.1'
+gem 'winrm-elevated', '~> 0.4.0'
 ```
 The above would target the `winrm-fs` branch in mwrock's test-kitchen repo.
 


### PR DESCRIPTION
This PR runs all winrm calls to the transport's `execute` method through a scheduled task that runs under a local account context of the configured transport user. The `:elevated` setting of the winrm transport must be set to true
```
transport:
  name: winrm
  elevated: true
```
and the winrm-elevated gem must be available for this to happen.