### PR TITLE
Adding a Hostname column to kitchen list command

### DIFF
--- a/features/kitchen_defaults.feature
+++ b/features/kitchen_defaults.feature
@@ -18,7 +18,7 @@ Feature: Test Kitchen defaults
       - name: default
     """
     When I successfully run `kitchen list`
-    Then the output should match /^default-win-81\s+Dummy\s+Dummy\s+Dummy\s+Winrm\s+\<Not Created\>\s+\<None\>$/
+    Then the output should match /^default-win-81\s+<None>\s+Dummy\s+Dummy\s+Dummy\s+Winrm\s+\<Not Created\>\s+\<None\>$/
 
   Scenario: Non-Windows platforms get the Ssh Transport by default
     Given a file named ".kitchen.yml" with:
@@ -35,4 +35,4 @@ Feature: Test Kitchen defaults
       - name: default
     """
     When I successfully run `kitchen list`
-    Then the output should match /^default-ubuntu-1404\s+Dummy\s+Dummy\s+Dummy\s+Ssh\s+\<Not Created\>\s+\<None\>$/
+    Then the output should match /^default-ubuntu-1404\s+<None>\s+Dummy\s+Dummy\s+Dummy\s+Ssh\s+\<Not Created\>\s+\<None\>$/

--- a/features/kitchen_list_command.feature
+++ b/features/kitchen_list_command.feature
@@ -22,8 +22,8 @@ Feature: Listing Test Kitchen instances
   Scenario: Listing instances
     When I run `kitchen list`
     Then the exit status should be 0
-    And the output should match /^foobar-ubuntu-1304\s+Dummy\s+ChefSolo\s+Busser\s+Ssh\s+\<Not Created\>\s+\<None\>$/
-    And the output should match /^foobar-centos-64\s+Dummy\s+ChefSolo\s+Busser\s+Ssh\s+\<Not Created\>\s+\<None\>$/
+    And the output should match /^foobar-ubuntu-1304\s+<None>\s+Dummy\s+ChefSolo\s+Busser\s+Ssh\s+\<Not Created\>\s+\<None\>$/
+    And the output should match /^foobar-centos-64\s+<None>\s+Dummy\s+ChefSolo\s+Busser\s+Ssh\s+\<Not Created\>\s+\<None\>$/
 
   Scenario: Listing a single instance with the --json option
     When I run `kitchen list --json`
@@ -33,6 +33,7 @@ Feature: Listing Test Kitchen instances
     [
       {
         "instance": "foobar-ubuntu-1304",
+        "hostname": null,
         "driver": "Dummy",
         "provisioner": "ChefSolo",
         "verifier": "Busser",
@@ -42,6 +43,7 @@ Feature: Listing Test Kitchen instances
       },
       {
         "instance": "foobar-centos-64",
+        "hostname": null,
         "driver": "Dummy",
         "provisioner": "ChefSolo",
         "verifier": "Busser",
@@ -51,6 +53,7 @@ Feature: Listing Test Kitchen instances
       },
       {
         "instance": "foobar-centos-64-with-small-mem",
+        "hostname": null,
         "driver": "Dummy",
         "provisioner": "ChefSolo",
         "verifier": "Busser",

--- a/lib/kitchen/command/list.rb
+++ b/lib/kitchen/command/list.rb
@@ -63,6 +63,7 @@ module Kitchen
       def display_instance(instance)
         [
           color_pad(instance.name),
+          format_hostname(instance.hostname),
           color_pad(instance.driver.name),
           color_pad(instance.provisioner.name),
           color_pad(instance.verifier.name),
@@ -100,6 +101,18 @@ module Kitchen
         end
       end
 
+      # Format and color the stored hostname.
+      #
+      # @param hostname [String] the hostname
+      # @return [String] formatted hostname
+      # @api private
+      def format_hostname(hostname)
+        case hostname
+        when nil then colorize("<None>", :white)
+        else colorize(hostname, :white)
+        end
+      end
+
       # Constructs a list display table and output it to the screen.
       #
       # @param result [Array<Instance>] an array of instances
@@ -107,10 +120,10 @@ module Kitchen
       def list_table(result)
         table = [
           [
-            colorize("Instance", :green), colorize("Driver", :green),
-            colorize("Provisioner", :green), colorize("Verifier", :green),
-            colorize("Transport", :green), colorize("Last Action", :green),
-            colorize("Last Error", :green)
+            colorize("Instance", :green), colorize("Hostname", :green),
+            colorize("Driver", :green), colorize("Provisioner", :green),
+            colorize("Verifier", :green), colorize("Transport", :green),
+            colorize("Last Action", :green), colorize("Last Error", :green)
           ]
         ]
         table += Array(result).map { |i| display_instance(i) }
@@ -124,6 +137,7 @@ module Kitchen
       def to_hash(result)
         {
           :instance => result.name,
+          :hostname => result.hostname,
           :driver => result.driver.name,
           :provisioner => result.provisioner.name,
           :verifier => result.verifier.name,

--- a/lib/kitchen/instance.rb
+++ b/lib/kitchen/instance.rb
@@ -281,6 +281,13 @@ module Kitchen
       state_file.read[:last_error]
     end
 
+    # Returns the stored hostname of the instance
+    #
+    # @return [String] the hostaname of the instance
+    def hostname
+      state_file.read[:hostname]
+    end
+
     # Clean up any per-instance resources before exiting.
     #
     # @return [void]


### PR DESCRIPTION
## Background

This PR adds the address stored in the `hostname` field within the each Test Kitchen instance statefile to the output of the `kitchen list` command.  

It does this by reading the statefile for each instance and returning the value stored against the `hostname` field.  If there is no such address yet (e.g. in the case where kitchen has not created the instance) `<None>` will be returned.

The benefit of this is mostly for demo purposes, where individual instances sometimes need to be inspected for their state (e.g. if WinRM hasn't been enabled correctly on the target instance and you need to investigate).
## Example output:

![capture](https://cloud.githubusercontent.com/assets/6384654/19414381/b3d7f062-937d-11e6-9b5a-cdf9969e69e7.PNG)
## Notes for maintainer:
1. I decided to use the word **Hostname** in the table title - this matches the vocabulary used within kitchen, however it should be noted that it is down to the specific driver as to whether this is actually a Hostname or another address such as an IP address (e.g. in the AzureRM driver what is stored in this field is the value of the public IP or the internal IP address, depending on the configuration).
2. It has been suggested that the width of the table may be too large after making this change and further changes to rationalise the output may be required
3. I have not been able to successfully execute the cucumber tests locally on Windows.  Unless they are executed in the CI process I will need some help ensuring the features have been modified successfully.

Signed-off-by: Stuart Preston stuart@pendrica.com
