### PR TITLE
Fix to work with Thor 0.19.2

### DIFF
--- a/lib/kitchen/generator/init.rb
+++ b/lib/kitchen/generator/init.rb
@@ -34,7 +34,7 @@ module Kitchen
       class_option :driver,
         :type => :array,
         :aliases => "-D",
-        :default => "kitchen-vagrant",
+        :default => %w{kitchen-vagrant},
         :desc => <<-D.gsub(/^\s+/, "").gsub(/\n/, " ")
           One or more Kitchen Driver gems to be installed or added to a
           Gemfile

--- a/lib/kitchen/generator/init.rb
+++ b/lib/kitchen/generator/init.rb
@@ -34,7 +34,7 @@ module Kitchen
       class_option :driver,
         :type => :array,
         :aliases => "-D",
-        :default => %w{kitchen-vagrant},
+        :default => %w[kitchen-vagrant],
         :desc => <<-D.gsub(/^\s+/, "").gsub(/\n/, " ")
           One or more Kitchen Driver gems to be installed or added to a
           Gemfile


### PR DESCRIPTION
Thor released a new version today (November 26th) that requires the default value for an option match that option's type. As such, Test Kitchen is currently non-functional via gem install unless you back-rev the `thor` gem. This fix seems to be all that we need, currently scouring for other mismatches but it complained about the `init` command even though it wasn't the command being run so I think this should cover it.

Given the "gem/bundle installs are 100% busted" we should probably fast track this to a patch release.