### PR TITLE
Buffer errors until the end of an action

### DIFF
--- a/lib/kitchen/errors.rb
+++ b/lib/kitchen/errors.rb
@@ -43,15 +43,32 @@ module Kitchen
     #
     # @param exception [::StandardError] an exception
     # @return [Array<String>] a formatted message
-    def self.formatted_trace(exception)
-      arr = formatted_exception(exception).dup
-      last = arr.pop
+    def self.formatted_trace(exception, title = "Exception")
+      arr = formatted_exception(exception, title).dup
+
       if exception.respond_to?(:original) && exception.original
-        arr += formatted_exception(exception.original, "Nested Exception")
-        last = arr.pop
+        arr += if exception.original.is_a? Array
+                 exception.original.map do |composite_exception|
+                   formatted_trace(composite_exception, "Composite Exception").flatten
+                 end
+               else
+                 [
+                   formatted_exception(exception.original, "Nested Exception"),
+                   formatted_backtrace(exception)
+                 ].flatten
+               end
       end
-      arr += ["Backtrace".center(22, "-"), exception.backtrace, last].flatten
-      arr
+      arr.flatten
+    end
+
+    def self.formatted_backtrace(exception)
+      unless exception.backtrace.nil?
+        [
+          "Backtrace".center(22, "-"),
+          exception.backtrace,
+          "End Backtrace".center(22, "-")
+        ]
+      end
     end
 
     # Creates an array of strings, representing a formatted exception that

--- a/lib/kitchen/errors.rb
+++ b/lib/kitchen/errors.rb
@@ -45,24 +45,27 @@ module Kitchen
     # @return [Array<String>] a formatted message
     def self.formatted_trace(exception, title = "Exception")
       arr = formatted_exception(exception, title).dup
+      arr += formatted_backtrace(exception)
 
       if exception.respond_to?(:original) && exception.original
         arr += if exception.original.is_a? Array
-                 exception.original.map do |composite_exception|
-                   formatted_trace(composite_exception, "Composite Exception").flatten
-                 end
-               else
-                 [
-                   formatted_exception(exception.original, "Nested Exception"),
-                   formatted_backtrace(exception)
-                 ].flatten
-               end
+          exception.original.map do |composite_exception|
+            formatted_trace(composite_exception, "Composite Exception").flatten
+          end
+        else
+          [
+            formatted_exception(exception.original, "Nested Exception"),
+            formatted_backtrace(exception)
+          ].flatten
+        end
       end
       arr.flatten
     end
 
     def self.formatted_backtrace(exception)
-      unless exception.backtrace.nil?
+      if exception.backtrace.nil?
+        []
+      else
         [
           "Backtrace".center(22, "-"),
           exception.backtrace,

--- a/spec/kitchen/errors_spec.rb
+++ b/spec/kitchen/errors_spec.rb
@@ -49,8 +49,6 @@ describe Kitchen::Error do
         "------Exception-------",
         "Class: Kitchen::StandardError",
         "Message: shoot",
-        "------Backtrace-------",
-        nil,
         "----------------------"
       ])
     end
@@ -59,7 +57,7 @@ describe Kitchen::Error do
       begin
         raise Kitchen::StandardError, "shoot"
       rescue => e
-        Kitchen::Error.formatted_trace(e)[4...-1].must_equal e.backtrace
+        Kitchen::Error.formatted_trace(e)[5...-1].must_equal e.backtrace
       end
     end
 
@@ -73,14 +71,34 @@ describe Kitchen::Error do
           "------Exception-------",
           "Class: Kitchen::StandardError",
           "Message: shoot",
+          "----------------------",
           "---Nested Exception---",
           "Class: IOError",
           "Message: no disk, yo",
-          "------Backtrace-------",
-          nil,
           "----------------------"
         ])
       end
+    end
+
+    it "returns an array when an error has more than one error in original" do
+      error_array = []
+      error_array << Kitchen::StandardError.new("one")
+      error_array << Kitchen::StandardError.new("two")
+      composite_error = Kitchen::StandardError.new("array", error_array)
+
+      Kitchen::Error.formatted_trace(composite_error).must_equal([
+        "------Exception-------",
+        "Class: Kitchen::StandardError",
+        "Message: array",
+        "----------------------",
+        "-Composite Exception--",
+        "Class: Kitchen::StandardError",
+        "Message: one", "----------------------",
+        "-Composite Exception--",
+        "Class: Kitchen::StandardError",
+        "Message: two",
+        "----------------------"
+      ])
     end
   end
 end


### PR DESCRIPTION
Updates the behavior where an earlier failure would block later instances.  With this PR, all the errors for the action are buffered until the end of the action for all instances.  If there were any errors, they are reported (one in the console - the rest in the log).