### PR TITLE
Added `cache` interface for Drivers so that provisioners can leverage 

### DIFF
--- a/lib/kitchen/driver/base.rb
+++ b/lib/kitchen/driver/base.rb
@@ -123,7 +123,7 @@ module Kitchen
       # that it can leverage it internally
       #
       # @return path [String] a path of the cache directory
-      def cache
+      def cache_directory
       end
 
       private

--- a/lib/kitchen/driver/base.rb
+++ b/lib/kitchen/driver/base.rb
@@ -119,6 +119,13 @@ module Kitchen
         @api_version = version
       end
 
+      # Cache directory that a driver could implement to inform the provisioner
+      # that it can leverage it internally
+      #
+      # @return path [String] a path of the cache directory
+      def cache
+      end
+
       private
 
       # Intercepts any bare #puts calls in subclasses and issues an INFO log

--- a/lib/kitchen/driver/ssh_base.rb
+++ b/lib/kitchen/driver/ssh_base.rb
@@ -220,7 +220,7 @@ module Kitchen
       # that it can leverage it internally
       #
       # @return path [String] a path of the cache directory
-      def cache
+      def cache_directory
       end
 
       private

--- a/lib/kitchen/driver/ssh_base.rb
+++ b/lib/kitchen/driver/ssh_base.rb
@@ -216,6 +216,13 @@ module Kitchen
         @serial_actions += methods
       end
 
+      # Cache directory that a driver could implement to inform the provisioner
+      # that it can leverage it internally
+      #
+      # @return path [String] a path of the cache directory
+      def cache
+      end
+
       private
 
       def backcompat_merged_state(state)

--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -163,15 +163,7 @@ module Kitchen
       # @return [Hash] an option hash for the install commands
       # @api private
       def install_options
