### PR TITLE
Retry `Kitchen::Provisioner#run_command` after allowed exit codes

### DIFF
--- a/lib/kitchen/command.rb
+++ b/lib/kitchen/command.rb
@@ -170,7 +170,6 @@ module Kitchen
         concurrency.times do
           threads << Thread.new do
             while instance = queue.pop
-              puts "running #{instance.name}"
               run_action_in_thread(action, instance, *args)
             end
           end

--- a/lib/kitchen/command.rb
+++ b/lib/kitchen/command.rb
@@ -176,14 +176,19 @@ module Kitchen
           end
         end
         threads.map(&:join)
+        report_errors
+      end
+
+      # private
+
+      def report_errors
         unless @action_errors.empty?
           msg = ["#{@action_errors.length} actions failed.",
-                 @action_errors.map { |e| ">>>>>>     #{e.message}"}].join("\n")
+                 @action_errors.map { |e| ">>>>>>     #{e.message}" }].join("\n")
           raise ActionFailed.new(msg, @action_errors)
         end
       end
 
-      # private
       def concurrency_setting(instances)
         concurrency = 1
         if options[:concurrency]

--- a/lib/kitchen/provisioner/base.rb
+++ b/lib/kitchen/provisioner/base.rb
@@ -33,8 +33,8 @@ module Kitchen
       default_config :ftp_proxy, nil
 
       default_config :retry_on_exit_code, []
-      default_config :max_retries, nil
-      default_config :wait_for_retry, nil
+      default_config :max_retries, 1
+      default_config :wait_for_retry, 30
 
       default_config :root_path do |provisioner|
         provisioner.windows_os? ? "$env:TEMP\\kitchen" : "/tmp/kitchen"

--- a/lib/kitchen/provisioner/base.rb
+++ b/lib/kitchen/provisioner/base.rb
@@ -32,6 +32,9 @@ module Kitchen
       default_config :https_proxy, nil
       default_config :ftp_proxy, nil
 
+      default_config :retry_on_exit_code, nil
+      default_config :max_retries, nil
+
       default_config :root_path do |provisioner|
         provisioner.windows_os? ? "$env:TEMP\\kitchen" : "/tmp/kitchen"
       end
@@ -70,7 +73,7 @@ module Kitchen
           conn.upload(sandbox_dirs, config[:root_path])
           debug("Transfer complete")
           conn.execute(prepare_command)
-          conn.execute(run_command)
+          conn.execute_with_retry(run_command, config[:retry_on_exit_code], config[:max_retries])
         end
       rescue Kitchen::Transport::TransportFailed => ex
         raise ActionFailed, ex.message

--- a/lib/kitchen/provisioner/base.rb
+++ b/lib/kitchen/provisioner/base.rb
@@ -32,7 +32,7 @@ module Kitchen
       default_config :https_proxy, nil
       default_config :ftp_proxy, nil
 
-      default_config :retry_on_exit_code, nil
+      default_config :retry_on_exit_code, []
       default_config :max_retries, nil
       default_config :wait_for_retry, nil
 

--- a/lib/kitchen/provisioner/chef_zero.rb
+++ b/lib/kitchen/provisioner/chef_zero.rb
@@ -76,13 +76,17 @@ module Kitchen
 
         prefix_command(
           wrap_shell_code(
-            [cmd, *chef_client_args].join(" ").
+            [cmd, *chef_client_args, last_exit_code].join(" ").
             tap { |str| str.insert(0, reload_ps1_path) if windows_os? }
           )
         )
       end
 
       private
+
+      def last_exit_code
+        "; exit $LastExitCode" if powershell_shell?
+      end
 
       # Adds optional flags to a chef-client command, depending on
       # configuration data. Note that this method mutates the incoming Array.

--- a/lib/kitchen/transport/base.rb
+++ b/lib/kitchen/transport/base.rb
@@ -28,7 +28,14 @@ module Kitchen
     # Wrapped exception for any internally raised Transport errors.
     #
     # @author Salim Afiune <salim@afiunemaya.com.mx>
-    class TransportFailed < TransientFailure; end
+    class TransportFailed < TransientFailure
+      attr_reader :exit_code
+
+      def initialize(message, exit_code = nil)
+        @exit_code = exit_code
+        super(message)
+      end
+    end
 
     # Base class for a transport.
     #

--- a/lib/kitchen/transport/base.rb
+++ b/lib/kitchen/transport/base.rb
@@ -117,16 +117,14 @@ module Kitchen
         # @param wait_time [Fixnum] number of seconds to wait before retrying command
         # @raise [TransportFailed] if the command does not exit successfully,
         #   which may vary by implementation
-        def execute_with_retry(command, retryable_exit_codes = [], max_retries, wait_time)
-          max_retries = 1 if max_retries.nil?
-          wait_time = 30 if wait_time.nil?
+        def execute_with_retry(command, retryable_exit_codes = [], max_retries = 1, wait_time = 30)
           tries = 0
           begin
             tries += 1
             debug("Attempting to execute command - try #{tries} of #{max_retries}.")
             execute(command)
           rescue Kitchen::Transport::TransportFailed => e
