### PR TITLE
Add environment variables $TEST_KITCHEN and $CI

### DIFF
--- a/lib/kitchen/configurable.rb
+++ b/lib/kitchen/configurable.rb
@@ -312,7 +312,10 @@ module Kitchen
     end
 
     def env_wrapped(code)
-      (proxy_settings << code).join("\n")
+      code_parts = proxy_settings
+      code_parts << shell_env_var('TEST_KITCHEN', 1)
+      code_parts << code
+      code_parts.join("\n")
     end
 
     def proxy_setting_keys

--- a/lib/kitchen/configurable.rb
+++ b/lib/kitchen/configurable.rb
@@ -313,7 +313,8 @@ module Kitchen
 
     def env_wrapped(code)
       code_parts = proxy_settings
-      code_parts << shell_env_var('TEST_KITCHEN', 1)
+      code_parts << shell_env_var("TEST_KITCHEN", 1)
+      code_parts << shell_env_var("CI", ENV["CI"]) if ENV["CI"]
       code_parts << code
       code_parts.join("\n")
     end

--- a/spec/kitchen/configurable_spec.rb
+++ b/spec/kitchen/configurable_spec.rb
@@ -747,6 +747,7 @@ describe Kitchen::Configurable do
       it "uses bourne shell (sh)" do
         cmd.must_equal(outdent!(<<-CODE.chomp))
           sh -c '
+          TEST_KITCHEN="1"; export TEST_KITCHEN
           mkdir foo
           '
         CODE
@@ -759,6 +760,7 @@ describe Kitchen::Configurable do
           sh -c '
           http_proxy="http://proxy"; export http_proxy
           HTTP_PROXY="http://proxy"; export HTTP_PROXY
+          TEST_KITCHEN="1"; export TEST_KITCHEN
           mkdir foo
           '
         CODE
@@ -771,6 +773,7 @@ describe Kitchen::Configurable do
           sh -c '
           https_proxy="https://proxy"; export https_proxy
           HTTPS_PROXY="https://proxy"; export HTTPS_PROXY
+          TEST_KITCHEN="1"; export TEST_KITCHEN
           mkdir foo
           '
         CODE
@@ -783,6 +786,7 @@ describe Kitchen::Configurable do
           sh -c '
           ftp_proxy="ftp://proxy"; export ftp_proxy
           FTP_PROXY="ftp://proxy"; export FTP_PROXY
+          TEST_KITCHEN="1"; export TEST_KITCHEN
           mkdir foo
           '
         CODE
@@ -801,6 +805,7 @@ describe Kitchen::Configurable do
           HTTPS_PROXY="https://proxy"; export HTTPS_PROXY
           ftp_proxy="ftp://proxy"; export ftp_proxy
           FTP_PROXY="ftp://proxy"; export FTP_PROXY
+          TEST_KITCHEN="1"; export TEST_KITCHEN
           mkdir foo
           '
         CODE
@@ -814,6 +819,7 @@ describe Kitchen::Configurable do
           sh -c '
           http_proxy="http://proxy"; export http_proxy
           HTTP_PROXY="http://proxy"; export HTTP_PROXY
+          TEST_KITCHEN="1"; export TEST_KITCHEN
           mkdir foo
           '
         CODE
@@ -827,6 +833,7 @@ describe Kitchen::Configurable do
           sh -c '
           https_proxy="https://proxy"; export https_proxy
           HTTPS_PROXY="https://proxy"; export HTTPS_PROXY
+          TEST_KITCHEN="1"; export TEST_KITCHEN
           mkdir foo
           '
         CODE
@@ -839,6 +846,7 @@ describe Kitchen::Configurable do
 
         cmd.must_equal(outdent!(<<-CODE.chomp))
           sh -c '
+          TEST_KITCHEN="1"; export TEST_KITCHEN
           mkdir foo
           '
         CODE
@@ -851,6 +859,7 @@ describe Kitchen::Configurable do
 
         cmd.must_equal(outdent!(<<-CODE.chomp))
           sh -c '
+          TEST_KITCHEN="1"; export TEST_KITCHEN
           mkdir foo
           '
         CODE
@@ -864,6 +873,7 @@ describe Kitchen::Configurable do
           sh -c '
           ftp_proxy="ftp://proxy"; export ftp_proxy
           FTP_PROXY="ftp://proxy"; export FTP_PROXY
+          TEST_KITCHEN="1"; export TEST_KITCHEN
           mkdir foo
           '
         CODE
@@ -874,6 +884,7 @@ describe Kitchen::Configurable do
 
         cmd.must_equal(outdent!(<<-CODE.chomp))
           sh -c '
+          TEST_KITCHEN="1"; export TEST_KITCHEN
           mkdir foo
           '
         CODE
@@ -891,6 +902,7 @@ describe Kitchen::Configurable do
           HTTP_PROXY="http://proxy"; export HTTP_PROXY
           no_proxy="http://no"; export no_proxy
           NO_PROXY="http://no"; export NO_PROXY
+          TEST_KITCHEN="1"; export TEST_KITCHEN
           mkdir foo
           '
         CODE
@@ -908,6 +920,7 @@ describe Kitchen::Configurable do
           HTTPS_PROXY="https://proxy"; export HTTPS_PROXY
           no_proxy="http://no"; export no_proxy
           NO_PROXY="http://no"; export NO_PROXY
+          TEST_KITCHEN="1"; export TEST_KITCHEN
           mkdir foo
           '
         CODE
@@ -925,6 +938,7 @@ describe Kitchen::Configurable do
           FTP_PROXY="ftp://proxy"; export FTP_PROXY
           no_proxy="http://no"; export no_proxy
           NO_PROXY="http://no"; export NO_PROXY
