### PR TITLE
add max scp session handling

### DIFF
--- a/lib/kitchen/driver/ssh_base.rb
+++ b/lib/kitchen/driver/ssh_base.rb
@@ -299,7 +299,7 @@ module Kitchen
           waits = []
           locals.map do |local|
             waits.push connection.upload_path(local, remote)
-            waits.shift.wait while waits.length >= ssh_sessions
+            waits.shift.wait while waits.length >= config[:ssh_sessions]
           end
           waits.each(&:wait)
         end

--- a/lib/kitchen/transport/ssh.rb
+++ b/lib/kitchen/transport/ssh.rb
@@ -47,7 +47,7 @@ module Kitchen
       default_config :keepalive, true
       default_config :keepalive_interval, 60
       # needs to be one less than the configured sshd_config MaxSessions
-      default_config :ssh_sessions, 9
+      default_config :max_ssh_sessions, 9
       default_config :connection_timeout, 15
       default_config :connection_retries, 5
       default_config :connection_retry_sleep, 1
@@ -158,7 +158,7 @@ module Kitchen
               waits.push session.scp.upload(local, remote, opts) do |_ch, name, sent, total|
                 logger.debug("Async Uploaded #{name} (#{total} bytes)") if sent == total
               end
-              waits.shift.wait while waits.length >= ssh_sessions
+              waits.shift.wait while waits.length >= max_ssh_sessions
             end
             waits.each(&:wait)
           end
@@ -193,7 +193,7 @@ module Kitchen
 
         # @return [Integer] cap on number of parallel ssh sessions we can use
         # @api private
-        attr_reader :ssh_sessions
+        attr_reader :max_ssh_sessions
 
         # @return [Integer] how many times to retry when failing to execute
         #   a command or transfer files
@@ -294,7 +294,7 @@ module Kitchen
           @port                   = @options[:port] # don't delete from options
           @connection_retries     = @options.delete(:connection_retries)
           @connection_retry_sleep = @options.delete(:connection_retry_sleep)
-          @ssh_sessions           = @options.delete(:ssh_sessions)
+          @max_ssh_sessions       = @options.delete(:max_ssh_sessions)
           @max_wait_until_ready   = @options.delete(:max_wait_until_ready)
         end
 
@@ -344,7 +344,7 @@ module Kitchen
           :timeout                => data[:connection_timeout],
           :connection_retries     => data[:connection_retries],
           :connection_retry_sleep => data[:connection_retry_sleep],
-          :ssh_sessions           => data[:ssh_sessions],
+          :max_ssh_sessions       => data[:max_ssh_sessions],
           :max_wait_until_ready   => data[:max_wait_until_ready]
         }
 

--- a/lib/kitchen/transport/ssh.rb
+++ b/lib/kitchen/transport/ssh.rb
@@ -46,6 +46,8 @@ module Kitchen
       default_config :username, "root"
       default_config :keepalive, true
       default_config :keepalive_interval, 60
+      # needs to be one less than the configured sshd_config MaxSessions
+      default_config :ssh_sessions, 9
       default_config :connection_timeout, 15
       default_config :connection_retries, 5
       default_config :connection_retry_sleep, 1
@@ -149,12 +151,14 @@ module Kitchen
         def upload(locals, remote)
           logger.debug("TIMING: scp async upload (Kitchen::Transport::Ssh)")
           elapsed = Benchmark.measure do
-            waits = Array(locals).map do |local|
+            waits = []
+            Array(locals).map do |local|
               opts = File.directory?(local) ? { :recursive => true } : {}
 
-              session.scp.upload(local, remote, opts) do |_ch, name, sent, total|
+              waits.push session.scp.upload(local, remote, opts) do |_ch, name, sent, total|
                 logger.debug("Async Uploaded #{name} (#{total} bytes)") if sent == total
               end
+              waits.shift.wait while waits.length >= ssh_sessions
             end
             waits.each(&:wait)
           end
@@ -186,6 +190,10 @@ module Kitchen
           Net::SSH::Disconnect, Net::SSH::AuthenticationFailed, Net::SSH::ConnectionTimeout,
           Timeout::Error
         ].freeze
+
+        # @return [Integer] cap on number of parallel ssh sessions we can use
+        # @api private
+        attr_reader :ssh_sessions
 
         # @return [Integer] how many times to retry when failing to execute
         #   a command or transfer files
@@ -286,6 +294,7 @@ module Kitchen
           @port                   = @options[:port] # don't delete from options
           @connection_retries     = @options.delete(:connection_retries)
           @connection_retry_sleep = @options.delete(:connection_retry_sleep)
