### PR TITLE
Allow the user to make deprecations errors

### DIFF
--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -67,6 +67,8 @@ module Kitchen
         attributes/**/* definitions/**/* files/**/* libraries/**/*
         providers/**/* recipes/**/* resources/**/* templates/**/*
       ].join(",")
+      # to ease upgrades, allow the user to turn deprecation warnings into errors
+      default_config :deprecations_as_errors, false
 
       default_config :data_path do |provisioner|
         provisioner.calculate_path("data")
@@ -218,7 +220,8 @@ module Kitchen
           :chef_server_url  => "http://127.0.0.1:8889",
           :encrypted_data_bag_secret => remote_path_join(
             root, "encrypted_data_bag_secret"
-          )
+          ),
+          :treat_deprecation_warnings_as_errors => config[:deprecations_as_errors]
         }
       end
 

--- a/spec/kitchen/provisioner/chef_base_spec.rb
+++ b/spec/kitchen/provisioner/chef_base_spec.rb
@@ -1321,6 +1321,10 @@ POLICYFILE
             file.must_include %{encrypted_data_bag_secret } +
               %{"/tmp/kitchen/encrypted_data_bag_secret"}
           end
+
+          it "disables deprecation warnings" do
+            file.must_include %{treat_deprecation_warnings_as_errors false}
+          end
         end
 
         it "supports overwriting defaults" do


### PR DESCRIPTION
This came out of a discussion at the chef CBGB meeting about easing the
migration to later major numbered versions of chef.
cc @coderanger

Signed-off-by: Thom May <thom@chef.io>