### PR TITLE
Add a new config option always_update_cookbooks

### DIFF
--- a/lib/kitchen/provisioner/chef/berkshelf.rb
+++ b/lib/kitchen/provisioner/chef/berkshelf.rb
@@ -62,13 +62,9 @@ module Kitchen
           debug("Using Berksfile from #{berksfile}")
 
           ::Berkshelf.ui.mute do
-            if ::Berkshelf::Berksfile.method_defined?(:vendor)
-              # Berkshelf 3.0 requires the directory to not exist
-              FileUtils.rm_rf(path)
-              ::Berkshelf::Berksfile.from_file(berksfile).vendor(path)
-            else
-              ::Berkshelf::Berksfile.from_file(berksfile).install(:path => path)
-            end
+            # Berkshelf requires the directory to not exist
+            FileUtils.rm_rf(path)
+            ::Berkshelf::Berksfile.from_file(berksfile).vendor(path)
           end
         end
 

--- a/lib/kitchen/provisioner/chef/berkshelf.rb
+++ b/lib/kitchen/provisioner/chef/berkshelf.rb
@@ -40,17 +40,18 @@ module Kitchen
         #   cookbooks
         # @param logger [Kitchen::Logger] a logger to use for output, defaults
         #   to `Kitchen.logger`
-        def initialize(berksfile, path, logger = Kitchen.logger)
+        def initialize(berksfile, path, logger: Kitchen.logger, always_update: false)
           @berksfile  = berksfile
           @path       = path
           @logger     = logger
+          @always_update = always_update
         end
 
         # Loads the library code required to use the resolver.
         #
         # @param logger [Kitchen::Logger] a logger to use for output, defaults
         #   to `Kitchen.logger`
-        def self.load!(logger = Kitchen.logger)
+        def self.load!(logger: Kitchen.logger)
           load_berkshelf!(logger)
         end
 
@@ -62,9 +63,11 @@ module Kitchen
           debug("Using Berksfile from #{berksfile}")
 
           ::Berkshelf.ui.mute do
+            berksfile_obj = ::Berkshelf::Berksfile.from_file(berksfile)
+            berksfile_obj.update if always_update
             # Berkshelf requires the directory to not exist
             FileUtils.rm_rf(path)
-            ::Berkshelf::Berksfile.from_file(berksfile).vendor(path)
+            berksfile_obj.vendor(path)
           end
         end
 
@@ -81,6 +84,10 @@ module Kitchen
         # @return [Kitchen::Logger] a logger to use for output
         # @api private
         attr_reader :logger
+
+        # @return [Boolean] If true, always update cookbooks in Berkshelf.
+        # @api private
+        attr_reader :always_update
 
         # Load the Berkshelf-specific libary code.
         #

--- a/lib/kitchen/provisioner/chef/common_sandbox.rb
+++ b/lib/kitchen/provisioner/chef/common_sandbox.rb
@@ -301,7 +301,9 @@ module Kitchen
                  "kitchen config. The run_list in your config will be ignored.")
             warn("Ignored run_list: #{config[:run_list].inspect}")
           end
-          policy = Chef::Policyfile.new(policyfile, sandbox_path, logger)
+          policy = Chef::Policyfile.new(policyfile, sandbox_path,
+            :logger => logger,
+            :always_update => config[:always_update_cookbooks])
           Kitchen.mutex.synchronize do
             policy.compile
           end
@@ -315,7 +317,9 @@ module Kitchen
         # @api private
         def resolve_with_policyfile
           Kitchen.mutex.synchronize do
-            Chef::Policyfile.new(policyfile, sandbox_path, logger).resolve
+            Chef::Policyfile.new(policyfile, sandbox_path,
+              :logger => logger,
+              :always_update => config[:always_update_cookbooks]).resolve
           end
         end
 
@@ -324,7 +328,9 @@ module Kitchen
         # @api private
         def resolve_with_berkshelf
           Kitchen.mutex.synchronize do
-            Chef::Berkshelf.new(berksfile, tmpbooks_dir, logger).resolve
+            Chef::Berkshelf.new(berksfile, tmpbooks_dir,
+              :logger => logger,
+              :always_update => config[:always_update_cookbooks]).resolve
           end
         end
 
@@ -333,7 +339,7 @@ module Kitchen
         # @api private
         def resolve_with_librarian
           Kitchen.mutex.synchronize do
-            Chef::Librarian.new(cheffile, tmpbooks_dir, logger).resolve
+            Chef::Librarian.new(cheffile, tmpbooks_dir, :logger => logger).resolve
           end
         end
 

--- a/lib/kitchen/provisioner/chef/librarian.rb
+++ b/lib/kitchen/provisioner/chef/librarian.rb
@@ -40,7 +40,7 @@ module Kitchen
         #   cookbooks
         # @param logger [Kitchen::Logger] a logger to use for output, defaults
         #   to `Kitchen.logger`
