### PR TITLE
Ability to work with Instances over SSH tunnel.

### DIFF
--- a/lib/kitchen/transport/ssh.rb
+++ b/lib/kitchen/transport/ssh.rb
@@ -146,7 +146,7 @@ module Kitchen
           if options.key?(:forward_agent)
             args += %W[ -o ForwardAgent=#{options[:forward_agent] ? "yes" : "no"} ]
           end
-         if ssh_gateway
+          if ssh_gateway
             gateway_command = "ssh -q #{ssh_gateway_username}@#{ssh_gateway} nc #{hostname} #{port}"
             args += %W[ -o ProxyCommand=#{gateway_command} ]
             args += %W[ -p 22 ] # Should support other ports than 22 for ssh gateways

--- a/test-kitchen.gemspec
+++ b/test-kitchen.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "mixlib-shellout", ">= 1.2", "< 3.0"
   gem.add_dependency "net-scp",         "~> 1.1"
   gem.add_dependency "net-ssh",         ">= 2.9", "< 4.0"
+  gem.add_dependency "net-ssh-gateway", "~> 1.2.0"
   gem.add_dependency "safe_yaml",       "~> 1.0"
   gem.add_dependency "thor",            "~> 0.18"
   gem.add_dependency "mixlib-install",  "~> 1.0", ">= 1.0.4"


### PR DESCRIPTION
Inspired by:
https://github.com/test-kitchen/test-kitchen/pull/294
https://github.com/test-kitchen/test-kitchen/pull/933

In your .kitchen.yml file you use:
```
transport:
  name: ssh
  ssh_gateway: <gateway>
  ssh_gateway_username: <username at the gateway>
```
and all ssh operations will be tunnelled through this <gateway>.
Basically we replace Net::SSH session in transport/ssh.rb with Net::SSH::Gateway, since this moment all ssh operations go through the tunnel. Remote end 'not being ready' also reported correctly:
```
local@ey-test-kitchen:~/test-kitchen-ey$ bundle exec kitchen converge -l debug
-----> Starting Kitchen (v1.10.2)
D      Berksfile found at /home/local/test-kitchen-ey/Berksfile, loading Berkshelf
D      Berkshelf 4.3.5 library loaded
-----> Creating <default-centos-7>...
D      [SSH] opening connection to local@10.236.62.20<{:user_known_hosts_file=>"/dev/null", :paranoid=>false, :port=>22, :compression=>false, :compression_level=>0, :keepalive=>true, :keepalive_interval=>60, :timeout=>15}> via eyurchenko@10.236.11.190
D      [SSH] connection failed (#<Net::SSH::ConnectionTimeout: timeout during server version negotiating>)
       Waiting for SSH service on 10.236.62.20:22, retrying in 3 seconds
D      [SSH] opening connection to local@10.236.62.20<{:user_known_hosts_file=>"/dev/null", :paranoid=>false, :port=>22, :compression=>false, :compression_level=>0, :keepalive=>true, :keepalive_interval=>60, :timeout=>15}> via eyurchenko@10.236.11.190
D      [SSH] local@10.236.62.20<{:user_known_hosts_file=>"/dev/null", :paranoid=>false, :port=>22, :compression=>false, :compression_level=>0, :keepalive=>true, :keepalive_interval=>60, :timeout=>15}> (echo '[SSH] Established')
       [SSH] Established
D      SSH ready on <default-centos-7>
...
```