### PR TITLE
Added `last_error` and `--json` to `kitchen list`

### DIFF
--- a/features/kitchen_action_commands.feature
+++ b/features/kitchen_action_commands.feature
@@ -28,12 +28,12 @@ Feature: Running instance actions
   @spawn
   Scenario: Creating a single instance
     When I successfully run `kitchen list client-beans`
-    Then the stdout should match /^client-beans\s+.+\s+\<Not Created\>\Z/
+    Then the stdout should match /^client-beans\s+.+\s+\<Not Created\>\s+\<None\>\Z/
     When I run `kitchen create client-beans`
     Then the output should contain "Finished creating <client-beans>"
     And the exit status should be 0
     When I successfully run `kitchen list client-beans`
-    Then the stdout should match /^client-beans\s+.+\s+Created\Z/
+    Then the stdout should match /^client-beans\s+.+\s+Created\s+\<None\>\Z/
 
   @spawn
   Scenario: Creating a single instance that fails
@@ -44,23 +44,23 @@ Feature: Running instance actions
       fail_create: true
     """
     When I successfully run `kitchen list client-beans`
-    Then the stdout should match /^client-beans\s+.+\s+\<Not Created\>\Z/
+    Then the stdout should match /^client-beans\s+.+\s+\<Not Created\>\s+\<None\>\Z/
     When I run `kitchen create client-beans`
     Then the output should contain "Create failed on instance <client-beans>"
     And the exit status should not be 0
     When I successfully run `kitchen list client-beans`
-    Then the stdout should match /^client-beans\s+.+\s+\<Not Created\>\Z/
+    Then the stdout should match /^client-beans\s+.+\s+\<Not Created\>\s+Kitchen::ActionFailed\Z/
 
   @spawn
   Scenario: Converging a single instance
     When I successfully run `kitchen create client-beans`
     And I successfully run `kitchen list client-beans`
-    Then the stdout should match /^client-beans\s+.+\s+Created\Z/
+    Then the stdout should match /^client-beans\s+.+\s+Created\s+\<None\>\Z/
     When I run `kitchen converge client-beans`
     Then the output should contain "Finished converging <client-beans>"
     And the exit status should be 0
     When I successfully run `kitchen list client-beans`
-    Then the stdout should match /^client-beans\s+.+\s+Converged\Z/
+    Then the stdout should match /^client-beans\s+.+\s+Converged\s+\<None\>\Z/
 
   @spawn
   Scenario: Converging a single instance that fails
@@ -72,23 +72,23 @@ Feature: Running instance actions
     """
     When I successfully run `kitchen create client-beans`
     And I successfully run `kitchen list client-beans`
-    Then the stdout should match /^client-beans\s+.+\s+Created\Z/
+    Then the stdout should match /^client-beans\s+.+\s+Created\s+\<None\>\Z/
     When I run `kitchen converge client-beans`
     Then the output should contain "Converge failed on instance <client-beans>"
     And the exit status should not be 0
     When I successfully run `kitchen list client-beans`
-    Then the stdout should match /^client-beans\s+.+\s+Created\Z/
+    Then the stdout should match /^client-beans\s+.+\s+Created\s+Kitchen::ActionFailed\Z/
 
   @spawn
   Scenario: Setting up a single instance
     When I successfully run `kitchen converge client-beans`
     And I successfully run `kitchen list client-beans`
-    Then the stdout should match /^client-beans\s+.+\s+Converged\Z/
+    Then the stdout should match /^client-beans\s+.+\s+Converged\s+\<None\>\Z/
     When I run `kitchen setup client-beans`
     Then the output should contain "Finished setting up <client-beans>"
     And the exit status should be 0
     When I successfully run `kitchen list client-beans`
-    Then the stdout should match /^client-beans\s+.+\s+Set Up\Z/
+    Then the stdout should match /^client-beans\s+.+\s+Set Up\s+\<None\>\Z/
 
   @spawn
   Scenario: Setting up a single instance that fails
