### PR TITLE
Fix WinRM Upload Failures After Reboot

### DIFF
--- a/lib/kitchen/transport/winrm.rb
+++ b/lib/kitchen/transport/winrm.rb
@@ -90,6 +90,7 @@ module Kitchen
         ensure
           @file_transporter = nil
           @session = nil
+          @elevated_runner = nil
         end
 
         # (see Base::Connection#execute)

--- a/lib/kitchen/transport/winrm.rb
+++ b/lib/kitchen/transport/winrm.rb
@@ -88,6 +88,7 @@ module Kitchen
 
           session.close
         ensure
+          @file_transporter = nil
           @session = nil
         end
 


### PR DESCRIPTION
https://github.com/test-kitchen/test-kitchen/blob/master/lib/kitchen/transport/winrm.rb#L253 memoized the file_transporter with the first session and it wasn't cleared out in the case of a session close.

Resolves https://github.com/test-kitchen/kitchen-dsc/issues/22
Resolves #1062 