### PR TITLE
Encrypt data bags automatically on provisioning sandbox

### DIFF
--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -77,6 +77,10 @@ module Kitchen
       end
       expand_path_for :data_bags_path
 
+      # If set to true, then encrypt the data bags from data_bags_path with the provided
+      # encrypted_data_bag_secret_key when they get pushed into the box
+      default_config :encrypt_data_bags, false
+
       default_config :environments_path do |provisioner|
         provisioner.calculate_path("environments")
       end

--- a/test-kitchen.gemspec
+++ b/test-kitchen.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "safe_yaml",       "~> 1.0"
   gem.add_dependency "thor",            "~> 0.18"
   gem.add_dependency "mixlib-install",  ">= 1.2", "< 3.0"
+  gem.add_dependency "chef",            "~> 12.17"
 
   gem.add_development_dependency "pry"
   gem.add_development_dependency "pry-byebug"


### PR DESCRIPTION
Hey all, this is a feature that I've been really missing when writing tests for cookbooks recently. The tl;dr is:

> You can now use unencrypted data bag fixtures in `/test/fixtures/data_bags/*` etc that Kitchen will encrypt when it pushes them into the testing sandbox. This allows users to edit these fixtures with their favourite editor, and see the contents of the fixtures when looking at a git diff.

I'm open to feedback if people feel like we should use a different config key etc, so I haven't finalised this with a changelog and version bump just yet. I'll do that if people think this looks like the right approach.

---

Users can now supply an `encrypt_data_bags` boolean key to the
provisioner config inside .kitchen.yml that tells Kitchen to encrypt the
data bags it pushes into the test machine when converging.

This allows users to maintain test data bag fixtures that are in
plaintext while accessing them as encrypted bags inside their recipes,
facilitating easier development and removing the need to edit JSON
fixtures using Chef solo/zero.