### PR TITLE
Remove codeclimate-test-reporter as that has been deprecated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,8 +64,3 @@ matrix:
 
 notifications:
   irc: "chat.freenode.net#kitchenci"
-
-addons:
-  code_climate:
-    repo_token:
-      secure: "lcqi3hbalLTinxwsl+um1aN1dgijBrODSMseGEJMJGkofz3VZ+Ofuuwp9x9VjvewuiUFHsiPD5SQ6hx8N+L3wXB6qA+HTmIrXecL7VjehbImEyOuu4/++vcTdpTINAd2Qt/KuJ1eY0okSwVmvtX1VD8gYD8yrlMKdj6uexf8Bgs="

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,3 @@ group :integration do
   gem "berkshelf", "~> 4.3"
   gem "kitchen-inspec", "~> 0.15.1"
 end
-
-group :test do
-  gem "codeclimate-test-reporter", :require => nil
-end


### PR DESCRIPTION
Fixes the build for master. 

Tracking bug to re-enable codeclimate reporting - https://github.com/test-kitchen/test-kitchen/issues/1146

Signed-off-by: Steven Murawski <steven.murawski@gmail.com>