### PR TITLE
Adding transport option "ssh_key_only".

### DIFF
--- a/lib/kitchen/transport/ssh.rb
+++ b/lib/kitchen/transport/ssh.rb
@@ -422,6 +422,10 @@ module Kitchen
           opts[:auth_methods] = ["publickey"]
         end
 
+        if data[:ssh_key_only]
+          opts[:auth_methods] = ["publickey"]
+        end
+
         opts[:password] = data[:password]           if data.key?(:password)
         opts[:forward_agent] = data[:forward_agent] if data.key?(:forward_agent)
         opts[:verbose] = data[:verbose].to_sym      if data.key?(:verbose)

--- a/spec/kitchen/transport/ssh_spec.rb
+++ b/spec/kitchen/transport/ssh_spec.rb
@@ -201,6 +201,10 @@ describe Kitchen::Transport::Ssh do
       transport[:ssh_key].must_equal nil
     end
 
+    it "sets :ssh_key_only to nil by default" do
+      transport[:ssh_key_only].must_equal nil
+    end
+
     it "expands :ssh_path path if set" do
       config[:kitchen_root] = "/rooty"
       config[:ssh_key] = "my_key"
@@ -584,6 +588,16 @@ describe Kitchen::Transport::Ssh do
 
         klass.expects(:new).with do |hash|
           hash[:keys].nil?
+        end
+
+        make_connection
+      end
+
+      it "sets :auth_methods to only publickey if :ssh_key_only is set in config" do
+        config[:ssh_key_only] = true
+
+        klass.expects(:new).with do |hash|
+          hash[:auth_methods] == ["publickey"]
         end
 
         make_connection


### PR DESCRIPTION
When bootstrapping with cloud-init, there is a small window of time where the public ssh key will not be present, this will cause a login failure and eventually fallback to a password prompt.
#704 provided a mechanism to bypass this condition by setting auth_method to publickey, but only does so when a private key is specified. When using a ssh-agent, there is no need to specify a key, but still a need to set auth_method.

This PR is useful to force net/ssh to set the auth_method to publickey but not
attempt to provide a private key. A running ssh-agent can then provide
the key.
