### PR TITLE
Add color options

### DIFF
--- a/lib/kitchen/cli.rb
+++ b/lib/kitchen/cli.rb
@@ -91,6 +91,10 @@ module Kitchen
       method_option :log_overwrite,
         :desc => "Set to false to prevent log overwriting each time Test Kitchen runs",
         :type => :boolean
+      method_option :color,
+        :type => :boolean,
+        :lazy_default => $stdout.tty?,
+        :desc => "Toggle color output for STDOUT logger"
     end
 
     # Sets the test_base_path method_options
@@ -349,6 +353,7 @@ module Kitchen
       unless options[:log_overwrite].nil?
         @config.log_overwrite = options[:log_overwrite]
       end
+      @config.colorize = options[:color] unless options[:color].nil?
 
       if options[:test_base_path]
         # ensure we have an absolute path
@@ -360,7 +365,7 @@ module Kitchen
         log_level,
         options[:log_overwrite]
       )
-
+      
       update_parallel!
     end
 

--- a/lib/kitchen/cli.rb
+++ b/lib/kitchen/cli.rb
@@ -365,7 +365,7 @@ module Kitchen
         log_level,
         options[:log_overwrite]
       )
-      
+
       update_parallel!
     end
 

--- a/lib/kitchen/config.rb
+++ b/lib/kitchen/config.rb
@@ -81,6 +81,10 @@ module Kitchen
     # @api private
     attr_accessor :test_base_path
 
+    # @return [Boolean] whether to force color output or not in logger
+    # @api private
+    attr_accessor :colorize
+
     # Creates a new configuration, representing a particular testing
     # configuration for a project.
     #
@@ -104,6 +108,7 @@ module Kitchen
       @kitchen_root   = options.fetch(:kitchen_root) { Dir.pwd }
       @log_level      = options.fetch(:log_level) { Kitchen::DEFAULT_LOG_LEVEL }
       @log_overwrite  = options.fetch(:log_overwrite) { Kitchen::DEFAULT_LOG_OVERWRITE }
+      @colorize       = options.fetch(:colorize) { Kitchen.tty? }
       @log_root       = options.fetch(:log_root) { default_log_root }
       @test_base_path = options.fetch(:test_base_path) { default_test_base_path }
     end
@@ -268,7 +273,8 @@ module Kitchen
         :logdev   => log_location,
         :level    => Util.to_logger_level(log_level),
         :log_overwrite => log_overwrite,
-        :progname => name
+        :progname => name,
+        :colorize => @colorize
       )
     end
 

--- a/lib/kitchen/logger.rb
+++ b/lib/kitchen/logger.rb
@@ -78,8 +78,8 @@ module Kitchen
     def populate_loggers(color, options)
       @loggers = []
       @loggers << logdev unless logdev.nil?
-      @loggers << stdout_logger(options[:stdout], color) if options[:stdout]
-      @loggers << stdout_logger($stdout, color) if @loggers.empty?
+      @loggers << stdout_logger(options[:stdout], color, options[:colorize]) if options[:stdout]
+      @loggers << stdout_logger($stdout, color, options[:colorize]) if @loggers.empty?
     end
     private :populate_loggers
 
@@ -288,9 +288,9 @@ module Kitchen
     # @param color [Symbol] color to use when outputing messages
     # @return [StdoutLogger] a new logger
     # @api private
-    def stdout_logger(stdout, color)
+    def stdout_logger(stdout, color, colorize)
       logger = StdoutLogger.new(stdout)
-      if Kitchen.tty?
+      if colorize
         logger.formatter = proc do |_severity, _datetime, _progname, msg|
           Color.colorize("#{msg}", color).concat("\n")
         end

--- a/lib/kitchen/logger.rb
+++ b/lib/kitchen/logger.rb
@@ -80,8 +80,10 @@ module Kitchen
     def populate_loggers(options)
       @loggers = []
       @loggers << logdev unless logdev.nil?
