### PR TITLE
Remove ruby 2.1.9 from test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 
 rvm:
-  - 2.1.9
   - 2.2.5
   - 2.3.1
   - ruby-head

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ environment:
   SSL_CERT_FILE: c:\projects\test_kitchen\certs.pem
 
   matrix:
-    - ruby_version: "21"
+    - ruby_version: "23"
 
 clone_folder: c:\projects\test_kitchen
 clone_depth: 1


### PR DESCRIPTION
The nio4r gem bumb to 2.0.0 is not compatible with ruby 2.1 anbd test-kitchen builds are broken. Since ruby 2.1 is retired, this removes it from our travis and appveyor matrix.

Signed-off-by: Matt Wrock <matt@mattwrock.com>