### PR TITLE
ignore_proxy:  Option to ignore the proxy settings running chef-client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.gem
 *.rbc
+*.un~
 .bundle
 .config
 .yardoc

--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -416,13 +416,13 @@ module Kitchen
           file.write(format_config_file(data))
         end
 
-        prepare_config_idempotency_check if config[:enforce_idempotency]
+        prepare_config_idempotency_check(data) if config[:enforce_idempotency]
       end
 
       # Writes a configuration file to the sandbox directory
       # to check for idempotency of the run.
       # @api private
-      def prepare_config_idempotency_check
+      def prepare_config_idempotency_check(data)
         handler_filename = "chef-client-fail-if-update-handler.rb"
         source = File.join(
           File.dirname(__FILE__), %w{.. .. .. support }, handler_filename

--- a/spec/kitchen/provisioner/chef_base_spec.rb
+++ b/spec/kitchen/provisioner/chef_base_spec.rb
@@ -82,6 +82,10 @@ describe Kitchen::Provisioner::ChefBase do
       provisioner[:chef_omnibus_install_options].must_equal nil
     end
 
+    it ":chef_ignore_proxy defaults to false" do
+      provisioner[:chef_ignore_proxy].must_equal false
+    end
+
     it ":run_list defaults to an empty array" do
       provisioner[:run_list].must_equal []
     end

--- a/spec/kitchen/provisioner/chef_solo_spec.rb
+++ b/spec/kitchen/provisioner/chef_solo_spec.rb
@@ -355,6 +355,14 @@ describe Kitchen::Provisioner::ChefSolo do
                                         ])
       end
 
+      it "does not export http proxy variables when chef_ignore_proxy is set" do
+        config[:http_proxy] = "http://proxy"
+        config[:https_proxy] = "https://proxy"
+        config[:chef_gnore_proxy] = true
+
+        cmd.wont_match regexify("proxy")
+      end
+
       it "does no powershell PATH reloading for older chef omnibus packages" do
         cmd.wont_match regexify(%{[System.Environment]::})
       end

--- a/spec/kitchen/provisioner/chef_zero_spec.rb
+++ b/spec/kitchen/provisioner/chef_zero_spec.rb
@@ -742,6 +742,14 @@ describe Kitchen::Provisioner::ChefZero do
                                           ])
         end
 
+        it "does not export http proxy variables when chef_ignore_proxy is set" do
+          config[:http_proxy] = "http://proxy"
+          config[:https_proxy] = "https://proxy"
+          config[:chef_ignore_proxy] = true
+
+          cmd.wont_match regexify("proxy")
+        end
+
         it "does no powershell PATH reloading for older chef omnibus packages" do
           cmd.wont_match regexify(%{[System.Environment]::})
         end


### PR DESCRIPTION
I run chef-client in an enterprise environment where the client will not
have access to the internet.  I would like to test without proxies being
specified.  I also use omnibus to install chef on my instances.  These
two requirements lead to this work flow. No_proxy setting are just not the
same as not specifying the proxy values and in many cases no_proxy settings
 do not work.

Work flow before:
- Set the proxies in .kitchen.yml
- Kitchen converge, runs omnibus, fails running chef-client
- Remove the proxy setting.
- Kitchen converge.
- Add the proxy settings
- Kitchen verify.

Work flow with ignore_proxy set
- Kitchen test  (proxy settings are only used for omnibus chef-client install and for setup)
