### PR TITLE
Add native policyfile resolution support

### DIFF
--- a/lib/kitchen/data_munger.rb
+++ b/lib/kitchen/data_munger.rb
@@ -624,10 +624,11 @@ module Kitchen
     # Destructively moves key Chef configuration key/value pairs from being
     # directly under a suite or platform into a `:provisioner` sub-hash.
     #
-    # There are two key Chef configuration key/value pairs:
+    # There are three key Chef configuration key/value pairs:
     #
     # 1. `:attributes`
     # 2. `:run_list`
+    # 3. `:named_run_list`
     #
     # This method converts the following:
     #
@@ -678,11 +679,13 @@ module Kitchen
       data.fetch(:suites, []).each do |suite|
         move_chef_data_to_provisioner_at!(suite, :attributes)
         move_chef_data_to_provisioner_at!(suite, :run_list)
+        move_chef_data_to_provisioner_at!(suite, :named_run_list)
       end
 
       data.fetch(:platforms, []).each do |platform|
         move_chef_data_to_provisioner_at!(platform, :attributes)
         move_chef_data_to_provisioner_at!(platform, :run_list)
+        move_chef_data_to_provisioner_at!(platform, :named_run_list)
       end
     end
 

--- a/lib/kitchen/provisioner/chef/common_sandbox.rb
+++ b/lib/kitchen/provisioner/chef/common_sandbox.rb
@@ -302,6 +302,11 @@ module Kitchen
             warn("Ignored run_list: #{config[:run_list].inspect}")
           end
           policylock = policyfile.gsub(/\.rb\Z/, ".lock.json")
+          unless File.exist?(policylock)
+            Kitchen.mutex.synchronize do
+              Chef::Policyfile.new(policyfile, sandbox_path, logger).compile
+            end
+          end
           policy_name = JSON.parse(IO.read(policylock))["name"]
           policy_group = "local"
           config[:attributes].merge(:policy_name => policy_name, :policy_group => policy_group)

--- a/lib/kitchen/provisioner/chef/policyfile.rb
+++ b/lib/kitchen/provisioner/chef/policyfile.rb
@@ -1,0 +1,99 @@
+# -*- encoding: utf-8 -*-
+#
+# Author:: Fletcher Nichol (<fnichol@nichol.ca>)
+#
+# Copyright (C) 2013, Fletcher Nichol
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "kitchen/errors"
+require "kitchen/logging"
+require "kitchen/shell_out"
+
+module Kitchen
+
+  module Provisioner
+
+    module Chef
+
+      # Chef cookbook resolver that uses Policyfiles to calculate dependencies.
+      #
+      # @author Fletcher Nichol <fnichol@nichol.ca>
+      class Policyfile
+
+        include Logging
+        include ShellOut
+
+        # Creates a new cookbook resolver.
+        #
+        # @param berksfile [String] path to a Berksfile
+        # @param path [String] path in which to vendor the resulting
+        #   cookbooks
+        # @param logger [Kitchen::Logger] a logger to use for output, defaults
+        #   to `Kitchen.logger`
+        def initialize(policyfile, path, logger = Kitchen.logger)
+          @policyfile = policyfile
+          @path       = path
+          @logger     = logger
+        end
+
+        # Loads the library code required to use the resolver.
+        #
+        # @param logger [Kitchen::Logger] a logger to use for output, defaults
+        #   to `Kitchen.logger`
+        def self.load!(logger = Kitchen.logger)
+          detect_chef_command!(logger)
+        end
+
+        # Performs the cookbook resolution and vendors the resulting cookbooks
+        # in the desired path.
+        def resolve
+          info("Exporting cookbook dependencies from Policyfile #{path}...")
+          run_command("chef export #{policyfile} #{path} --force")
+        end
+
+        private
+
+        # @return [String] path to a Berksfile
+        # @api private
+        attr_reader :policyfile
+
+        # @return [String] path in which to vendor the resulting cookbooks
+        # @api private
+        attr_reader :path
+
+        # @return [Kitchen::Logger] a logger to use for output
+        # @api private
+        attr_reader :logger
+
+        # Ensure the `chef` command is in the path.
+        #
+        # @param logger [Kitchen::Logger] the logger to use
+        # @raise [UserError] if the `chef` command is not in the PATH
+        # @api private
+        def self.detect_chef_command!(logger)
+          unless ENV["PATH"].split(File::PATH_SEPARATOR).any? { |p|
+            File.exist?(File.join(p, "chef"))
+          }
+            logger.fatal("The `chef` executable cannot be found in your " \
+                         "PATH. Ensure you have installed ChefDK from " \
+                         "https://downloads.chef.io and that your PATH " \
+                         "setting includes the path to the `chef` comand.")
+            raise UserError,
+              "Could not find the chef executable in your PATH."
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/kitchen/provisioner/chef/policyfile.rb
+++ b/lib/kitchen/provisioner/chef/policyfile.rb
@@ -62,6 +62,14 @@ module Kitchen
           run_command("chef export #{policyfile} #{path} --force")
         end
 
+        # Runs `chef install` to determine the correct cookbook set and
+        # generate the policyfile lock.
+        def compile
+          info("Policy lock file doesn't exist, running `chef install` for "\
+               "Policyfile #{policyfile}...")
+          run_command("chef install #{policyfile}")
+        end
+
         private
 
         # @return [String] path to a Berksfile