-            if retry? tries, max_retries, retryable_exit_codes, e.exit_code
+            if retry?(tries, max_retries, retryable_exit_codes, e.exit_code)
               close
               sleep wait_time
               retry

--- a/lib/kitchen/transport/base.rb
+++ b/lib/kitchen/transport/base.rb
@@ -115,7 +115,7 @@ module Kitchen
         #   which may vary by implementation
         # rubocop:disable Lint/UnusedMethodArgument
         def execute_with_retry(command, retryable_exit_codes = [], max_retries, wait_time)
-          max_retries = 3 if max_retries.nil?
+          max_retries = 1 if max_retries.nil?
           wait_time = 30 if wait_time.nil?
           tries = 0
           begin
@@ -123,7 +123,10 @@ module Kitchen
             debug("Attempting to execute command - try #{tries} of #{max_retries}.")
             execute(command)
           rescue Kitchen::Transport::TransportFailed => e
-            if (tries < max_retries) && (retryable_exit_codes.include? e.exit_code)
+            if (tries <= max_retries) &&
+                !retryable_exit_codes.nil? &&
+                (retryable_exit_codes.include? e.exit_code)
+              close
               sleep wait_time
               retry
             else

--- a/lib/kitchen/transport/base.rb
+++ b/lib/kitchen/transport/base.rb
@@ -114,16 +114,21 @@ module Kitchen
         # @raise [TransportFailed] if the command does not exit successfully,
         #   which may vary by implementation
         # rubocop:disable Lint/UnusedMethodArgument
-        def execute_with_retry(command, retryable_exit_codes = [], max_retries = nil)
+        def execute_with_retry(command, retryable_exit_codes = [], max_retries, wait_time)
           max_retries = 3 if max_retries.nil?
+          wait_time = 30 if wait_time.nil?
           tries = 0
           begin
             tries += 1
             debug("Attempting to execute command - try #{tries} of #{max_retries}.")
             execute(command)
           rescue Kitchen::Transport::TransportFailed => e
-            retry if (tries < max_retries) && (retryable_exit_codes.include? e.exit_code)
-            raise e
+            if (tries < max_retries) && (retryable_exit_codes.include? e.exit_code)
+              sleep wait_time
+              retry
+            else
+              raise e
+            end
           end
         end
 

--- a/lib/kitchen/transport/ssh.rb
+++ b/lib/kitchen/transport/ssh.rb
@@ -124,8 +124,10 @@ module Kitchen
           exit_code = execute_with_exit_code(command)
 
           if exit_code != 0
-            raise Transport::SshFailed,
-              "SSH exited (#{exit_code}) for command: [#{command}]"
+            raise Transport::SshFailed.new(
+              "SSH exited (#{exit_code}) for command: [#{command}]",
+              exit_code
+            )
           end
         rescue Net::SSH::Exception => ex
           raise SshFailed, "SSH command failed (#{ex.message})"

--- a/lib/kitchen/transport/winrm.rb
+++ b/lib/kitchen/transport/winrm.rb
@@ -105,8 +105,10 @@ module Kitchen
             log_stderr_on_warn(stderr)
           elsif exit_code != 0
             log_stderr_on_warn(stderr)
-            raise Transport::WinrmFailed,
-              "WinRM exited (#{exit_code}) for command: [#{command}]"
+            raise Transport::WinrmFailed.new(
+              "WinRM exited (#{exit_code}) for command: [#{command}]",
+              exit_code
+            )
           end
         end
 

--- a/spec/kitchen/provisioner/base_spec.rb
+++ b/spec/kitchen/provisioner/base_spec.rb
@@ -157,6 +157,7 @@ describe Kitchen::Provisioner::Base do
       FileUtils.mkdir_p(File.join(provisioner.sandbox_path, "stuff"))
       transport.stubs(:connection).yields(connection)
       connection.stubs(:execute)
+      connection.stubs(:execute_with_retry)
       connection.stubs(:upload)
     end
 
@@ -193,7 +194,7 @@ describe Kitchen::Provisioner::Base do
       connection.expects(:execute).with("install").in_sequence(order)
       connection.expects(:execute).with("init").in_sequence(order)
       connection.expects(:execute).with("prepare").in_sequence(order)
-      connection.expects(:execute).with("run").in_sequence(order)
+      connection.expects(:execute_with_retry).with("run", nil, nil).in_sequence(order)
 
       cmd
     end

--- a/spec/kitchen/provisioner/base_spec.rb
+++ b/spec/kitchen/provisioner/base_spec.rb
@@ -194,7 +194,7 @@ describe Kitchen::Provisioner::Base do
       connection.expects(:execute).with("install").in_sequence(order)
       connection.expects(:execute).with("init").in_sequence(order)
       connection.expects(:execute).with("prepare").in_sequence(order)
-      connection.expects(:execute_with_retry).with("run", nil, nil).in_sequence(order)
+      connection.expects(:execute_with_retry).with("run", nil, nil, nil).in_sequence(order)
 
       cmd
     end

