### PR TITLE
Escape paths before running policyfile commands

### DIFF
--- a/.cane
+++ b/.cane
@@ -5,4 +5,5 @@
 --abc-exclude Kitchen::Driver::SSHBase#verify
 --abc-exclude Kitchen::Configurable#wrap_shell_code
 --style-exclude lib/vendor/**/*.rb
+--style-exclude spec/kitchen/provisioner/chef/policyfile_spec.rb
 --doc-exclude lib/vendor/**/.rb

--- a/lib/kitchen/provisioner/chef/policyfile.rb
+++ b/lib/kitchen/provisioner/chef/policyfile.rb
@@ -16,6 +16,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "shellwords"
+require "rbconfig"
+
 require "kitchen/errors"
 require "kitchen/logging"
 require "kitchen/shell_out"
@@ -59,7 +62,7 @@ module Kitchen
         # in the desired path.
         def resolve
           info("Exporting cookbook dependencies from Policyfile #{path}...")
-          run_command("chef export #{policyfile} #{path} --force")
+          run_command("chef export #{escape_path(policyfile)} #{escape_path(path)} --force")
         end
 
         # Runs `chef install` to determine the correct cookbook set and
@@ -67,7 +70,7 @@ module Kitchen
         def compile
           info("Policy lock file doesn't exist, running `chef install` for "\
                "Policyfile #{policyfile}...")
-          run_command("chef install #{policyfile}")
+          run_command("chef install #{escape_path(policyfile)}")
         end
 
         private
@@ -99,6 +102,29 @@ module Kitchen
                          "setting includes the path to the `chef` comand.")
             raise UserError,
               "Could not find the chef executable in your PATH."
