### PR TITLE
Add fallback support for `policyfile` for compat with the older policyfile_zero

### DIFF
--- a/lib/kitchen/provisioner/chef/common_sandbox.rb
+++ b/lib/kitchen/provisioner/chef/common_sandbox.rb
@@ -92,7 +92,7 @@ module Kitchen
         #   kitchen root
         # @api private
         def policyfile
-          basename = config[:policyfile_path] || "Policyfile.rb"
+          basename = config[:policyfile_path] || config[:policyfile] || "Policyfile.rb"
           File.join(config[:kitchen_root], basename)
         end
 

--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -54,6 +54,8 @@ module Kitchen
       default_config :log_file, nil
       default_config :log_level, "auto"
       default_config :profile_ruby, false
+      # The older policyfile_zero used `policyfile` so support it for compat.
+      default_config :policyfile, nil
       # Will try to autodetect by searching for `Policyfile.rb` if not set.
       # If set, will error if the file doesn't exist.
       default_config :policyfile_path, nil
@@ -167,7 +169,7 @@ module Kitchen
       #   kitchen root
       # @api private
       def policyfile
-        policyfile_basename = config[:policyfile_path] || "Policyfile.rb"
+        policyfile_basename = config[:policyfile_path] || config[:policyfile] || "Policyfile.rb"
         File.join(config[:kitchen_root], policyfile_basename)
       end
 
@@ -350,7 +352,7 @@ module Kitchen
       # @raise [UserError]
       # @api private
       def sanity_check_sandbox_options!
-        if config[:policyfile_path] && !File.exist?(policyfile)
+        if (config[:policyfile_path] || config[:policyfile]) && !File.exist?(policyfile)
           raise UserError, "policyfile_path set in config "\
             "(#{config[:policyfile_path]} could not be found. " \
             "Expected to find it at full path #{policyfile} " \


### PR DESCRIPTION
Because yay compat! We can revert this at some point but the code is minimal enough that it seems fine to leave for a while. Were there any other compat breaks when the provisioner code was moved?