@@ -100,23 +100,23 @@ Feature: Running instance actions
     """
     When I successfully run `kitchen converge client-beans`
     And I successfully run `kitchen list client-beans`
-    Then the stdout should match /^client-beans\s+.+\s+Converged\Z/
+    Then the stdout should match /^client-beans\s+.+\s+Converged\s+\<None\>\Z/
     When I run `kitchen verify client-beans`
     Then the output should contain "Verify failed on instance <client-beans>"
     And the exit status should not be 0
     When I successfully run `kitchen list client-beans`
-    Then the stdout should match /^client-beans\s+.+\s+Set Up\Z/
+    Then the stdout should match /^client-beans\s+.+\s+Set Up\s+Kitchen::ActionFailed\Z/
 
   @spawn
   Scenario: Verifying a single instance
     When I successfully run `kitchen setup client-beans`
     And I successfully run `kitchen list client-beans`
-    Then the stdout should match /^client-beans\s+.+\s+Set Up\Z/
+    Then the stdout should match /^client-beans\s+.+\s+Set Up\s+\<None\>\Z/
     When I run `kitchen verify client-beans`
     Then the output should contain "Finished verifying <client-beans>"
     And the exit status should be 0
     When I successfully run `kitchen list client-beans`
-    Then the stdout should match /^client-beans\s+.+\s+Verified\Z/
+    Then the stdout should match /^client-beans\s+.+\s+Verified\s+\<None\>\Z/
 
   @spawn
   Scenario: Verifying a single instance that fails
@@ -128,23 +128,23 @@ Feature: Running instance actions
     """
     When I successfully run `kitchen setup client-beans`
     And I successfully run `kitchen list client-beans`
-    Then the stdout should match /^client-beans\s+.+\s+Set Up\Z/
+    Then the stdout should match /^client-beans\s+.+\s+Set Up\s+\<None\>\Z/
     When I run `kitchen verify client-beans`
     Then the output should contain "Verify failed on instance <client-beans>"
     And the exit status should not be 0
     When I successfully run `kitchen list client-beans`
-    Then the stdout should match /^client-beans\s+.+\s+Set Up\Z/
+    Then the stdout should match /^client-beans\s+.+\s+Set Up\s+Kitchen::ActionFailed\Z/
 
   @spawn
   Scenario: Destroying a single instance
     When I successfully run `kitchen create client-beans`
     And I successfully run `kitchen list client-beans`
-    Then the stdout should match /^client-beans\s+.+\s+Created\Z/
+    Then the stdout should match /^client-beans\s+.+\s+Created\s+\<None\>\Z/
     When I run `kitchen destroy client-beans`
     Then the output should contain "Finished destroying <client-beans>"
     And the exit status should be 0
     When I successfully run `kitchen list client-beans`
-    Then the stdout should match /^client-beans\s+.+\s+\<Not Created\>\Z/
+    Then the stdout should match /^client-beans\s+.+\s+\<Not Created\>\s+\<None\>\Z/
 
   @spawn
   Scenario: Destroying a single instance that fails
@@ -156,9 +156,9 @@ Feature: Running instance actions
     """
     When I successfully run `kitchen create client-beans`
     And I successfully run `kitchen list client-beans`
-    Then the stdout should match /^client-beans\s+.+\s+Created\Z/
+    Then the stdout should match /^client-beans\s+.+\s+Created\s+\<None\>\Z/
     When I run `kitchen destroy client-beans`
     Then the output should contain "Destroy failed on instance <client-beans>"
     And the exit status should not be 0
     When I successfully run `kitchen list client-beans`
-    Then the stdout should match /^client-beans\s+.+\s+Created\Z/
+    Then the stdout should match /^client-beans\s+.+\s+Created\s+Kitchen::ActionFailed\Z/

--- a/features/kitchen_defaults.feature
+++ b/features/kitchen_defaults.feature
@@ -18,7 +18,7 @@ Feature: Test Kitchen defaults
       - name: default
     """
     When I successfully run `kitchen list`
-    Then the output should match /^default-win-81\s+Dummy\s+Dummy\s+Dummy\s+Winrm\s+\<Not Created\>$/
+    Then the output should match /^default-win-81\s+Dummy\s+Dummy\s+Dummy\s+Winrm\s+\<Not Created\>\s+\<None\>$/
 
   Scenario: Non-Windows platforms get the Ssh Transport by default
     Given a file named ".kitchen.yml" with:
@@ -35,4 +35,4 @@ Feature: Test Kitchen defaults
       - name: default
     """
     When I successfully run `kitchen list`
-    Then the output should match /^default-ubuntu-1404\s+Dummy\s+Dummy\s+Dummy\s+Ssh\s+\<Not Created\>$/
+    Then the output should match /^default-ubuntu-1404\s+Dummy\s+Dummy\s+Dummy\s+Ssh\s+\<Not Created\>\s+\<None\>$/

--- a/features/kitchen_list_command.feature
+++ b/features/kitchen_list_command.feature
@@ -25,6 +25,42 @@ Feature: Listing Test Kitchen instances
     And the output should match /^foobar-ubuntu-1304\s+Dummy\s+ChefSolo\s+Busser\s+Ssh\s+\<Not Created\>\s+\<None\>$/
     And the output should match /^foobar-centos-64\s+Dummy\s+ChefSolo\s+Busser\s+Ssh\s+\<Not Created\>\s+\<None\>$/
 
+  Scenario: Listing a single instance with the --json option
+    When I run `kitchen list --json`
+    Then the exit status should be 0
+    And the output should contain exactly:
+    """
+    [
+      {
+        "instance": "foobar-ubuntu-1304",
+        "driver": "Dummy",
+        "provisioner": "ChefSolo",
+        "verifier": "Busser",
+        "transport": "Ssh",
+        "last_action": null,
+        "last_error": null
+      },
+      {
+        "instance": "foobar-centos-64",
+        "driver": "Dummy",
+        "provisioner": "ChefSolo",
+        "verifier": "Busser",
+        "transport": "Ssh",
+        "last_action": null,
+        "last_error": null
+      },
+      {
+        "instance": "foobar-centos-64-with-small-mem",
+        "driver": "Dummy",
+        "provisioner": "ChefSolo",
+        "verifier": "Busser",
+        "transport": "Ssh",
+        "last_action": null,
+        "last_error": null
+      }
+    ]
+    """
+
   Scenario: Listing instances with the --bare option
     When I run `kitchen list --bare`
     Then the exit status should be 0

--- a/features/kitchen_list_command.feature
+++ b/features/kitchen_list_command.feature
@@ -22,8 +22,8 @@ Feature: Listing Test Kitchen instances
   Scenario: Listing instances
     When I run `kitchen list`
     Then the exit status should be 0
-    And the output should match /^foobar-ubuntu-1304\s+Dummy\s+ChefSolo\s+Busser\s+Ssh\s+\<Not Created\>$/
-    And the output should match /^foobar-centos-64\s+Dummy\s+ChefSolo\s+Busser\s+Ssh\s+\<Not Created\>$/
+    And the output should match /^foobar-ubuntu-1304\s+Dummy\s+ChefSolo\s+Busser\s+Ssh\s+\<Not Created\>\s+\<None\>$/
+    And the output should match /^foobar-centos-64\s+Dummy\s+ChefSolo\s+Busser\s+Ssh\s+\<Not Created\>\s+\<None\>$/
 
   Scenario: Listing instances with the --bare option
     When I run `kitchen list --bare`

--- a/features/kitchen_test_command.feature
+++ b/features/kitchen_test_command.feature
@@ -36,7 +36,7 @@ Feature: Running a full test instance test
   Scenario: Running a single instance never destroying an instance
     When I successfully run `kitchen test client-beans --destroy=never`
     And I successfully run `kitchen list client-beans`
-    Then the output should match /^client-beans\s+.+\s+Verified$/
+    Then the output should match /^client-beans\s+.+\s+Verified\s+\<None\>$/
 
   @spawn
   Scenario: Running a single instance always destroying an instance
@@ -49,7 +49,7 @@ Feature: Running a full test instance test
     When I run `kitchen test client-beans --destroy=always`
     Then the exit status should not be 0
     When I successfully run `kitchen list client-beans`
-    Then the output should match /^client-beans\s+.+\s+\<Not Created\>$/
+    Then the output should match /^client-beans\s+.+\s+\<Not Created\>\s+\<None\>$/
 
   @spawn
   Scenario: Running a single instance not destroying an instance on failure
@@ -62,14 +62,14 @@ Feature: Running a full test instance test
     When I run `kitchen test client-beans --destroy=passing`
     Then the exit status should not be 0
     When I successfully run `kitchen list client-beans`
-    Then the output should match /^client-beans\s+.+\s+Created$/
+    Then the output should match /^client-beans\s+.+\s+Created\s+Kitchen::ActionFailed$/
 
   @spawn
   Scenario: Running a single instance destroying an instance on success
     When I run `kitchen test client-beans --destroy=passing`
     Then the exit status should be 0
     When I successfully run `kitchen list client-beans`
-    Then the output should match /^client-beans\s+.+\s+\<Not Created\>$/
+    Then the output should match /^client-beans\s+.+\s+\<Not Created\>\s+\<None\>$/
 
   @spawn
   Scenario: Running all instances
@@ -82,7 +82,7 @@ Feature: Running a full test instance test
     Then the output should contain "Kitchen is finished."
     And the exit status should be 0
     When I successfully run `kitchen list`
-    Then the output should match /^client-cool\s+.+\s+\<Not Created\>$/
-    Then the output should match /^client-beans\s+.+\s+\<Not Created\>$/
-    Then the output should match /^server-cool\s+.+\s+\<Not Created\>$/
-    Then the output should match /^server-beans\s+.+\s+\<Not Created\>$/
+    Then the output should match /^client-cool\s+.+\s+\<Not Created\>\s+\<None\>$/
+    Then the output should match /^client-beans\s+.+\s+\<Not Created\>\s+\<None\>$/
+    Then the output should match /^server-cool\s+.+\s+\<Not Created\>\s+\<None\>$/
+    Then the output should match /^server-beans\s+.+\s+\<Not Created\>\s+\<None\>$/

--- a/lib/kitchen/cli.rb
+++ b/lib/kitchen/cli.rb
@@ -110,6 +110,10 @@ module Kitchen
       :aliases => "-b",
       :type => :boolean,
       :desc => "List the name of each instance only, one per line"
+    method_option :json,
+      :aliases => "-j",
+      :type => :boolean,
+      :desc => "Print data as JSON"
     method_option :debug,
       :aliases => "-d",
       :type => :boolean,

--- a/lib/kitchen/command/list.rb
+++ b/lib/kitchen/command/list.rb
@@ -64,7 +64,8 @@ module Kitchen
           color_pad(instance.provisioner.name),
           color_pad(instance.verifier.name),
           color_pad(instance.transport.name),
-          format_last_action(instance.last_action)
+          format_last_action(instance.last_action),
+          format_last_error(instance.last_error)
         ]
       end
 
@@ -84,6 +85,18 @@ module Kitchen
         end
       end
 
+      # Format and color the given last error.
+      #
+      # @param last_error [String] the last error
+      # @return [String] formated last error
+      # @api private
+      def format_last_error(last_error)
+        case last_error
+        when nil then colorize("<None>", :white)
+        else colorize(last_error, :red)
+        end
+      end
+
       # Constructs a list display table and output it to the screen.
       #
       # @param result [Array<Instance>] an array of instances
@@ -93,7 +106,8 @@ module Kitchen
           [
             colorize("Instance", :green), colorize("Driver", :green),
             colorize("Provisioner", :green), colorize("Verifier", :green),
-            colorize("Transport", :green), colorize("Last Action", :green)
+            colorize("Transport", :green), colorize("Last Action", :green),
+            colorize("Last Error", :green)
           ]
         ]
         table += Array(result).map { |i| display_instance(i) }

--- a/lib/kitchen/command/list.rb
+++ b/lib/kitchen/command/list.rb
@@ -17,6 +17,7 @@
 # limitations under the License.
 
 require "kitchen/command"
+require "json"
 
 module Kitchen
 
@@ -35,6 +36,8 @@ module Kitchen
             "please use `kitchen diagnose'."
         elsif options[:bare]
           puts Array(result).map(&:name).join("\n")
+        elsif options[:json]
+          puts JSON.pretty_generate(Array(result).map { |r| to_hash(r) })
         else
           list_table(result)
         end
@@ -112,6 +115,22 @@ module Kitchen
         ]
         table += Array(result).map { |i| display_instance(i) }
         print_table(table)
+      end
+
+      # Constructs a hashtable representation of a single instance.
+      #
+      # @param result [Hash{Symbol => String}] hash of a single instance
+      # @api private
+      def to_hash(result)
+        {
+          :instance => result.name,
+          :driver => result.driver.name,
+          :provisioner => result.provisioner.name,
+          :verifier => result.verifier.name,
+          :transport => result.transport.name,
+          :last_action => result.last_action,
+          :last_error => result.last_error
+        }
       end
 
       # Outputs a formatted display table.

--- a/lib/kitchen/instance.rb
+++ b/lib/kitchen/instance.rb
@@ -274,6 +274,13 @@ module Kitchen
       state_file.read[:last_action]
     end
 
+    # Returns the error encountered on the last action on the instance
+    #
+    # @return [String] the message of the last error
+    def last_error
+      state_file.read[:last_error]
+    end
+
     # Clean up any per-instance resources before exiting.
     #
     # @return [void]
@@ -485,14 +492,17 @@ module Kitchen
         synchronize_or_call(what, state, &block)
       end
       state[:last_action] = what.to_s
+      state[:last_error] = nil
       elapsed
     rescue ActionFailed => e
       log_failure(what, e)
+      state[:last_error] = e.class.name
       raise(InstanceFailure, failure_message(what) +
         "  Please see .kitchen/logs/#{name}.log for more details",
         e.backtrace)
     rescue Exception => e # rubocop:disable Lint/RescueException
       log_failure(what, e)
+      state[:last_error] = e.class.name
       raise ActionFailed,
         "Failed to complete ##{what} action: [#{e.message}]", e.backtrace
     ensure


### PR DESCRIPTION
`last_error` contains last exception from the last action performed on the instance. Can be `nil` if action completed successfully.
`--json` will print machine-readable JSON output on `kitchen list`, for better test automation integration.
e.g.:
```text
nitz@lap:~/proj$ /opt/chefdk/embedded/bin/ruby ~/projects/test-kitchen/bin/kitchen list -j default-centos-6-chef-11
[
  {
    "instance": "default-centos-6-chef-11",
    "driver": "Vagrant",
    "provisioner": "ChefZero",
    "verifier": "Busser",
    "transport": "Ssh",
    "last_action": "create",
    "last_error": "Kitchen::ActionFailed"
  }
]
```