+          end
+        end
+
+        # Escape spaces in a path in way that works with both Sh (Unix) and
+        # Windows.
+        #
+        # @param path [String] Path to escape
+        # @return [String]
+        # @api private
+        def escape_path(path)
+          if RbConfig::CONFIG["host_os"] =~ /mswin|mingw/
+            # I know what you're thinking: "just use Shellwords.escape". That
+            # method produces incorrect results on Windows with certain input
+            # which would be a metacharacter in Sh but is not for one or more of
+            # Windows command line parsing libraries. This covers the 99% case of
+            # spaces in the path without breaking other stuff.
+            if path =~ /[ \t\n\v"]/
+              "\"#{path.gsub(/[ \t\n\v\"\\]/) {|m| "\\"+m[0] }}\""
+            else
+              path
+            end
+          else
+            Shellwords.escape(path)
           end
         end
       end

--- a/lib/kitchen/provisioner/chef/policyfile.rb
+++ b/lib/kitchen/provisioner/chef/policyfile.rb
@@ -119,7 +119,7 @@ module Kitchen
             # Windows command line parsing libraries. This covers the 99% case of
             # spaces in the path without breaking other stuff.
             if path =~ /[ \t\n\v"]/
-              "\"#{path.gsub(/[ \t\n\v\"\\]/) {|m| "\\"+m[0] }}\""
+              "\"#{path.gsub(/[ \t\n\v\"\\]/) { |m| "\\" + m[0] }}\""
             else
               path
             end

--- a/lib/kitchen/provisioner/chef/policyfile.rb
+++ b/lib/kitchen/provisioner/chef/policyfile.rb
@@ -36,7 +36,7 @@ module Kitchen
 
         # Creates a new cookbook resolver.
         #
-        # @param berksfile [String] path to a Berksfile
+        # @param policyfile [String] path to a Policyfile
         # @param path [String] path in which to vendor the resulting
         #   cookbooks
         # @param logger [Kitchen::Logger] a logger to use for output, defaults

--- a/spec/kitchen/provisioner/chef/policyfile_spec.rb
+++ b/spec/kitchen/provisioner/chef/policyfile_spec.rb
@@ -22,58 +22,69 @@ require "kitchen/provisioner/chef/policyfile"
 describe Kitchen::Provisioner::Chef::Policyfile do
   let(:policyfile) { "" }
   let(:path) { "" }
-  let(:null_logger) { double("null_logger", :fatal => nil, :error => nil,
-                                            :warn => nil, :info => nil,
-                                            :debug => nil, :banner => nil) }
-  let(:described_object) { described_class.new(policyfile, path, null_logger) }
+  let(:null_logger) { stub(:fatal => nil, :error => nil, :warn => nil,
+                           :info => nil, :debug => nil, :banner => nil) }
+  let(:described_object) do
+    Kitchen::Provisioner::Chef::Policyfile.new(policyfile, path, null_logger)
+  end
   let(:os) { "" }
   before do
-    stub_const("RbConfig::CONFIG", "host_os" => os)
+    @original_rbconfig = RbConfig::CONFIG
+    verbose = $VERBOSE
+    $VERBOSE = nil
+    RbConfig.const_set(:CONFIG, "host_os" => os)
+    $VERBOSE = verbose
+  end
+  after do
+    verbose = $VERBOSE
+    $VERBOSE = nil
+    RbConfig.const_set(:CONFIG, @original_rbconfig)
+    $VERBOSE = verbose
   end
 
   # rubocop:disable Metrics/LineLength
   describe "#resolve" do
     subject { described_object.resolve }
 
-    context "on Unix" do
+    describe "on Unix" do
       let(:os) { "linux-gnu" }
 
-      context "with simple paths" do
+      describe "with simple paths" do
         let(:policyfile) { "/home/user/cookbook/Policyfile.rb" }
         let(:path) { "/tmp/kitchen/cookbooks" }
         it do
-          expect(described_object).to receive(:run_command).with("chef export /home/user/cookbook/Policyfile.rb /tmp/kitchen/cookbooks --force")
+          described_object.expects(:run_command).with("chef export /home/user/cookbook/Policyfile.rb /tmp/kitchen/cookbooks --force")
           subject
         end
       end
 
-      context "with Jenkins-y paths" do
+      describe "with Jenkins-y paths" do
         let(:policyfile) { "/home/jenkins/My Chef Cookbook/workspace/current/Policyfile.rb" }
         let(:path) { "/tmp/kitchen/cookbooks" }
         it do
-          expect(described_object).to receive(:run_command).with("chef export /home/jenkins/My\\ Chef\\ Cookbook/workspace/current/Policyfile.rb /tmp/kitchen/cookbooks --force")
+          described_object.expects(:run_command).with("chef export /home/jenkins/My\\ Chef\\ Cookbook/workspace/current/Policyfile.rb /tmp/kitchen/cookbooks --force")
           subject
         end
       end
     end
 
-    context "on Windows" do
+    describe "on Windows" do
       let(:os) { "mswin" }
 
-      context "with simple paths" do
+      describe "with simple paths" do
         let(:policyfile) { "C:\\cookbook\\Policyfile.rb" }
         let(:path) { "C:\\Temp\\kitchen\\cookbooks" }
         it do
-          expect(described_object).to receive(:run_command).with("chef export C:\\cookbook\\Policyfile.rb C:\\Temp\\kitchen\\cookbooks --force")
+          described_object.expects(:run_command).with("chef export C:\\cookbook\\Policyfile.rb C:\\Temp\\kitchen\\cookbooks --force")
           subject
         end
       end
 
-      context "with Jenkins-y paths" do
+      describe "with Jenkins-y paths" do
         let(:policyfile) { "C:\\Program Files\\Jenkins\\My Chef Cookbook\\workspace\\current\\Policyfile.rb" }
         let(:path) { "C:\\Temp\\kitchen\\cookbooks" }
         it do
-          expect(described_object).to receive(:run_command).with("chef export \"C:\\\\Program\\ Files\\\\Jenkins\\\\My\\ Chef\\ Cookbook\\\\workspace\\\\current\\\\Policyfile.rb\" C:\\Temp\\kitchen\\cookbooks --force")
+          described_object.expects(:run_command).with("chef export \"C:\\\\Program\\ Files\\\\Jenkins\\\\My\\ Chef\\ Cookbook\\\\workspace\\\\current\\\\Policyfile.rb\" C:\\Temp\\kitchen\\cookbooks --force")
           subject
         end
       end
@@ -83,41 +94,41 @@ describe Kitchen::Provisioner::Chef::Policyfile do
   describe "#compile" do
     subject { described_object.compile }
 
-    context "on Unix" do
+    describe "on Unix" do
       let(:os) { "linux-gnu" }
 
-      context "with simple paths" do
+      describe "with simple paths" do
         let(:policyfile) { "/home/user/cookbook/Policyfile.rb" }
         it do
-          expect(described_object).to receive(:run_command).with("chef install /home/user/cookbook/Policyfile.rb")
+          described_object.expects(:run_command).with("chef install /home/user/cookbook/Policyfile.rb")
           subject
         end
       end
 
-      context "with Jenkins-y paths" do
+      describe "with Jenkins-y paths" do
         let(:policyfile) { "/home/jenkins/My Chef Cookbook/workspace/current/Policyfile.rb" }
         it do
-          expect(described_object).to receive(:run_command).with("chef install /home/jenkins/My\\ Chef\\ Cookbook/workspace/current/Policyfile.rb")
+          described_object.expects(:run_command).with("chef install /home/jenkins/My\\ Chef\\ Cookbook/workspace/current/Policyfile.rb")
           subject
         end
       end
     end
 
-    context "on Windows" do
+    describe "on Windows" do
       let(:os) { "mswin" }
 
-      context "with simple paths" do
+      describe "with simple paths" do
         let(:policyfile) { "C:\\cookbook\\Policyfile.rb" }
         it do
-          expect(described_object).to receive(:run_command).with("chef install C:\\cookbook\\Policyfile.rb")
+          described_object.expects(:run_command).with("chef install C:\\cookbook\\Policyfile.rb")
           subject
         end
       end
 
-      context "with Jenkins-y paths" do
+      describe "with Jenkins-y paths" do
         let(:policyfile) { "C:\\Program Files\\Jenkins\\My Chef Cookbook\\workspace\\current\\Policyfile.rb" }
         it do
-          expect(described_object).to receive(:run_command).with("chef install \"C:\\\\Program\\ Files\\\\Jenkins\\\\My\\ Chef\\ Cookbook\\\\workspace\\\\current\\\\Policyfile.rb\"")
+          described_object.expects(:run_command).with("chef install \"C:\\\\Program\\ Files\\\\Jenkins\\\\My\\ Chef\\ Cookbook\\\\workspace\\\\current\\\\Policyfile.rb\"")
           subject
         end
       end

--- a/spec/kitchen/provisioner/chef/policyfile_spec.rb
+++ b/spec/kitchen/provisioner/chef/policyfile_spec.rb
@@ -22,8 +22,10 @@ require "kitchen/provisioner/chef/policyfile"
 describe Kitchen::Provisioner::Chef::Policyfile do
   let(:policyfile) { "" }
   let(:path) { "" }
-  let(:null_logger) { stub(:fatal => nil, :error => nil, :warn => nil,
-                           :info => nil, :debug => nil, :banner => nil) }
+  let(:null_logger) do
+    stub(:fatal => nil, :error => nil, :warn => nil, :info => nil,
+         :debug => nil, :banner => nil)
+  end
   let(:described_object) do
     Kitchen::Provisioner::Chef::Policyfile.new(policyfile, path, null_logger)
   end

--- a/spec/kitchen/provisioner/chef/policyfile_spec.rb
+++ b/spec/kitchen/provisioner/chef/policyfile_spec.rb
@@ -22,13 +22,16 @@ require "kitchen/provisioner/chef/policyfile"
 describe Kitchen::Provisioner::Chef::Policyfile do
   let(:policyfile) { "" }
   let(:path) { "" }
-  let(:null_logger) { double("null_logger", fatal: nil, error: nil, warn: nil, info: nil, debug: nil, banner: nil) }
-  subject(:described_object) { described_class.new(policyfile, path, null_logger) }
+  let(:null_logger) { double("null_logger", :fatal => nil, :error => nil,
+                                            :warn => nil, :info => nil,
+                                            :debug => nil, :banner => nil) }
+  let(:described_object) { described_class.new(policyfile, path, null_logger) }
   let(:os) { "" }
   before do
-    stub_const('RbConfig::CONFIG', "host_os" => os)
+    stub_const("RbConfig::CONFIG", "host_os" => os)
   end
 
+  # rubocop:disable Metrics/LineLength
   describe "#resolve" do
     subject { described_object.resolve }
 
@@ -120,4 +123,5 @@ describe Kitchen::Provisioner::Chef::Policyfile do
       end
     end
   end
+  # rubocop:enable Metrics/LineLength
 end

--- a/spec/kitchen/provisioner/chef/policyfile_spec.rb
+++ b/spec/kitchen/provisioner/chef/policyfile_spec.rb
@@ -1,0 +1,123 @@
+# -*- encoding: utf-8 -*-
+#
+# Author:: Noah Kantrowitz
+#
+# Copyright (C) 2016, Noah Kantrowitz
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative "../../../spec_helper"
+require "kitchen/provisioner/chef/policyfile"
+
+describe Kitchen::Provisioner::Chef::Policyfile do
+  let(:policyfile) { "" }
+  let(:path) { "" }
+  let(:null_logger) { double("null_logger", fatal: nil, error: nil, warn: nil, info: nil, debug: nil, banner: nil) }
+  subject(:described_object) { described_class.new(policyfile, path, null_logger) }
+  let(:os) { "" }
+  before do
+    stub_const('RbConfig::CONFIG', "host_os" => os)
+  end
+
+  describe "#resolve" do
+    subject { described_object.resolve }
+
+    context "on Unix" do
+      let(:os) { "linux-gnu" }
+
+      context "with simple paths" do
+        let(:policyfile) { "/home/user/cookbook/Policyfile.rb" }
+        let(:path) { "/tmp/kitchen/cookbooks" }
+        it do
+          expect(described_object).to receive(:run_command).with("chef export /home/user/cookbook/Policyfile.rb /tmp/kitchen/cookbooks --force")
+          subject
+        end
+      end
+
+      context "with Jenkins-y paths" do
+        let(:policyfile) { "/home/jenkins/My Chef Cookbook/workspace/current/Policyfile.rb" }
+        let(:path) { "/tmp/kitchen/cookbooks" }
+        it do
+          expect(described_object).to receive(:run_command).with("chef export /home/jenkins/My\\ Chef\\ Cookbook/workspace/current/Policyfile.rb /tmp/kitchen/cookbooks --force")
+          subject
+        end
+      end
+    end
+
+    context "on Windows" do
+      let(:os) { "mswin" }
+
+      context "with simple paths" do
+        let(:policyfile) { "C:\\cookbook\\Policyfile.rb" }
+        let(:path) { "C:\\Temp\\kitchen\\cookbooks" }
+        it do
+          expect(described_object).to receive(:run_command).with("chef export C:\\cookbook\\Policyfile.rb C:\\Temp\\kitchen\\cookbooks --force")
+          subject
+        end
+      end
+
+      context "with Jenkins-y paths" do
+        let(:policyfile) { "C:\\Program Files\\Jenkins\\My Chef Cookbook\\workspace\\current\\Policyfile.rb" }
+        let(:path) { "C:\\Temp\\kitchen\\cookbooks" }
+        it do
+          expect(described_object).to receive(:run_command).with("chef export \"C:\\\\Program\\ Files\\\\Jenkins\\\\My\\ Chef\\ Cookbook\\\\workspace\\\\current\\\\Policyfile.rb\" C:\\Temp\\kitchen\\cookbooks --force")
+          subject
+        end
+      end
+    end
+  end
+
+  describe "#compile" do
+    subject { described_object.compile }
+
+    context "on Unix" do
+      let(:os) { "linux-gnu" }
+
+      context "with simple paths" do
+        let(:policyfile) { "/home/user/cookbook/Policyfile.rb" }
+        it do
+          expect(described_object).to receive(:run_command).with("chef install /home/user/cookbook/Policyfile.rb")
+          subject
+        end
+      end
+
+      context "with Jenkins-y paths" do
+        let(:policyfile) { "/home/jenkins/My Chef Cookbook/workspace/current/Policyfile.rb" }
+        it do
+          expect(described_object).to receive(:run_command).with("chef install /home/jenkins/My\\ Chef\\ Cookbook/workspace/current/Policyfile.rb")
+          subject
+        end
+      end
+    end
+
+    context "on Windows" do
+      let(:os) { "mswin" }
+
+      context "with simple paths" do
+        let(:policyfile) { "C:\\cookbook\\Policyfile.rb" }
+        it do
+          expect(described_object).to receive(:run_command).with("chef install C:\\cookbook\\Policyfile.rb")
+          subject
+        end
+      end
+
+      context "with Jenkins-y paths" do
+        let(:policyfile) { "C:\\Program Files\\Jenkins\\My Chef Cookbook\\workspace\\current\\Policyfile.rb" }
+        it do
+          expect(described_object).to receive(:run_command).with("chef install \"C:\\\\Program\\ Files\\\\Jenkins\\\\My\\ Chef\\ Cookbook\\\\workspace\\\\current\\\\Policyfile.rb\"")
+          subject
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Some of my coworkers noticed that TK+Policyfiles breaks if there are spaces in some of the enclosing folder names. As the tests say, this comes up with Jenkins a lot, but good hygiene. Notably this is not the full Windows path escape function because [it is huge and annoying](https://github.com/poise/poise/blob/master/lib/poise/utils/win32.rb#L65-L101) and I think this should cover all non-what-were-you-thinking cases.