### PR TITLE
fix broken path on nano so shell out works

### DIFF
--- a/lib/kitchen/configurable.rb
+++ b/lib/kitchen/configurable.rb
@@ -254,9 +254,10 @@ module Kitchen
     # @api private
     def reload_ps1_path
       [
-        %{$env:PATH},
-        %(try { [System.Environment]::GetEnvironmentVariable("PATH","Machine") } catch {}\n\n)
-      ].join(" = ")
+        "$env:PATH = try {",
+        "[System.Environment]::GetEnvironmentVariable('PATH','Machine')",
+        "} catch { $env:PATH }\n\n"
+      ].join("\n")
     end
 
     # Builds a shell environment variable assignment string for the

--- a/spec/kitchen/provisioner/chef_solo_spec.rb
+++ b/spec/kitchen/provisioner/chef_solo_spec.rb
@@ -499,8 +499,9 @@ describe Kitchen::Provisioner::ChefSolo do
       end
 
       it "reloads PATH for older chef omnibus packages" do
-        cmd.must_match regexify("$env:PATH = " +
-          %(try { [System.Environment]::GetEnvironmentVariable("PATH","Machine") } catch {}))
+        cmd.must_match regexify("$env:PATH = try {\n" \
+        "[System.Environment]::GetEnvironmentVariable('PATH','Machine')\n" \
+        "} catch { $env:PATH }")
       end
 
       it "calls the chef-solo command from :chef_solo_path" do

--- a/spec/kitchen/provisioner/chef_zero_spec.rb
+++ b/spec/kitchen/provisioner/chef_zero_spec.rb
@@ -817,8 +817,9 @@ describe Kitchen::Provisioner::ChefZero do
         end
 
         it "reloads PATH for older chef omnibus packages" do
-          cmd.must_match regexify("$env:PATH = " +
-            %(try { [System.Environment]::GetEnvironmentVariable("PATH","Machine") } catch {}))
+          cmd.must_match regexify("$env:PATH = try {\n" \
+          "[System.Environment]::GetEnvironmentVariable('PATH','Machine')\n" \
+          "} catch { $env:PATH }")
         end
 
         it "calls the chef-client command from :chef_client_path" do
@@ -978,8 +979,9 @@ describe Kitchen::Provisioner::ChefZero do
         end
 
         it "reloads PATH for older chef omnibus packages" do
-          cmd.must_match regexify("$env:PATH = " +
-            %(try { [System.Environment]::GetEnvironmentVariable("PATH","Machine") } catch {}))
+          cmd.must_match regexify("$env:PATH = try {\n" \
+          "[System.Environment]::GetEnvironmentVariable('PATH','Machine')\n" \
+          "} catch { $env:PATH }")
         end
       end
     end


### PR DESCRIPTION
Ugh. shelling out on nano is totally busted because we clear the path. This fixes that.