### PR TITLE
Add support for Windows Nano installs via chef provisioners

### DIFF
--- a/lib/kitchen/configurable.rb
+++ b/lib/kitchen/configurable.rb
@@ -255,7 +255,7 @@ module Kitchen
     def reload_ps1_path
       [
         %{$env:PATH},
-        %{[System.Environment]::GetEnvironmentVariable("PATH","Machine")\n\n}
+        %(try { [System.Environment]::GetEnvironmentVariable("PATH","Machine") } catch {}\n\n)
       ].join(" = ")
     end
 

--- a/spec/kitchen/provisioner/chef_solo_spec.rb
+++ b/spec/kitchen/provisioner/chef_solo_spec.rb
@@ -500,7 +500,7 @@ describe Kitchen::Provisioner::ChefSolo do
 
       it "reloads PATH for older chef omnibus packages" do
         cmd.must_match regexify("$env:PATH = " +
-          %{[System.Environment]::GetEnvironmentVariable("PATH","Machine")})
+          %(try { [System.Environment]::GetEnvironmentVariable("PATH","Machine") } catch {}))
       end
 
       it "calls the chef-solo command from :chef_solo_path" do

--- a/spec/kitchen/provisioner/chef_zero_spec.rb
+++ b/spec/kitchen/provisioner/chef_zero_spec.rb
@@ -818,7 +818,7 @@ describe Kitchen::Provisioner::ChefZero do
 
         it "reloads PATH for older chef omnibus packages" do
           cmd.must_match regexify("$env:PATH = " +
-            %{[System.Environment]::GetEnvironmentVariable("PATH","Machine")})
+            %(try { [System.Environment]::GetEnvironmentVariable("PATH","Machine") } catch {}))
         end
 
         it "calls the chef-client command from :chef_client_path" do
@@ -979,7 +979,7 @@ describe Kitchen::Provisioner::ChefZero do
 
         it "reloads PATH for older chef omnibus packages" do
           cmd.must_match regexify("$env:PATH = " +
-            %{[System.Environment]::GetEnvironmentVariable("PATH","Machine")})
+            %(try { [System.Environment]::GetEnvironmentVariable("PATH","Machine") } catch {}))
         end
       end
     end

--- a/test-kitchen.gemspec
+++ b/test-kitchen.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "net-ssh-gateway", "~> 1.2.0"
   gem.add_dependency "safe_yaml",       "~> 1.0"
   gem.add_dependency "thor",            "~> 0.18"
-  gem.add_dependency "mixlib-install",  "~> 1.0", ">= 1.0.4"
+  gem.add_dependency "mixlib-install",  "~> 1.2"
 
   gem.add_development_dependency "pry"
   gem.add_development_dependency "pry-byebug"


### PR DESCRIPTION
When used with the nano branch of `mixlib-install` and a provisioner config of:
```
provisioner:
  name: chef_zero
  install_msi_url: https://s3-us-west-2.amazonaws.com/nano-chef-client/chef-12.14.57.appx
```
This is successfully working to test on nano.

Still nedds much cleanup in mixlib-install and some testing to ensure we can get rid of refreshing the `$env:path` the `GetEnvironmentVariable`. I think because we use absolute paths in the chef provosioners, thats ok but needs testing.