--- a/spec/kitchen/provisioner/base_spec.rb
+++ b/spec/kitchen/provisioner/base_spec.rb
@@ -194,7 +194,7 @@ describe Kitchen::Provisioner::Base do
       connection.expects(:execute).with("install").in_sequence(order)
       connection.expects(:execute).with("init").in_sequence(order)
       connection.expects(:execute).with("prepare").in_sequence(order)
-      connection.expects(:execute_with_retry).with("run", [], nil, nil).in_sequence(order)
+      connection.expects(:execute_with_retry).with("run", [], 1, 30).in_sequence(order)
 
       cmd
     end

--- a/spec/kitchen/provisioner/base_spec.rb
+++ b/spec/kitchen/provisioner/base_spec.rb
@@ -194,7 +194,7 @@ describe Kitchen::Provisioner::Base do
       connection.expects(:execute).with("install").in_sequence(order)
       connection.expects(:execute).with("init").in_sequence(order)
       connection.expects(:execute).with("prepare").in_sequence(order)
-      connection.expects(:execute_with_retry).with("run", nil, nil, nil).in_sequence(order)
+      connection.expects(:execute_with_retry).with("run", [], nil, nil).in_sequence(order)
 
       cmd
     end

--- a/spec/kitchen/transport/base_spec.rb
+++ b/spec/kitchen/transport/base_spec.rb
@@ -54,6 +54,27 @@ describe Kitchen::Transport::Base do
       transport.send(:logger).must_equal Kitchen.logger
     end
   end
+
+  describe Kitchen::Transport::TransportFailed do
+    
+    let(:failure_with_no_exit_code) { Kitchen::Transport::TransportFailed.new("Boom") }
+    let(:failure_with_exit_code) { Kitchen::Transport::TransportFailed.new("Boom", 123) }
+
+    describe "when no exit code is provided" do
+
+      it "#exit_code is nil" do
+        failure_with_no_exit_code.exit_code.must_be_nil
+      end
+    end
+
+    describe "when an exit code is provided" do
+
+      it "#exit_code returns the supplied exit code" do
+        failure_with_exit_code.exit_code.must_equal 123
+      end
+    end
+  end
+
 end
 
 describe Kitchen::Transport::Base::Connection do

--- a/spec/kitchen/transport/base_spec.rb
+++ b/spec/kitchen/transport/base_spec.rb
@@ -113,11 +113,11 @@ describe Kitchen::Transport::Base::Connection do
     let(:failure_with_exit_code) { Kitchen::Transport::TransportFailed.new("Boom", 123) }
 
     it "raises ClientError with no retries" do
-      proc { connection.execute_with_retry("hi") }.
+      proc { connection.execute_with_retry("hi", [], nil, nil) }.
         must_raise Kitchen::ClientError
     end
 
-    it "retries three times by default" do
+    it "retries three times" do
       connection.expects(:execute).with("Hi").returns("Hello")
       connection.expects(:debug).with("Attempting to execute command - try 3 of 3.")
       connection.expects(:execute).with("Hi").raises(failure_with_exit_code)
@@ -125,7 +125,7 @@ describe Kitchen::Transport::Base::Connection do
       connection.expects(:execute).with("Hi").raises(failure_with_exit_code)
       connection.expects(:debug).with("Attempting to execute command - try 1 of 3.")
 
-      connection.execute_with_retry("Hi", [123]).must_equal "Hello"
+      connection.execute_with_retry("Hi", [123], 3, 1).must_equal "Hello"
     end
   end
 end

--- a/spec/kitchen/transport/ssh_spec.rb
+++ b/spec/kitchen/transport/ssh_spec.rb
@@ -900,6 +900,14 @@ describe Kitchen::Transport::Ssh::Connection do
         }.must_raise Kitchen::Transport::SshFailed
         err.message.must_equal "SSH exited (42) for command: [doit]"
       end
+
+      it "returns the exit code with an SshFailed exception" do
+        begin
+          connection.execute("doit")
+        rescue Kitchen::Transport::SshFailed => e
+          e.exit_code.must_equal 42
+        end
+      end
     end
 
     describe "for an interrupted command" do

--- a/spec/kitchen/transport/winrm_spec.rb
+++ b/spec/kitchen/transport/winrm_spec.rb
@@ -935,6 +935,14 @@ MSG
           }.must_raise Kitchen::Transport::WinrmFailed
           err.message.must_equal "WinRM exited (1) for command: [doit]"
         end
+
+        it "raises WinrmFailed exception with the exit code of the failure" do
+          begin
+            connection.execute("doit")
+          rescue Kitchen::Transport::WinrmFailed => e
+            e.exit_code.must_equal 1
+          end
+        end
       end
     end
 


### PR DESCRIPTION
- [x] Allow user to define exit codes to retry Provision#run_command
- [x] Allow user to define wait time between attempts
- [x] Allow user to define exit codes to retry 
- [x] Allow user to define maximum number of retry attempts

Resolves #1016 
