### PR TITLE
Update `chef_omnbius_url` default value

### DIFF
--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -46,7 +46,7 @@ module Kitchen
     class ChefBase < Base
 
       default_config :require_chef_omnibus, true
-      default_config :chef_omnibus_url, "https://www.chef.io/chef/install.sh"
+      default_config :chef_omnibus_url, "https://omnitruck.chef.io/install.sh"
       default_config :chef_omnibus_install_options, nil
       default_config :run_list, []
       default_config :attributes, {}

--- a/spec/kitchen/provisioner/chef_base_spec.rb
+++ b/spec/kitchen/provisioner/chef_base_spec.rb
@@ -58,7 +58,7 @@ describe Kitchen::Provisioner::ChefBase do
 
       it ":chef_omnibus_url has a default" do
         provisioner[:chef_omnibus_url].
-          must_equal "https://www.chef.io/chef/install.sh"
+          must_equal "https://omnitruck.chef.io/install.sh"
       end
 
       it ":chef_metadata_url defaults to nil" do
@@ -72,7 +72,7 @@ describe Kitchen::Provisioner::ChefBase do
 
       it ":chef_omnibus_url has a default" do
         provisioner[:chef_omnibus_url].
-          must_equal "https://www.chef.io/chef/install.sh"
+          must_equal "https://omnitruck.chef.io/install.sh"
       end
 
     end
@@ -149,7 +149,7 @@ describe Kitchen::Provisioner::ChefBase do
     let(:cmd) { provisioner.install_command }
 
     let(:install_opts) {
-      { :omnibus_url => "https://www.chef.io/chef/install.sh",
+      { :omnibus_url => "https://omnitruck.chef.io/install.sh",
         :project => nil, :install_flags => nil, :sudo_command => "sudo -E",
         :http_proxy => nil, :https_proxy => nil }
     }


### PR DESCRIPTION
The correct install.sh URL for Omnitruck is now:
https://omnitruck.chef.io/install.sh

/cc @test-kitchen/core 