### PR TITLE
Use command_prefix provided by Kitchen::Provisioner::Base in shell provisioner

### DIFF
--- a/lib/kitchen/provisioner/shell.rb
+++ b/lib/kitchen/provisioner/shell.rb
@@ -79,7 +79,7 @@ module Kitchen
         )
         code = powershell_shell? ? %{& "#{script}"} : sudo(script)
 
-        wrap_shell_code(prefix_command(code))
+        prefix_command(wrap_shell_code(code))
       end
 
       private

--- a/lib/kitchen/provisioner/shell.rb
+++ b/lib/kitchen/provisioner/shell.rb
@@ -79,7 +79,7 @@ module Kitchen
         )
         code = powershell_shell? ? %{& "#{script}"} : sudo(script)
 
-        wrap_shell_code(code)
+        wrap_shell_code(prefix_command(code))
       end
 
       private

--- a/spec/kitchen/provisioner/shell_spec.rb
+++ b/spec/kitchen/provisioner/shell_spec.rb
@@ -321,7 +321,7 @@ describe Kitchen::Provisioner::Shell do
         config[:root_path] = "/r"
         config[:sudo] = false
 
-        cmd.must_match regexify("TEST=yes /r/bootstrap.sh", :partial_line)
+        cmd.must_match(/^TEST=yes/)
       end
     end
 

--- a/spec/kitchen/provisioner/shell_spec.rb
+++ b/spec/kitchen/provisioner/shell_spec.rb
@@ -315,6 +315,14 @@ describe Kitchen::Provisioner::Shell do
         cmd.must_match regexify("/r/bootstrap.sh", :partial_line)
         cmd.wont_match regexify("sudo -E /r/bootstrap.sh", :partial_line)
       end
+
+      it "uses command_prefix for script when configured" do
+        config[:command_prefix] = "TEST=yes"
+        config[:root_path] = "/r"
+        config[:sudo] = false
+
+        cmd.must_match regexify("TEST=yes /r/bootstrap.sh", :partial_line)
+      end
     end
 
     describe "for powershell shells on windows os types" do


### PR DESCRIPTION
Kitchen::Provisioner::Base provides a `:command_prefix` option for... prefixing commands. Use this in the shell provisioner so that we can do things like prefixing environment variables for use within the script.