### PR TITLE
Shell verifier enhancements for running test suite within an instance

### DIFF
--- a/lib/kitchen/verifier/shell.rb
+++ b/lib/kitchen/verifier/shell.rb
@@ -66,6 +66,8 @@ module Kitchen
       def prepare_command
         return unless config[:remote_upload_path]
         commands = []
+        commands << [sudo('rm -rf'), config[:remote_upload_path] + ' &&']
+        commands << [sudo('mkdir -p'), config[:remote_upload_path] + ' &&']
         commands << [sudo('cp -r'),
                      File.join(config[:root_path],
                                File.basename(config[:upload_path]) + '/*'),

--- a/lib/kitchen/verifier/shell.rb
+++ b/lib/kitchen/verifier/shell.rb
@@ -59,7 +59,7 @@ module Kitchen
       end
 
       def install_command
-        cmd = "#{sudo('mkdir')} -p #{config[:root_path]}/#{config[:upload_path]}"
+        cmd = "#{sudo("mkdir")} -p #{config[:root_path]}/#{config[:upload_path]}"
         debug(cmd)
         cmd
       end
@@ -72,15 +72,14 @@ module Kitchen
       def prepare_command
         return unless config[:remote_upload_path]
         commands = []
-        commands << [sudo('rm -rf'), config[:remote_upload_path] + ' &&']
-        commands << [sudo('mkdir -p'), config[:remote_upload_path] + ' &&']
-        commands << [sudo('cp -r'),
-                     File.join(config[:root_path],
-                               File.basename(config[:upload_path]) + '/*'),
+        commands << [sudo("rm -rf"), config[:remote_upload_path] + " &&"]
+        commands << [sudo("mkdir -p"), config[:remote_upload_path] + " &&"]
+        commands << [sudo("cp -r"),
+                     File.join(config[:root_path], File.basename(config[:upload_path]) + "/*"),
                      config[:remote_upload_path]
                     ]
 
-        commands = commands.join(' ')
+        commands = commands.join(" ")
         logger.debug commands
         commands
       end

--- a/lib/kitchen/verifier/shell.rb
+++ b/lib/kitchen/verifier/shell.rb
@@ -58,6 +58,12 @@ module Kitchen
         prepare_upload
       end
 
+      def install_command
+        cmd = "#{sudo('mkdir')} -p #{config[:root_path]}/#{config[:upload_path]}"
+        debug(cmd)
+        cmd
+      end
+
       def prepare_upload
         return unless config[:upload_path]
         FileUtils.cp_r(config[:upload_path], sandbox_path, :preserve => true)

--- a/lib/kitchen/verifier/shell.rb
+++ b/lib/kitchen/verifier/shell.rb
@@ -53,6 +53,30 @@ module Kitchen
         debug("[#{name}] Verify completed.")
       end
 
+      def create_sandbox
+        super
+        prepare_upload
+      end
+
+      def prepare_upload
+        return unless config[:upload_path]
+        FileUtils.cp_r(config[:upload_path], sandbox_path, :preserve => true)
+      end
+
+      def prepare_command
+        return unless config[:remote_upload_path]
+        commands = []
+        commands << [sudo('cp -r'),
+                     File.join(config[:root_path],
+                               File.basename(config[:upload_path]) + '/*'),
+                     config[:remote_upload_path]
+                    ]
+
+        commands = commands.join(' ')
+        logger.debug commands
+        commands
+      end
+
       # for legacy drivers.
       def run_command
         if config[:remote_exec]


### PR DESCRIPTION
This set of commits reuploads test suite under verifier control on each `kitchen verify` execution.
This is critical while developing new tests and extending test suite.
