### PR TITLE
Check the actual value, because `password: nil` shouldn't disable sending the key.

### DIFF
--- a/lib/kitchen/transport/ssh.rb
+++ b/lib/kitchen/transport/ssh.rb
@@ -416,7 +416,7 @@ module Kitchen
           :ssh_gateway_username   => data[:ssh_gateway_username]
         }
 
-        if data[:ssh_key] && !data.key?(:password)
+        if data[:ssh_key] && !data[:password]
           opts[:keys_only] = true
           opts[:keys] = Array(data[:ssh_key])
           opts[:auth_methods] = ["publickey"]


### PR DESCRIPTION
This is currently breaking kitchen-docker.