### PR TITLE
Use a less volatile recipe for ci tests

### DIFF
--- a/.kitchen.ci.yml
+++ b/.kitchen.ci.yml
@@ -23,4 +23,4 @@ verifier:
 suites:
   - name: default
     run_list:
-      - recipe[filezilla]
+      - recipe[test_cookbook::default]

--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,3 @@
 source "https://supermarket.chef.io"
 
-cookbook "filezilla"
+cookbook "test_cookbook", :path => "./test/cookbooks/test_cookbook"

--- a/test/cookbooks/test_cookbook/metadata.rb
+++ b/test/cookbooks/test_cookbook/metadata.rb
@@ -1,0 +1,6 @@
+name "test_cookbook"
+maintainer "Maintainer"
+maintainer_email "Maintainer@example.com"
+license "Apache 2.0"
+description "Used for testing test-kitchen"
+version "0.1.0"

--- a/test/cookbooks/test_cookbook/recipes/default.rb
+++ b/test/cookbooks/test_cookbook/recipes/default.rb
@@ -1,0 +1,1 @@
+directory "/tk_test_directory"

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -1,3 +1,3 @@
-describe oneget("FileZilla Client 3.14.1") do
-  it { should be_installed }
+describe directory("/tk_test_directory") do
+  it { should exist }
 end


### PR DESCRIPTION
This replaces the current package based integration test with a less volitile directory creation test. All we really need here is for a real provisioner and verifier to run and it doesn't so much matter what they do. I originally set this up with a package because that was the absolute simplest way to run a cookbook as is from the supermarket, but the reality is its only a few lines of code to add a test cookbook with a simple directory resource.

Ideally we would use the shell provisioner to keep this chef agnostic, but until we break the chef provisioners out of core, its nice to have this coverage.