### PR TITLE
Export no_proxy from kitchen config

### DIFF
--- a/lib/kitchen/configurable.rb
+++ b/lib/kitchen/configurable.rb
@@ -316,7 +316,7 @@ module Kitchen
     end
 
     def proxy_setting_keys
-      [:http_proxy, :https_proxy, :ftp_proxy]
+      [:http_proxy, :https_proxy, :ftp_proxy, :no_proxy]
     end
 
     def resolve_proxy_settings_from_config

--- a/spec/kitchen/configurable_spec.rb
+++ b/spec/kitchen/configurable_spec.rb
@@ -792,6 +792,7 @@ describe Kitchen::Configurable do
         config[:http_proxy] = "http://proxy"
         config[:https_proxy] = "https://proxy"
         config[:ftp_proxy] = "ftp://proxy"
+        config[:no_proxy] = "http://no"
 
         cmd.must_equal(outdent!(<<-CODE.chomp))
           sh -c '
@@ -801,6 +802,8 @@ describe Kitchen::Configurable do
           HTTPS_PROXY="https://proxy"; export HTTPS_PROXY
           ftp_proxy="ftp://proxy"; export ftp_proxy
           FTP_PROXY="ftp://proxy"; export FTP_PROXY
+          no_proxy="http://no"; export no_proxy
+          NO_PROXY="http://no"; export NO_PROXY
           mkdir foo
           '
         CODE


### PR DESCRIPTION
Currently the only way no_proxy is set is if you are using proxy settings from ENV vars. This addresses the use case of when you define your proxy settings in a kitchen config.