-        def initialize(cheffile, path, logger = Kitchen.logger)
+        def initialize(cheffile, path, logger: Kitchen.logger)
           @cheffile   = cheffile
           @path       = path
           @logger     = logger
@@ -50,7 +50,7 @@ module Kitchen
         #
         # @param logger [Kitchen::Logger] a logger to use for output, defaults
         #   to `Kitchen.logger`
-        def self.load!(logger = Kitchen.logger)
+        def self.load!(logger: Kitchen.logger)
           load_librarian!(logger)
         end
 

--- a/lib/kitchen/provisioner/chef/policyfile.rb
+++ b/lib/kitchen/provisioner/chef/policyfile.rb
@@ -44,17 +44,18 @@ module Kitchen
         #   cookbooks
         # @param logger [Kitchen::Logger] a logger to use for output, defaults
         #   to `Kitchen.logger`
-        def initialize(policyfile, path, logger = Kitchen.logger)
+        def initialize(policyfile, path, logger: Kitchen.logger, always_update: false)
           @policyfile = policyfile
           @path       = path
           @logger     = logger
+          @always_update = always_update
         end
 
         # Loads the library code required to use the resolver.
         #
         # @param logger [Kitchen::Logger] a logger to use for output, defaults
         #   to `Kitchen.logger`
-        def self.load!(logger = Kitchen.logger)
+        def self.load!(logger: Kitchen.logger)
           detect_chef_command!(logger)
         end
 
@@ -68,6 +69,10 @@ module Kitchen
         # Runs `chef install` to determine the correct cookbook set and
         # generate the policyfile lock.
         def compile
+          if always_update
+            info("Updating policy lock using `chef update`")
+            run_command("chef update #{escape_path(policyfile)}")
+          end
           if File.exist?(lockfile)
             info("Installing cookbooks for Policyfile #{policyfile} using `chef install`")
           else
@@ -97,6 +102,10 @@ module Kitchen
         # @return [Kitchen::Logger] a logger to use for output
         # @api private
         attr_reader :logger
+
+        # @return [Boolean] If true, always update cookbooks in the policy.
+        # @api private
+        attr_reader :always_update
 
         # Ensure the `chef` command is in the path.
         #

--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -344,6 +344,11 @@ module Kitchen
         installer.install_command
       end
 
+      # Hook used in subclasses to indicate support for policyfiles.
+      #
+      # @abstract
+      # @return [Boolean]
+      # @api private
       def supports_policyfile?
         false
       end

--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -59,6 +59,9 @@ module Kitchen
       # Will try to autodetect by searching for `Policyfile.rb` if not set.
       # If set, will error if the file doesn't exist.
       default_config :policyfile_path, nil
+      # If set to true (which is the default from `chef generate`), try to update
+      # backend cookbook downloader on every kitchen run.
+      default_config :always_update_cookbooks, false
       default_config :cookbook_files_glob, %w[
         README.* metadata.{json,rb}
         attributes/**/* definitions/**/* files/**/* libraries/**/*
@@ -281,13 +284,13 @@ module Kitchen
         super
         if File.exist?(policyfile)
           debug("Policyfile found at #{policyfile}, using Policyfile to resolve dependencies")
-          Chef::Policyfile.load!(logger)
+          Chef::Policyfile.load!(:logger => logger)
         elsif File.exist?(berksfile)
           debug("Berksfile found at #{berksfile}, loading Berkshelf")
-          Chef::Berkshelf.load!(logger)
+          Chef::Berkshelf.load!(:logger => logger)
         elsif File.exist?(cheffile)
           debug("Cheffile found at #{cheffile}, loading Librarian-Chef")
-          Chef::Librarian.load!(logger)
+          Chef::Librarian.load!(:logger => logger)
         end
       end
 

--- a/spec/kitchen/provisioner/chef/policyfile_spec.rb
+++ b/spec/kitchen/provisioner/chef/policyfile_spec.rb
@@ -27,7 +27,7 @@ describe Kitchen::Provisioner::Chef::Policyfile do
          :debug => nil, :banner => nil)
   end
   let(:described_object) do
-    Kitchen::Provisioner::Chef::Policyfile.new(policyfile, path, null_logger)
+    Kitchen::Provisioner::Chef::Policyfile.new(policyfile, path, :logger => null_logger)
   end
   let(:os) { "" }
   before do


### PR DESCRIPTION
 Add a new config option `always_update_cookbooks` to force both berks and policyfiles to update on each kitchen run.

The intention is to enable this by default in the skeleton generated by `chef generate`.

Open to more intuitive names for the config option. Also the removes Berks 2.x support because I think we should be done with that. I can put it back if anyone objects.