-        # Verify if the `-d` option has already been passed, then we
-        # don't use config[:chef_omnibus_cache]
-        cache_dir_option = ' ' << "-d #{config[:chef_omnibus_cache]}"
-        if config[:chef_omnibus_install_options].nil?
-          config[:chef_omnibus_install_options] = cache_dir_option
-        elsif config[:chef_omnibus_install_options].match(/\s*-d\s*/).nil?
-          config[:chef_omnibus_install_options] << cache_dir_option
-        end
-
+        verify_omnibus_directory_option
         project = /\s*-P (\w+)\s*/.match(config[:chef_omnibus_install_options])
         {
           :omnibus_url => config[:chef_omnibus_url],
@@ -183,6 +175,19 @@ module Kitchen
           [:install_msi_url, :http_proxy, :https_proxy].each do |key|
             opts[key] = config[key] if config.key? key
           end
+        end
+      end
+
+      # Verify if the "omnibus_dir_option" has already been passed, if so we
+      # don't use config[:chef_omnibus_cache]
+      #
+      # @api private
+      def verify_omnibus_directory_option
+        cache_dir_option = "#{omnibus_dir_option} #{config[:chef_omnibus_cache]}"
+        if config[:chef_omnibus_install_options].nil?
+          config[:chef_omnibus_install_options] = cache_dir_option
+        elsif config[:chef_omnibus_install_options].match(/\s*#{omnibus_dir_option}\s*/).nil?
+          config[:chef_omnibus_install_options] << " " << cache_dir_option
         end
       end
 
@@ -344,6 +349,13 @@ module Kitchen
         else
           install_from_file(installer.install_command)
         end
+      end
+
+      # @return [String] Correct option per platform to specify the the
+      #                  cache directory
+      # @api private
+      def omnibus_dir_option
+        windows_os? ? "-download_directory" : "-d"
       end
 
       def install_from_file(command)

--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -156,7 +156,7 @@ module Kitchen
       # @return [Hash] an option hash for the install commands
       # @api private
       def install_options
-        add_omnibus_directory_option if instance.driver.cache
+        add_omnibus_directory_option if instance.driver.cache_directory
         project = /\s*-P (\w+)\s*/.match(config[:chef_omnibus_install_options])
         {
           :omnibus_url => config[:chef_omnibus_url],
@@ -172,11 +172,11 @@ module Kitchen
       end
 
       # Verify if the "omnibus_dir_option" has already been passed, if so we
-      # don't use the @driver.cache
+      # don't use the @driver.cache_directory
       #
       # @api private
       def add_omnibus_directory_option
-        cache_dir_option = "#{omnibus_dir_option} #{instance.driver.cache}"
+        cache_dir_option = "#{omnibus_dir_option} #{instance.driver.cache_directory}"
         if config[:chef_omnibus_install_options].nil?
           config[:chef_omnibus_install_options] = cache_dir_option
         elsif config[:chef_omnibus_install_options].match(/\s*#{omnibus_dir_option}\s*/).nil?

--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -52,7 +52,7 @@ module Kitchen
       # other drivers that can mount or share a folder to avoid downloading the
       # same software every converge
       default_config :chef_omnibus_cache do |provisioner|
-        provisioner.windows_os? ? "$env:TEMP\\kitchen\\omnibus" : "/tmp/kitchen/omnibus"
+        provisioner.windows_os? ? "$env:TEMP\\omnibus\\cache" : "/tmp/omnibus/cache"
       end
       default_config :chef_omnibus_install_options, nil
       default_config :run_list, []

--- a/lib/kitchen/transport/ssh.rb
+++ b/lib/kitchen/transport/ssh.rb
@@ -394,7 +394,7 @@ module Kitchen
       # @param data [Hash] merged configuration and mutable state data
       # @return [Hash] hash of connection options
       # @api private
-      # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/CyclomaticComplexity
+      # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
       def connection_options(data)
         opts = {
           :logger                 => logger,

--- a/spec/kitchen/provisioner/chef_base_spec.rb
+++ b/spec/kitchen/provisioner/chef_base_spec.rb
@@ -61,6 +61,11 @@ describe Kitchen::Provisioner::ChefBase do
           must_equal "https://omnitruck.chef.io/install.sh"
       end
 
+      it ":chef_omnibus_cache has a default" do
+        provisioner[:chef_omnibus_cache].
+          must_equal "/tmp/kitchen/omnibus"
+      end
+
       it ":chef_metadata_url defaults to nil" do
         provisioner[:chef_metadata_url].must_equal(nil)
       end
@@ -75,6 +80,10 @@ describe Kitchen::Provisioner::ChefBase do
           must_equal "https://omnitruck.chef.io/install.sh"
       end
 
+      it ":chef_omnibus_cache has a default" do
+        provisioner[:chef_omnibus_cache].
+          must_equal "$env:TEMP\\kitchen\\omnibus"
+      end
     end
 
     it ":require_chef_omnibus defaults to true" do

--- a/spec/kitchen/provisioner/chef_base_spec.rb
+++ b/spec/kitchen/provisioner/chef_base_spec.rb
@@ -26,7 +26,7 @@ describe Kitchen::Provisioner::ChefBase do
   let(:logged_output)   { StringIO.new }
   let(:logger)          { Logger.new(logged_output) }
   let(:platform)        { stub(:os_type => nil) }
-  let(:driver)          { stub(:cache => nil) }
+  let(:driver)          { stub(:cache_directory => nil) }
   let(:suite)           { stub(:name => "fries") }
   let(:default_version) { true }
 
@@ -316,10 +316,10 @@ describe Kitchen::Provisioner::ChefBase do
         cmd.wont_match(/\Amy_prefix /)
       end
 
-      describe "when driver implements the cache interface" do
-        before { driver.stubs(:cache).returns("/tmp/custom/place") }
+      describe "when driver implements the cache_directory interface" do
+        before { driver.stubs(:cache_directory).returns("/tmp/custom/place") }
 
-        it "will use driver.cache to provide a cache directory" do
+        it "will use driver.cache_directory to provide a cache directory" do
           install_opts[:install_flags] = "-d /tmp/custom/place"
 
           Mixlib::Install::ScriptGenerator.expects(:new).
@@ -327,7 +327,7 @@ describe Kitchen::Provisioner::ChefBase do
           cmd
         end
 
-        it "will use driver.cache even if other options are given" do
+        it "will use driver.cache_directory even if other options are given" do
           config[:chef_omnibus_install_options] = "-P cool -v 123"
           install_opts[:install_flags] = "-P cool -v 123 -d /tmp/custom/place"
           install_opts[:project] = "cool"
@@ -337,7 +337,7 @@ describe Kitchen::Provisioner::ChefBase do
           cmd
         end
 
-        it "will not use driver.cache if -d options is given" do
+        it "will not use driver.cache_directory if -d options is given" do
           config[:chef_omnibus_install_options] = "-P cool -d /path -v 123"
           install_opts[:install_flags] = "-P cool -d /path -v 123"
           install_opts[:project] = "cool"
@@ -486,8 +486,8 @@ describe Kitchen::Provisioner::ChefBase do
         cmd
       end
 
-      describe "when driver implements the cache" do
-        before { driver.stubs(:cache).returns("$env:TEMP\\dummy\\place") }
+      describe "when driver implements the cache_directory" do
+        before { driver.stubs(:cache_directory).returns("$env:TEMP\\dummy\\place") }
 
         it "will have the same behavior on windows" do
           config[:chef_omnibus_install_options] = "-version 123"

--- a/spec/kitchen/provisioner/chef_base_spec.rb
+++ b/spec/kitchen/provisioner/chef_base_spec.rb
@@ -63,7 +63,7 @@ describe Kitchen::Provisioner::ChefBase do
 
       it ":chef_omnibus_cache has a default" do
         provisioner[:chef_omnibus_cache].
-          must_equal "/tmp/kitchen/omnibus"
+          must_equal "/tmp/omnibus/cache"
       end
 
       it ":chef_metadata_url defaults to nil" do
@@ -82,7 +82,7 @@ describe Kitchen::Provisioner::ChefBase do
 
       it ":chef_omnibus_cache has a default" do
         provisioner[:chef_omnibus_cache].
-          must_equal "$env:TEMP\\kitchen\\omnibus"
+          must_equal "$env:TEMP\\omnibus\\cache"
       end
     end
 
@@ -304,8 +304,8 @@ describe Kitchen::Provisioner::ChefBase do
 
       it "will not use chef_omnibus_cache if -d options is given" do
         config[:chef_omnibus_cache] = "/tmp/custom/place"
-        config[:chef_omnibus_install_options] = "-d /force/path"
-        install_opts[:install_flags] = "-d /force/path"
+        config[:chef_omnibus_install_options] = "-P cool -d /path -v 123"
+        install_opts[:install_flags] = "-d /path"
 
         Mixlib::Install::ScriptGenerator.expects(:new).
           with("11", false, install_opts).returns(installer)

--- a/spec/kitchen/provisioner/chef_base_spec.rb
+++ b/spec/kitchen/provisioner/chef_base_spec.rb
@@ -293,6 +293,25 @@ describe Kitchen::Provisioner::ChefBase do
         cmd
       end
 
+      it "will use chef_omnibus_cache to provide a cache directory" do
+        config[:chef_omnibus_cache] = "/tmp/custom/place"
+        install_opts[:install_flags] = "-d /tmp/custom/place"
+
+        Mixlib::Install::ScriptGenerator.expects(:new).
+          with("11", false, install_opts).returns(installer)
+        cmd
+      end
+
+      it "will not use chef_omnibus_cache if -d options is given" do
+        config[:chef_omnibus_cache] = "/tmp/custom/place"
+        config[:chef_omnibus_install_options] = "-d /force/path"
+        install_opts[:install_flags] = "-d /force/path"
+
+        Mixlib::Install::ScriptGenerator.expects(:new).
+          with("11", false, install_opts).returns(installer)
+        cmd
+      end
+
       it "will set the install root" do
         config[:chef_omnibus_root] = "/tmp/test"
         install_opts[:root] = "/tmp/test"


### PR DESCRIPTION
Introducing a new interface `cache_directory` inside the Drivers for provisioners
to leverage. When a driver is ready to implement it, the provisioner will
detect it and use the cache directory to pass the `-d` option to omnitruck 
so we can cache the packages and avoid re-pulling down artifacts that you
already have on the image.

Closes https://github.com/test-kitchen/test-kitchen/issues/809

Signed-off-by: Salim Afiune <afiune@chef.io>