--- a/lib/kitchen/provisioner/chef_zero.rb
+++ b/lib/kitchen/provisioner/chef_zero.rb
@@ -32,6 +32,7 @@ module Kitchen
       plugin_version Kitchen::VERSION
 
       default_config :client_rb, {}
+      default_config :named_run_list, {}
       default_config :json_attributes, true
       default_config :chef_zero_host, nil
       default_config :chef_zero_port, 8889
@@ -207,6 +208,7 @@ module Kitchen
       # @api private
       def prepare_client_rb
         data = default_config_rb.merge(config[:client_rb])
+        data = data.merge(:named_run_list => config[:named_run_list]) if config[:named_run_list]
 
         info("Preparing client.rb")
         debug("Creating client.rb from #{data.inspect}")
@@ -239,6 +241,14 @@ module Kitchen
         shim = remote_path_join(config[:root_path], "chef-client-zero.rb")
 
         "#{chef_client_zero_env}\n#{sudo(ruby)} #{shim}"
+      end
+
+      # This provisioner supports policyfiles, so override the default (which
+      # is false)
+      # @return [true] always returns true
+      # @api private
+      def supports_policyfile?
+        true
       end
     end
   end

--- a/spec/kitchen/data_munger_spec.rb
+++ b/spec/kitchen/data_munger_spec.rb
@@ -480,6 +480,23 @@ module Kitchen # rubocop:disable Metrics/ModuleLength
           )
         end
 
+        it "moves named_run_list into provisioner" do
+          DataMunger.new(
+            {
+              :provisioner => "chefy",
+              :suites => [
+                {
+                  :name => "sweet",
+                  :named_run_list => "other_run_list"
+                }
+              ]
+            },
+            {}
+          ).provisioner_data_for("sweet", "plat").must_equal(
+            :name => "chefy",
+            :named_run_list => "other_run_list"
+          )
+        end
         it "maintains run_list in provisioner" do
           DataMunger.new(
             {
@@ -536,6 +553,23 @@ module Kitchen # rubocop:disable Metrics/ModuleLength
           )
         end
 
+        it "merge provisioner into named_run_list if provisioner exists" do
+          DataMunger.new(
+            {
+              :suites => [
+                {
+                  :name => "sweet",
+                  :named_run_list => "other_run_list",
+                  :provisioner => "chefy"
+                }
+              ]
+            },
+            {}
+          ).provisioner_data_for("sweet", "plat").must_equal(
+            :name => "chefy",
+            :named_run_list => "other_run_list"
+          )
+        end
         it "drops nil run_list" do
           DataMunger.new(
             {
@@ -609,6 +643,23 @@ module Kitchen # rubocop:disable Metrics/ModuleLength
           )
         end
 
+        it "moves named_run_list into provisioner" do
+          DataMunger.new(
+            {
+              :provisioner => "chefy",
+              :platforms => [
+                {
+                  :name => "plat",
+                  :named_run_list => "other_run_list"
+                }
+              ]
+            },
+            {}
+          ).provisioner_data_for("sweet", "plat").must_equal(
+            :name => "chefy",
+            :named_run_list => "other_run_list"
+          )
+        end
         it "maintains run_list in provisioner" do
           DataMunger.new(
             {
@@ -665,6 +716,23 @@ module Kitchen # rubocop:disable Metrics/ModuleLength
           )
         end
 
+        it "merge provisioner into named_run_list if provisioner exists" do
+          DataMunger.new(
+            {
+              :platforms => [
+                {
+                  :name => "plat",
+                  :named_run_list => "other_run_list",
+                  :provisioner => "chefy"
+                }
+              ]
+            },
+            {}
+          ).provisioner_data_for("sweet", "plat").must_equal(
+            :name => "chefy",
+            :named_run_list => "other_run_list"
+          )
+        end
         it "drops nil run_list" do
           DataMunger.new(
             {

--- a/spec/kitchen/provisioner/chef_base_spec.rb
+++ b/spec/kitchen/provisioner/chef_base_spec.rb
@@ -1038,6 +1038,22 @@ POLICYFILE
             end
 
           end
+          describe "when the policyfile lock doesn't exist" do
+            before do
+              File.open("#{kitchen_root}/Policyfile.rb", "wb") do |file|
+                file.write(<<-POLICYFILE)
+  name 'wat'
+  run_list 'wat'
+  cookbook 'wat'
+  POLICYFILE
+              end
+
+              it "runs `chef install` to generate the lock" do
+                resolver.expects(:compile)
+                provisioner.create_sandbox
+              end
+            end
+          end
         end
       end
 


### PR DESCRIPTION
Auto detects policyfiles and uses them for resolution. It's a bit wonky in that it only works with the `chef_zero` provisioner, but `chef_solo` seems to still be the default, so you have to at least add `provisioner: chef_zero` to your kitchen YAML. I tested with a kitchen YAML like:

```yaml
provisioner: chef_zero

platforms:
  - name: ubuntu-14.04

suites:
  - name: default
    attributes:
      rando_attr: hello from rando
    named_run_list: foo 
```

I confirmed the named run list functionality works, and also attributes work as expected, so it will fix https://github.com/chef/chef-dk/issues/460