### PR TITLE
Fix grammar in common_sandbox warning message

### DIFF
--- a/lib/kitchen/provisioner/chef/common_sandbox.rb
+++ b/lib/kitchen/provisioner/chef/common_sandbox.rb
@@ -298,7 +298,7 @@ module Kitchen
         def update_dna_for_policyfile
           if !config[:run_list].nil? && !config[:run_list].empty?
             warn("You must set your run_list in your policyfile instead of "\
-                 "kitchen config. The run_list your config will be ignored.")
+                 "kitchen config. The run_list in your config will be ignored.")
             warn("Ignored run_list: #{config[:run_list].inspect}")
           end
           policylock = policyfile.gsub(/\.rb\Z/, ".lock.json")


### PR DESCRIPTION
It's a pretty simple fix. Doesn't really need explanation.