### PR TITLE
Dont set ssh key configuration if a password is specified

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,13 +1,7 @@
 # -*- encoding: utf-8 -*-
 source "https://rubygems.org"
 gemspec
-
-group :guard do
-  gem "guard-minitest"
-  gem "guard-cucumber", "~> 1.4"
-  gem "guard-rubocop"
-  gem "guard-yard"
-end
+gem "rack", "< 2.0"
 
 group :integration do
   gem "berkshelf", "~> 4.3"

--- a/lib/kitchen/transport/ssh.rb
+++ b/lib/kitchen/transport/ssh.rb
@@ -350,9 +350,12 @@ module Kitchen
           :max_wait_until_ready   => data[:max_wait_until_ready]
         }
 
-        opts[:keys_only] = true                     if data[:ssh_key]
-        opts[:keys] = Array(data[:ssh_key])         if data[:ssh_key]
-        opts[:auth_methods] = ["publickey"]         if data[:ssh_key]
+        if data[:ssh_key] && !data.key?(:password)
+          opts[:keys_only] = true
+          opts[:keys] = Array(data[:ssh_key])
+          opts[:auth_methods] = ["publickey"]
+        end
+
         opts[:password] = data[:password]           if data.key?(:password)
         opts[:forward_agent] = data[:forward_agent] if data.key?(:forward_agent)
         opts[:verbose] = data[:verbose].to_sym      if data.key?(:verbose)

--- a/spec/kitchen/transport/ssh_spec.rb
+++ b/spec/kitchen/transport/ssh_spec.rb
@@ -531,6 +531,64 @@ describe Kitchen::Transport::Ssh do
         make_connection
       end
 
+      it "does not set :keys_only if :ssh_key is set in config but password is set" do
+        config[:ssh_key] = "ssh_key_from_config"
+        config[:password] = "password"
+
+        klass.expects(:new).with do |hash|
+          hash[:keys_only].nil?
+        end
+
+        make_connection
+      end
+
+      it "does not set :auth_methods if :ssh_key is set in config but password is set" do
+        config[:ssh_key] = "ssh_key_from_config"
+        config[:password] = "password"
+
+        klass.expects(:new).with do |hash|
+          hash[:auth_methods].nil?
+        end
+
+        make_connection
+      end
+
+      it "does not set :keys_only if :ssh_key is set in state but password is set" do
+        state[:ssh_key] = "ssh_key_from_config"
+        config[:ssh_key] = false
+        config[:password] = "password"
+
+        klass.expects(:new).with do |hash|
+          hash[:keys_only].nil?
+        end
+
+        make_connection
+      end
+
+      it "does not set :keys to an array if :ssh_key is set in config but password is set" do
+        config[:kitchen_root] = "/r"
+        config[:ssh_key] = "ssh_key_from_config"
+        config[:password] = "password"
+
+        klass.expects(:new).with do |hash|
+          hash[:keys].nil?
+        end
+
+        make_connection
+      end
+
+      it "does not set :keys to an array if :ssh_key is set in state but password is set" do
+        state[:ssh_key] = "ssh_key_from_state"
+        config[:ssh_key] = "ssh_key_from_config"
+        config[:password] = "password"
+
+        klass.expects(:new).with do |hash|
+          hash[:keys].nil?
+        end
+
+        make_connection
+      end
+
       it "passes in :password if set in config" do
         config[:password] = "password_from_config"
 


### PR DESCRIPTION
If a user chooses not to use a ssh public key but prefers to use password authentication instead, test kitchen will not use the password even if one is specified in the config for many drivers.

This would only happen if the driver has a means of providing default ssh keys. kitchen-vagrant and kitchen-vra are two examples. Since both have a means of providing default keys that get passed to the transport, any password provided in the kitchen.yml is ignored.

This will ignore the ssh key settings if a password is explicitly set.