### PR TITLE
Bump Gemfile deps now that we require 2.2+ for testing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,13 +1,10 @@
 # -*- encoding: utf-8 -*-
 source "https://rubygems.org"
 gemspec
-gem "rack", "< 2.0"
-
-gem "train", "~> 0.19.0"
 
 group :integration do
-  gem "berkshelf", "~> 4.3"
-  gem "kitchen-inspec", "~> 0.15.1"
+  gem "berkshelf", "~> 5.0"
+  gem "kitchen-inspec", "~> 0.17"
 end
 
 group :test do


### PR DESCRIPTION
These were held back so Travis runs on 2.1 would work

Signed-off-by: Tim Smith <tsmith@chef.io>