-      @loggers << stdout_logger(options[:stdout], options[:color], options[:colorize]) if options[:stdout]
-      @loggers << stdout_logger($stdout, options[:color], options[:colorize]) if @loggers.empty?
+      @loggers << stdout_logger(options[:stdout], options[:color], options[:colorize]) if
+        options[:stdout]
+      @loggers << stdout_logger($stdout, options[:color], options[:colorize]) if
+        @loggers.empty?
     end
     private :populate_loggers
 

--- a/lib/kitchen/logger.rb
+++ b/lib/kitchen/logger.rb
@@ -54,8 +54,10 @@ module Kitchen
     #   messages (default: `"Kitchen"`)
     # @option options [IO] :stdout a standard out IO object to use
     #   (default: `$stdout`)
+    # @option options [Boolean] :colorize whether to colorize output
+    #   when Test Kitchen runs.
+    #   (default: `$stdout.tty?`)
     def initialize(options = {})
-      color = options[:color]
       @log_overwrite = if options[:log_overwrite].nil?
         default_log_overwrite
       else
@@ -64,7 +66,7 @@ module Kitchen
 
       @logdev = logdev_logger(options[:logdev], log_overwrite) if options[:logdev]
 
-      populate_loggers(color, options)
+      populate_loggers(options)
 
       # These setters cannot be called until @loggers are populated because
       # they are delegated
@@ -75,11 +77,11 @@ module Kitchen
     # Pulled out for Rubocop complexity issues
     #
     # @api private
-    def populate_loggers(color, options)
+    def populate_loggers(options)
       @loggers = []
       @loggers << logdev unless logdev.nil?
-      @loggers << stdout_logger(options[:stdout], color, options[:colorize]) if options[:stdout]
-      @loggers << stdout_logger($stdout, color, options[:colorize]) if @loggers.empty?
+      @loggers << stdout_logger(options[:stdout], options[:color], options[:colorize]) if options[:stdout]
+      @loggers << stdout_logger($stdout, options[:color], options[:colorize]) if @loggers.empty?
     end
     private :populate_loggers
 
@@ -286,6 +288,7 @@ module Kitchen
     #
     # @param stdout [IO] the IO object that represents stdout (or similar)
     # @param color [Symbol] color to use when outputing messages
+    # @param colorize [Boolean] whether to enable color
     # @return [StdoutLogger] a new logger
     # @api private
     def stdout_logger(stdout, color, colorize)

--- a/spec/kitchen/config_spec.rb
+++ b/spec/kitchen/config_spec.rb
@@ -41,9 +41,14 @@ module Kitchen
       @data || Hash.new
     end
   end
+
 end
 
 describe Kitchen::Config do
+  # Explicitly enable tty to test colorize default option later
+  before do
+    Kitchen.stubs(:tty?).returns(true)
+  end
 
   let(:loader)  { Kitchen::DummyLoader.new }
   let(:config)  { Kitchen::Config.new(opts) }
@@ -55,7 +60,8 @@ describe Kitchen::Config do
       :log_root       => "/tmp/logs",
       :test_base_path => "/testing/yo",
       :log_level      => :debug,
-      :log_overwrite  => false
+      :log_overwrite  => false,
+      :colorize       => false
     }
   end
 
@@ -70,7 +76,8 @@ describe Kitchen::Config do
       :kitchen_root => "/tmp/that/place",
       :test_base_path => "/testing/yo",
       :log_level => :debug,
-      :log_overwrite  => false
+      :log_overwrite  => false,
+      :colorize => false
     }
   end
 
@@ -149,6 +156,19 @@ describe Kitchen::Config do
       opts.delete(:log_overwrite)
 
       config.log_overwrite.must_equal true
+    end
+  end
+
+  describe "#colorize" do
+
+    it "returns its colorize" do
+      config.colorize.must_equal false
+    end
+
+    it "uses true by default" do
+      opts.delete(:colorize)
+
+      config.colorize.must_equal true
     end
   end
 
@@ -339,7 +359,8 @@ describe Kitchen::Config do
         :logdev => "/tmp/logs/tiny-unax.log",
         :log_overwrite => false,
         :level => 0,