+          TEST_KITCHEN="1"; export TEST_KITCHEN
           mkdir foo
           '
         CODE
@@ -936,7 +950,7 @@ describe Kitchen::Configurable do
       before { platform.stubs(:shell_type).returns("powershell") }
 
       it "uses powershell shell" do
-        cmd.must_equal("mkdir foo")
+        cmd.must_equal("$env:TEST_KITCHEN = \"1\"\nmkdir foo")
       end
 
       it "exports http_proxy & HTTP_PROXY when :http_proxy is set" do
@@ -945,6 +959,7 @@ describe Kitchen::Configurable do
         cmd.must_equal(outdent!(<<-CODE.chomp))
           $env:http_proxy = "http://proxy"
           $env:HTTP_PROXY = "http://proxy"
+          $env:TEST_KITCHEN = "1"
           mkdir foo
         CODE
       end
@@ -955,6 +970,7 @@ describe Kitchen::Configurable do
         cmd.must_equal(outdent!(<<-CODE.chomp))
           $env:https_proxy = "https://proxy"
           $env:HTTPS_PROXY = "https://proxy"
+          $env:TEST_KITCHEN = "1"
           mkdir foo
         CODE
       end
@@ -965,6 +981,7 @@ describe Kitchen::Configurable do
         cmd.must_equal(outdent!(<<-CODE.chomp))
           $env:ftp_proxy = "ftp://proxy"
           $env:FTP_PROXY = "ftp://proxy"
+          $env:TEST_KITCHEN = "1"
           mkdir foo
         CODE
       end
@@ -981,6 +998,7 @@ describe Kitchen::Configurable do
           $env:HTTPS_PROXY = "https://proxy"
           $env:ftp_proxy = "ftp://proxy"
           $env:FTP_PROXY = "ftp://proxy"
+          $env:TEST_KITCHEN = "1"
           mkdir foo
         CODE
       end
@@ -992,6 +1010,7 @@ describe Kitchen::Configurable do
         cmd.must_equal(outdent!(<<-CODE.chomp))
           $env:http_proxy = "http://proxy"
           $env:HTTP_PROXY = "http://proxy"
+          $env:TEST_KITCHEN = "1"
           mkdir foo
         CODE
       end
@@ -1003,6 +1022,7 @@ describe Kitchen::Configurable do
         cmd.must_equal(outdent!(<<-CODE.chomp))
           $env:https_proxy = "https://proxy"
           $env:HTTPS_PROXY = "https://proxy"
+          $env:TEST_KITCHEN = "1"
           mkdir foo
         CODE
       end
@@ -1014,6 +1034,7 @@ describe Kitchen::Configurable do
         cmd.must_equal(outdent!(<<-CODE.chomp))
           $env:ftp_proxy = "ftp://proxy"
           $env:FTP_PROXY = "ftp://proxy"
+          $env:TEST_KITCHEN = "1"
           mkdir foo
         CODE
       end
@@ -1029,6 +1050,7 @@ describe Kitchen::Configurable do
           $env:HTTP_PROXY = "http://proxy"
           $env:no_proxy = "http://no"
           $env:NO_PROXY = "http://no"
+          $env:TEST_KITCHEN = "1"
           mkdir foo
         CODE
       end
@@ -1044,6 +1066,7 @@ describe Kitchen::Configurable do
           $env:HTTPS_PROXY = "https://proxy"
           $env:no_proxy = "http://no"
           $env:NO_PROXY = "http://no"
+          $env:TEST_KITCHEN = "1"
           mkdir foo
         CODE
       end
@@ -1059,6 +1082,7 @@ describe Kitchen::Configurable do
           $env:FTP_PROXY = "ftp://proxy"
           $env:no_proxy = "http://no"
           $env:NO_PROXY = "http://no"
+          $env:TEST_KITCHEN = "1"
           mkdir foo
         CODE
       end

--- a/spec/kitchen/configurable_spec.rb
+++ b/spec/kitchen/configurable_spec.rb
@@ -732,7 +732,8 @@ describe Kitchen::Configurable do
       ENV.replace("http_proxy"  => nil, "HTTP_PROXY"  => nil,
                   "https_proxy" => nil, "HTTPS_PROXY" => nil,
                   "ftp_proxy"   => nil, "FTP_PROXY"   => nil,
-                  "no_proxy"    => nil, "NO_PROXY"    => nil)
+                  "no_proxy"    => nil, "NO_PROXY"    => nil,
+                  "CI"          => nil)
     end
 
     after do
@@ -943,6 +944,18 @@ describe Kitchen::Configurable do
           '
         CODE
       end
+
+      it "exports CI when CI is set" do
+        ENV["CI"] = "1"
+
+        cmd.must_equal(outdent!(<<-CODE.chomp))
+          sh -c '
+          TEST_KITCHEN="1"; export TEST_KITCHEN
+          CI="1"; export CI
+          mkdir foo
+          '
+        CODE
+      end
     end
 
     describe "for powershell shells" do
@@ -1083,6 +1096,16 @@ describe Kitchen::Configurable do
           $env:no_proxy = "http://no"
           $env:NO_PROXY = "http://no"
           $env:TEST_KITCHEN = "1"
+          mkdir foo
+        CODE
+      end
+
+      it "exports CI when CI is set" do
+        ENV["CI"] = "1"
+
+        cmd.must_equal(outdent!(<<-CODE.chomp))
+          $env:TEST_KITCHEN = "1"
+          $env:CI = "1"
           mkdir foo
         CODE
       end


### PR DESCRIPTION
This would address #458 in a way that works across all provisioners. For Chef we might maybe want to also inject this as a node attribute but I think `if ENV['TEST_KITCHEN']` in recipe code should be fine as is.