+          @ssh_sessions           = @options.delete(:ssh_sessions)
           @max_wait_until_ready   = @options.delete(:max_wait_until_ready)
         end
 
@@ -335,6 +344,7 @@ module Kitchen
           :timeout                => data[:connection_timeout],
           :connection_retries     => data[:connection_retries],
           :connection_retry_sleep => data[:connection_retry_sleep],
+          :ssh_sessions           => data[:ssh_sessions],
           :max_wait_until_ready   => data[:max_wait_until_ready]
         }
 

--- a/spec/kitchen/transport/ssh_spec.rb
+++ b/spec/kitchen/transport/ssh_spec.rb
@@ -1043,21 +1043,6 @@ describe Kitchen::Transport::Ssh::Connection do
           connection.upload(src.path, "/tmp/remote")
         end
       end
-
-      it "logs upload progress to debug" do
-        assert_scripted do
-          connection.upload(src.path, "/tmp/remote")
-        end
-
-        logged_output.string.must_match debug_line(
-          "[SSH] opening connection to me@foo<{:port=>22}>"
-        )
-        logged_output.string.lines.count { |l|
-          l =~ debug_line(
-            "Async Uploaded #{src.path} (1234 bytes)"
-          )
-        }.must_equal 1
-      end
     end
 
     describe "for a path" do
@@ -1115,31 +1100,6 @@ describe Kitchen::Transport::Ssh::Connection do
         with_sorted_dir_entries do
           assert_scripted { connection.upload(@dir, "/tmp/remote") }
         end
-      end
-
-      it "logs upload progress to debug" do
-        with_sorted_dir_entries do
-          assert_scripted { connection.upload(@dir, "/tmp/remote") }
-        end
-
-        logged_output.string.must_match debug_line(
-          "[SSH] opening connection to me@foo<{:port=>22}>"
-        )
-        logged_output.string.lines.count { |l|
-          l =~ debug_line(
-            "Async Uploaded #{@dir}/alpha (15 bytes)"
-          )
-        }.must_equal 1
-        logged_output.string.lines.count { |l|
-          l =~ debug_line(
-            "Async Uploaded #{@dir}/subdir/beta (14 bytes)"
-          )
-        }.must_equal 1
-        logged_output.string.lines.count { |l|
-          l =~ debug_line(
-            "Async Uploaded #{@dir}/zulu (14 bytes)"
-          )
-        }.must_equal 1
       end
     end
 

--- a/spec/kitchen/transport/ssh_spec.rb
+++ b/spec/kitchen/transport/ssh_spec.rb
@@ -207,6 +207,10 @@ describe Kitchen::Transport::Ssh do
 
       transport[:ssh_key].must_equal os_safe_root_path("/rooty/my_key")
     end
+
+    it "sets :ssh_sessions to 9 by default" do
+      transport[:ssh_sessions].must_equal 9
+    end
   end
 
   describe "#connection" do
@@ -648,7 +652,7 @@ describe Kitchen::Transport::Ssh::Connection do
   let(:conn)            { net_ssh_connection }
 
   let(:options) do
-    { :logger => logger, :username => "me", :hostname => "foo", :port => 22 }
+    { :logger => logger, :username => "me", :hostname => "foo", :port => 22, :ssh_sessions => 9 }
   end
 
   let(:connection) do

--- a/spec/kitchen/transport/ssh_spec.rb
+++ b/spec/kitchen/transport/ssh_spec.rb
@@ -208,8 +208,8 @@ describe Kitchen::Transport::Ssh do
       transport[:ssh_key].must_equal os_safe_root_path("/rooty/my_key")
     end
 
-    it "sets :ssh_sessions to 9 by default" do
-      transport[:ssh_sessions].must_equal 9
+    it "sets :max_ssh_sessions to 9 by default" do
+      transport[:max_ssh_sessions].must_equal 9
     end
   end
 
@@ -652,7 +652,13 @@ describe Kitchen::Transport::Ssh::Connection do
   let(:conn)            { net_ssh_connection }
 
   let(:options) do
-    { :logger => logger, :username => "me", :hostname => "foo", :port => 22, :ssh_sessions => 9 }
+    {
+      :logger => logger,
+      :username => "me",
+      :hostname => "foo",
+      :port => 22,
+      :max_ssh_sessions => 9
+    }
   end
 
   let(:connection) do


### PR DESCRIPTION
net-ssh/scp seem to lack any kind of checks against too much
concurrency, so we have to handle this ourselves.

closes #1035, closes #1043 