### PR TITLE
Make RakeTask#config public.

### DIFF
--- a/lib/kitchen/rake_tasks.rb
+++ b/lib/kitchen/rake_tasks.rb
@@ -44,10 +44,10 @@ module Kitchen
       define
     end
 
-    private
-
     # @return [Config] a Kitchen::Config
     attr_reader :config
+
+    private
 
     # Generates a test Rake task for each instance and one to test all
     # instances in serial.


### PR DESCRIPTION
Given the comment on initialize, I think that a public config accessor was the
original intent, but when define was made private, the accessor was made private
as well. I found having a public accessor convenient for "faking" multinode
support by overriding the rake task to spin up and destroy the dependency
instances before and after the real task.
