### PR TITLE
Add default pathing fixes for windows provisioner and verifier

### DIFF
--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -48,6 +48,9 @@ module Kitchen
       default_config :require_chef_omnibus, true
       default_config :chef_omnibus_url, "https://omnitruck.chef.io/install.sh"
       default_config :chef_omnibus_install_options, nil
+      default_config :chef_omnibus_root do |provisioner|
+        provisioner.windows_os? ? "$env:systemdrive\\opscode\\chef" : "/opt/chef"
+      end
       default_config :run_list, []
       default_config :attributes, {}
       default_config :config_path, nil

--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -164,7 +164,6 @@ module Kitchen
           :install_flags => config[:chef_omnibus_install_options],
           :sudo_command => sudo_command
         }.tap do |opts|
-          opts[:root] = config[:chef_omnibus_root] if config.key? :chef_omnibus_root
           [:install_msi_url, :http_proxy, :https_proxy].each do |key|
             opts[key] = config[key] if config.key? key
           end

--- a/lib/kitchen/transport/ssh.rb
+++ b/lib/kitchen/transport/ssh.rb
@@ -394,7 +394,7 @@ module Kitchen
       # @param data [Hash] merged configuration and mutable state data
       # @return [Hash] hash of connection options
       # @api private
-      # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/CyclomaticComplexity
+      # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
       def connection_options(data)
         opts = {
           :logger                 => logger,

--- a/lib/kitchen/verifier/base.rb
+++ b/lib/kitchen/verifier/base.rb
@@ -44,7 +44,9 @@ module Kitchen
         verifier.windows_os? ? nil : true
       end
 
-      default_config :chef_omnibus_root, "/opt/chef"
+      default_config :chef_omnibus_root do |verifier|
+        verifier.windows_os? ? "$env:systemdrive\\opscode\\chef" : "/opt/chef"
+      end
 
       default_config :sudo_command do |verifier|
         verifier.windows_os? ? nil : "sudo -E"

--- a/lib/kitchen/verifier/busser.rb
+++ b/lib/kitchen/verifier/busser.rb
@@ -43,11 +43,7 @@ module Kitchen
       end
 
       default_config :ruby_bindir do |verifier|
-        if verifier.windows_os?
-          "$env:systemdrive\\opscode\\chef\\embedded\\bin"
-        else
-          verifier.remote_path_join(%W[#{verifier[:chef_omnibus_root]} embedded bin])
-        end
+        verifier.remote_path_join(%W[#{verifier[:chef_omnibus_root]} embedded bin])
       end
 
       default_config :version, "busser"

--- a/spec/kitchen/provisioner/chef_base_spec.rb
+++ b/spec/kitchen/provisioner/chef_base_spec.rb
@@ -285,8 +285,8 @@ describe Kitchen::Provisioner::ChefBase do
       end
 
       it "will set the install root" do
+        config[:require_chef_omnibus] = true
         config[:chef_omnibus_root] = "/tmp/test"
-        install_opts[:root] = "/tmp/test"
 
         Mixlib::Install::ScriptGenerator.expects(:new).
           with(default_version, false, install_opts).returns(installer)


### PR DESCRIPTION
This patch should resolve behavior differences with both provisioners and verifiers for windows machines.

This is likely to resolve the following issue:
- https://github.com/test-kitchen/test-kitchen/issues/1013

And, although not the primary issue, another example of the incorrect pathing is shown here:
- https://github.com/test-kitchen/test-kitchen/issues/1125

``` bash
> kitchen diagnose  -l debug 2012
D      [Vagrant command] BEGIN (vagrant --version)
D      [Vagrant command] END (0m0.31s)
D      Berksfile found at /Users/josh/src/wf/cookbooks/wf_ohai/Berksfile, loading Berkshelf
D      Berkshelf 5.1.0 library loaded
D      Berksfile found at /Users/josh/src/wf/cookbooks/wf_ohai/Berksfile, loading Berkshelf
D      Berkshelf 5.1.0 previously loaded
D      [Vagrant command] BEGIN (vagrant plugin list)
D      [Vagrant command] END (0m0.94s)
D      Berksfile found at /Users/josh/src/wf/cookbooks/wf_ohai/Berksfile, loading Berkshelf
D      Berkshelf 5.1.0 previously loaded
D      winrm requested, loading winrm gem (["~> 2.0"])
D      winrm is loaded.
D      winrm-fs requested, loading winrm-fs gem (["~> 1.0"])
D      winrm-fs is loaded.
```

Yaml output below, with pathing issues commented.

Keys:
- `provisioner.chef_client_path`
- `provisioner.ruby_bindir`

``` yaml

---
timestamp: 2016-09-26 20:37:54 UTC
kitchen_version: 1.13.0
instances:
  default-windows2012:
    platform:
      os_type: windows
      shell_type: powershell
    state_file:
      hostname: 127.0.0.1
      last_action: converge
      password: vagrant
      port: '55985'
      rdp_port: '3389'
      username: vagrant
    driver:
      boot_timeout:
      box: windows2012
      box_check_update:
      box_download_insecure:
      box_url: https://REDACTED/windows_2012_r2.box
      box_version:
      customize: {}
      gui:
      kitchen_root: "/Users/josh/src/wf/cookbooks/wf_ohai"
      linked_clone:
      log_level: :debug
      name: vagrant
      network: []
      pre_create_command:
      provider: virtualbox
      provision: false
      ssh: {}
      synced_folders: []
      test_base_path: "/Users/josh/src/wf/cookbooks/wf_ohai/test/integration"
      vagrant_binary: vagrant
      vagrantfile_erb: "/opt/chefdk/embedded/lib/ruby/gems/2.3.0/gems/kitchen-vagrant-0.20.0/templates/Vagrantfile.erb"
      vagrantfiles: []
      vm_hostname:
    provisioner:
      always_update_cookbooks: false
      attributes: {}
      chef_client_path: "\\bin\\chef-client.bat"    # <----- Here
      chef_omnibus_install_options:
      chef_omnibus_url: https://omnitruck.chef.io/install.sh
      chef_zero_host:
      chef_zero_port: 8889
      client_rb: {}
      clients_path:
      command_prefix:
      config_path:
      cookbook_files_glob: README.*,metadata.{json,rb},attributes/**/*,definitions/**/*,files/**/*,libraries/**/*,providers/**/*,recipes/**/*,resources/**/*,templates/**/*
      data_bags_path:
      data_path:
      encrypted_data_bag_secret_key_path:
      environments_path:
      ftp_proxy:
      http_proxy:
      https_proxy:
      json_attributes: true
      kitchen_root: "/Users/josh/src/wf/cookbooks/wf_ohai"
      log_file:
      log_level: auto
      max_retries: 1
      name: chef_zero
      named_run_list: {}
      nodes_path: "/Users/josh/src/wf/cookbooks/wf_ohai/test/integration/nodes"
      policyfile:
      policyfile_path:
      profile_ruby: false
      require_chef_omnibus: false
      retry_on_exit_code: []
      roles_path:
      root_path: "$env:TEMP\\kitchen"
      ruby_bindir: "\\embedded\\bin"    # <----- Here
      run_list:
      - recipe[wf_ohai]
      - recipe[export-node]
      sudo:
      sudo_command:
      test_base_path: "/Users/josh/src/wf/cookbooks/wf_ohai/test/integration"
      wait_for_retry: 30
    transport:
      connection_retries: 5
      connection_retry_sleep: 1
      elevated: false
      endpoint_template: http://%{hostname}:%{port}/wsman
      kitchen_root: "/Users/josh/src/wf/cookbooks/wf_ohai"
      log_level: :debug
      max_wait_until_ready: 600
      name: winrm
      password:
      port: 5985
      rdp_port: 3389
      test_base_path: "/Users/josh/src/wf/cookbooks/wf_ohai/test/integration"
      username: administrator
      winrm_transport: :negotiate
    verifier:
      busser_bin: "$env:TEMP\\verifier\\bin\\busser.bat"
      chef_omnibus_root: "/opt/chef"
      command_prefix:
      ftp_proxy:
      http_proxy:
      https_proxy:
      kitchen_root: "/Users/josh/src/wf/cookbooks/wf_ohai"
      log_level: :debug
      name: busser
      root_path: "$env:TEMP\\verifier"
      ruby_bindir: "$env:systemdrive\\opscode\\chef\\embedded\\bin"
      sudo:
      sudo_command:
      suite_name: default
      test_base_path: "/Users/josh/src/wf/cookbooks/wf_ohai/test/integration"
      version: busser
```

Finally; here is the diagnose run with the patch:

`> kitchen diagnose 2012`

``` yaml

---
timestamp: 2016-09-26 23:08:30 UTC
kitchen_version: 1.13.0
instances:
  default-windows2012:
    platform:
      os_type: windows
      shell_type: powershell
    state_file:
      hostname: 127.0.0.1
      last_action: converge
      password: vagrant
      port: '55985'
      rdp_port: '3389'
      username: vagrant
    driver:
      boot_timeout:
      box: windows2012
      box_check_update:
      box_download_insecure:
      box_url: https://REDACTED/windows_2012_r2.box
      box_version:
      customize: {}
      gui:
      kitchen_root: "/Users/josh/src/wf/cookbooks/wf_ohai"
      linked_clone:
      log_level: :info
      name: vagrant
      network: []
      pre_create_command:
      provider: virtualbox
      provision: false
      ssh: {}
      synced_folders: []
      test_base_path: "/Users/josh/src/wf/cookbooks/wf_ohai/test/integration"
      vagrant_binary: vagrant
      vagrantfile_erb: "/opt/chefdk/embedded/lib/ruby/gems/2.3.0/gems/kitchen-vagrant-0.20.0/templates/Vagrantfile.erb"
      vagrantfiles: []
      vm_hostname:
    provisioner:
      always_update_cookbooks: false
      attributes: {}
      chef_client_path: "$env:systemdrive\\opscode\\chef\\bin\\chef-client.bat"     # <--- pathing fixed
      chef_omnibus_install_options:
      chef_omnibus_root: "$env:systemdrive\\opscode\\chef"     # <--- set for child dependencies
      chef_omnibus_url: https://omnitruck.chef.io/install.sh
      chef_zero_host:
      chef_zero_port: 8889
      client_rb: {}
      clients_path:
      command_prefix:
      config_path:
      cookbook_files_glob: README.*,metadata.{json,rb},attributes/**/*,definitions/**/*,files/**/*,libraries/**/*,providers/**/*,recipes/**/*,resources/**/*,templates/**/*
      data_bags_path:
      data_path:
      encrypted_data_bag_secret_key_path:
      environments_path:
      ftp_proxy:
      http_proxy:
      https_proxy:
      json_attributes: true
      kitchen_root: "/Users/josh/src/wf/cookbooks/wf_ohai"
      log_file:
      log_level: auto
      max_retries: 1
      name: chef_zero
      named_run_list: {}
      nodes_path: "/Users/josh/src/wf/cookbooks/wf_ohai/test/integration/nodes"
      policyfile:
      policyfile_path:
      profile_ruby: false
      require_chef_omnibus: false
      retry_on_exit_code: []
      roles_path:
      root_path: "$env:TEMP\\kitchen"
      ruby_bindir: "$env:systemdrive\\opscode\\chef\\embedded\\bin"    # <--- pathing fixed
      run_list:
      - recipe[wf_ohai]
      - recipe[export-node]
      sudo:
      sudo_command:
      test_base_path: "/Users/josh/src/wf/cookbooks/wf_ohai/test/integration"
      wait_for_retry: 30
    transport:
      connection_retries: 5
      connection_retry_sleep: 1
      elevated: false
      endpoint_template: http://%{hostname}:%{port}/wsman
      kitchen_root: "/Users/josh/src/wf/cookbooks/wf_ohai"
      log_level: :info
      max_wait_until_ready: 600
      name: winrm
      password:
      port: 5985
      rdp_port: 3389
      test_base_path: "/Users/josh/src/wf/cookbooks/wf_ohai/test/integration"
      username: administrator
      winrm_transport: :negotiate
    verifier:
      busser_bin: "$env:TEMP\\verifier\\bin\\busser.bat"    # <--- still correct
      chef_omnibus_root: "$env:systemdrive\\opscode\\chef"    # <--- set for the children deps to reference
      command_prefix:
      ftp_proxy:
      http_proxy:
      https_proxy:
      kitchen_root: "/Users/josh/src/wf/cookbooks/wf_ohai"
      log_level: :info
      name: busser
      root_path: "$env:TEMP\\verifier"
      ruby_bindir: "$env:systemdrive\\opscode\\chef\\embedded\\bin" # <--- still correct
      sudo:
      sudo_command:
      suite_name: default
      test_base_path: "/Users/josh/src/wf/cookbooks/wf_ohai/test/integration"
      version: busser
```
