### PR TITLE
support passing Kitchen::Config Hash keys to Kitchen::RakeTasks.new

### DIFF
--- a/lib/kitchen/rake_tasks.rb
+++ b/lib/kitchen/rake_tasks.rb
@@ -30,14 +30,14 @@ module Kitchen
     # Creates Kitchen Rake tasks and allows the callee to configure it.
     #
     # @yield [self] gives itself to the block
-    def initialize
+    def initialize(cfg = {})
       @loader = Kitchen::Loader::YAML.new(
         :project_config => ENV["KITCHEN_YAML"],
         :local_config => ENV["KITCHEN_LOCAL_YAML"],
         :global_config => ENV["KITCHEN_GLOBAL_YAML"]
       )
       @config = Kitchen::Config.new(
-        :loader => @loader
+        { :loader => @loader }.merge(cfg)
       )
       Kitchen.logger = Kitchen.default_file_logger(nil, false)
       yield self if block_given?


### PR DESCRIPTION
The current implementation of the `Kitchen::RakeTasks.new` method is that you aren't able to modify the config generated by `Kitchen::Config.new`. As such, if you want to change the `test_base_path` value, you need to duplicate most of this helper in to your `Rakefile`.

This change adds the ability to pass a Hash in to the `.new` method, and it will be merged with the config sent to `Kitchen::Config.new`. If nothing is passed in to the `.new` method, it defaults to an empty Hash (`{}`).