### PR TITLE
Adding test_base_path CLI arg to the diagnose command

### DIFF
--- a/lib/kitchen/cli.rb
+++ b/lib/kitchen/cli.rb
@@ -135,6 +135,7 @@ module Kitchen
       :type => :boolean,
       :desc => "Include all diagnostics"
     log_options
+    test_base_path
     def diagnose(*args)
       update_config!
       perform("diagnose", "diagnose", args, :loader => @loader)


### PR DESCRIPTION
\cc @test-kitchen/maintainers 

Previously this value would get set/merged into the config on things like `kitchen verify`, but you could not use it with `kitchen diagnose`