### PR TITLE
Fix #360

### DIFF
--- a/lib/kitchen/verifier/busser.rb
+++ b/lib/kitchen/verifier/busser.rb
@@ -102,7 +102,7 @@ module Kitchen
         prefix_command(wrap_shell_code(Util.outdent!(<<-CMD)))
           #{busser_env}
 
-          #{cmd} test
+          #{cmd} test #{plugins.join(" ").gsub!("busser-", "")}
         CMD
       end
 

--- a/spec/kitchen/verifier/busser_spec.rb
+++ b/spec/kitchen/verifier/busser_spec.rb
@@ -515,7 +515,7 @@ describe Kitchen::Verifier::Busser do
         it "runs busser's test" do
           config[:root_path] = "\\b"
 
-          cmd.must_match regexify(%{& \\b\\bin\\busser.bat test})
+          cmd.must_match regexify(%{& \\b\\bin\\busser.bat test}, :partial_line)
         end
       end
     end


### PR DESCRIPTION
This will only run the busser tests for the plugins detected instead of running `busser test` that runs bats tests even if they are not present.
