### PR TITLE
Added Errno::EPIPE to RESCUE_EXCEPTIONS_ON_ESTABLISH

### DIFF
--- a/lib/kitchen/transport/ssh.rb
+++ b/lib/kitchen/transport/ssh.rb
@@ -188,7 +188,7 @@ module Kitchen
 
         RESCUE_EXCEPTIONS_ON_ESTABLISH = [
           Errno::EACCES, Errno::EADDRINUSE, Errno::ECONNREFUSED, Errno::ETIMEDOUT,
-          Errno::ECONNRESET, Errno::ENETUNREACH, Errno::EHOSTUNREACH,
+          Errno::ECONNRESET, Errno::ENETUNREACH, Errno::EHOSTUNREACH, Errno::EPIPE,
           Net::SSH::Disconnect, Net::SSH::AuthenticationFailed, Net::SSH::ConnectionTimeout,
           Timeout::Error
         ].freeze


### PR DESCRIPTION
For issue https://github.com/test-kitchen/test-kitchen/issues/1079

Added Errno::EPIPE to ssh transport acceptable errors when waiting for SSH, as it can trigger when proxying through a bastion