### PR TITLE
Always run `chef install` even if the lock file exists.

### DIFF
--- a/lib/kitchen/provisioner/chef/common_sandbox.rb
+++ b/lib/kitchen/provisioner/chef/common_sandbox.rb
@@ -301,13 +301,11 @@ module Kitchen
                  "kitchen config. The run_list in your config will be ignored.")
             warn("Ignored run_list: #{config[:run_list].inspect}")
           end
-          policylock = policyfile.gsub(/\.rb\Z/, ".lock.json")
-          unless File.exist?(policylock)
-            Kitchen.mutex.synchronize do
-              Chef::Policyfile.new(policyfile, sandbox_path, logger).compile
-            end
+          policy = Chef::Policyfile.new(policyfile, sandbox_path, logger)
+          Kitchen.mutex.synchronize do
+            policy.compile
           end
-          policy_name = JSON.parse(IO.read(policylock))["name"]
+          policy_name = JSON.parse(IO.read(policy.lockfile))["name"]
           policy_group = "local"
           config[:attributes].merge(:policy_name => policy_name, :policy_group => policy_group)
         end

--- a/lib/kitchen/provisioner/chef/policyfile.rb
+++ b/lib/kitchen/provisioner/chef/policyfile.rb
@@ -68,9 +68,20 @@ module Kitchen
         # Runs `chef install` to determine the correct cookbook set and
         # generate the policyfile lock.
         def compile
-          info("Policy lock file doesn't exist, running `chef install` for "\
-               "Policyfile #{policyfile}...")
+          if File.exist?(lockfile)
+            info("Installing cookbooks for Policyfile #{policyfile} using `chef install`")
+          else
+            info("Policy lock file doesn't exist, running `chef install` for "\
+                 "Policyfile #{policyfile}...")
+          end
           run_command("chef install #{escape_path(policyfile)}")
+        end
+
+        # Return the path to the lockfile corresponding to this policyfile.
+        #
+        # @return [String]
+        def lockfile
+          policyfile.gsub(/\.rb\Z/, ".lock.json")
         end
 
         private

--- a/spec/kitchen/provisioner/chef_base_spec.rb
+++ b/spec/kitchen/provisioner/chef_base_spec.rb
@@ -897,7 +897,7 @@ describe Kitchen::Provisioner::ChefBase do
 
         let(:policyfile_path) { "#{kitchen_root}/Policyfile.rb" }
         let(:policyfile_lock_path) { "#{kitchen_root}/Policyfile.lock.json" }
-        let(:resolver) { stub(:compile => true, :resolve => true, lockfile: policyfile_lock_path) }
+        let(:resolver) { stub(:compile => true, :resolve => true, :lockfile => policyfile_lock_path) }
 
         describe "with the default name `Policyfile.rb`" do
           before do

--- a/spec/kitchen/provisioner/chef_base_spec.rb
+++ b/spec/kitchen/provisioner/chef_base_spec.rb
@@ -897,7 +897,9 @@ describe Kitchen::Provisioner::ChefBase do
 
         let(:policyfile_path) { "#{kitchen_root}/Policyfile.rb" }
         let(:policyfile_lock_path) { "#{kitchen_root}/Policyfile.lock.json" }
-        let(:resolver) { stub(:compile => true, :resolve => true, :lockfile => policyfile_lock_path) }
+        let(:resolver) {
+          stub(:compile => true, :resolve => true, :lockfile => policyfile_lock_path)
+        }
 
         describe "with the default name `Policyfile.rb`" do
           before do

--- a/spec/kitchen/provisioner/chef_base_spec.rb
+++ b/spec/kitchen/provisioner/chef_base_spec.rb
@@ -895,7 +895,9 @@ describe Kitchen::Provisioner::ChefBase do
 
       describe "with a Policyfile under kitchen_root" do
 
-        let(:resolver) { stub(:resolve => true) }
+        let(:policyfile_path) { "#{kitchen_root}/Policyfile.rb" }
+        let(:policyfile_lock_path) { "#{kitchen_root}/Policyfile.lock.json" }
+        let(:resolver) { stub(:compile => true, :resolve => true, lockfile: policyfile_lock_path) }
 
         describe "with the default name `Policyfile.rb`" do
           before do
@@ -948,13 +950,14 @@ POLICYFILE
             end
 
             it "uses uses the policyfile to resolve dependencies" do
+              resolver.expects(:compile)
               resolver.expects(:resolve)
 
               provisioner.create_sandbox
             end
 
             it "uses Kitchen.mutex for resolving" do
-              Kitchen.mutex.expects(:synchronize)
+              Kitchen.mutex.expects(:synchronize).twice
 
               provisioner.create_sandbox
             end
@@ -1014,6 +1017,7 @@ POLICYFILE
 
             it "uses uses the policyfile to resolve dependencies" do
               Kitchen::Provisioner::Chef::Policyfile.stubs(:load!)
+              resolver.expects(:compile)
               resolver.expects(:resolve)
 
               provisioner.create_sandbox
@@ -1026,6 +1030,7 @@ POLICYFILE
                 returns(resolver)
 
               Kitchen::Provisioner::Chef::Policyfile.stubs(:load!)
+              resolver.expects(:compile)
               resolver.expects(:resolve)
 
               provisioner.create_sandbox
@@ -1095,6 +1100,7 @@ POLICYFILE
 
             it "uses uses the policyfile to resolve dependencies" do
               Kitchen::Provisioner::Chef::Policyfile.stubs(:load!)
+              resolver.expects(:compile)
               resolver.expects(:resolve)
 
               provisioner.create_sandbox
@@ -1107,6 +1113,7 @@ POLICYFILE
                 returns(resolver)
 
               Kitchen::Provisioner::Chef::Policyfile.stubs(:load!)
+              resolver.expects(:compile)
               resolver.expects(:resolve)
 
               provisioner.create_sandbox


### PR DESCRIPTION
This is required to make sure the cookbooks are cached before we run
`chef export` in CI or other non-workstation environments.

Also refactored things a tad.