-        :progname => "tiny-unax"
+        :progname => "tiny-unax",
+        :colorize => false
       )
 
       config.instances

--- a/spec/kitchen/logger_spec.rb
+++ b/spec/kitchen/logger_spec.rb
@@ -23,7 +23,6 @@ require "kitchen"
 describe Kitchen::Logger do
 
   before do
-    Kitchen.stubs(:tty?).returns(true)
     @orig_stdout = $stdout
     $stdout = StringIO.new
   end
@@ -37,7 +36,7 @@ describe Kitchen::Logger do
   end
 
   let(:opts) do
-    { :color => :red }
+    { :color => :red, :colorize => true }
   end
 
   let(:logger) do
@@ -110,7 +109,7 @@ describe Kitchen::Logger do
     end
 
     it "sets up a simple STDOUT logger by default with no color" do
-      Kitchen.stubs(:tty?).returns(false)
+      opts[:colorize] = false
       opts.delete(:stdout)
       logger.info("hello")
 
@@ -124,7 +123,7 @@ describe Kitchen::Logger do
     end
 
     it "accepts a :stdout option to redirect output with no color" do
-      Kitchen.stubs(:tty?).returns(false)
+      opts[:colorize] = false
       logger.info("hello")
 
       stdout.string.must_equal "       hello\n"
@@ -141,7 +140,7 @@ describe Kitchen::Logger do
       end
 
       it "logs to banner with no color" do
-        Kitchen.stubs(:tty?).returns(false)
+        opts[:colorize] = false
         logger.banner("yo")
 
         stdout.string.must_equal "-----> yo\n"
@@ -154,7 +153,7 @@ describe Kitchen::Logger do
       end
 
       it "logs to debug with no color" do
-        Kitchen.stubs(:tty?).returns(false)
+        opts[:colorize] = false
         logger.debug("yo")
 
         stdout.string.must_equal "D      yo\n"
@@ -167,7 +166,7 @@ describe Kitchen::Logger do
       end
 
       it "logs to info with no color" do
-        Kitchen.stubs(:tty?).returns(false)
+        opts[:colorize] = false
         logger.info("yo")
 
         stdout.string.must_equal "       yo\n"
@@ -180,7 +179,7 @@ describe Kitchen::Logger do
       end
 
       it "logs to error with no color" do
-        Kitchen.stubs(:tty?).returns(false)
+        opts[:colorize] = false
         logger.error("yo")
 
         stdout.string.must_equal ">>>>>> yo\n"
@@ -193,7 +192,7 @@ describe Kitchen::Logger do
       end
 
       it "logs to warn with no color" do
-        Kitchen.stubs(:tty?).returns(false)
+        opts[:colorize] = false
         logger.warn("yo")
 
         stdout.string.must_equal "$$$$$$ yo\n"
@@ -206,7 +205,7 @@ describe Kitchen::Logger do
       end
 
       it "logs to fatal with no color" do
-        Kitchen.stubs(:tty?).returns(false)
+        opts[:colorize] = false
         logger.fatal("yo")
 
         stdout.string.must_equal "!!!!!! yo\n"
@@ -219,7 +218,7 @@ describe Kitchen::Logger do
       end
 
       it "logs to unknown with no color" do
-        Kitchen.stubs(:tty?).returns(false)
+        opts[:colorize] = false
         logger.unknown("yo")
 
         stdout.string.must_equal "?????? yo\n"


### PR DESCRIPTION
adds commandline flag ot enable disable color output:

`--color` - This is useful when running kitchen from environment that is not a tty.
`--no-color` - Useful when running kitchen from terminals that do not support ANSI

### Can be tested with:

should not give color output:
```
chef exec kitchen destroy  | cat
```
should not give color output:
```
chef exec kitchen destroy --no-color
```

should give color output:
```
chef exec kitchen destroy --color | cat
```

This PR fetched and rebased from @Igorshp's pr#765 as requested by @cheeseplus to solve #330 and using kitchen in Chef Delivery and Jenkins.