### PR TITLE
Transfer tests when using shell verifier

### DIFF
--- a/lib/kitchen/verifier/base.rb
+++ b/lib/kitchen/verifier/base.rb
@@ -227,6 +227,49 @@ module Kitchen
       def prefix_command(script)
         config[:command_prefix] ? "#{config[:command_prefix]} #{script}" : script
       end
+
+      # Returns an Array of common helper filenames currently residing on the
+      # local workstation.
+      #
+      # @return [Array<String>] array of helper files
+      # @api private
+      def helper_files
+        glob = File.join(config[:test_base_path], "helpers", "*/**/*")
+        Dir.glob(glob).reject { |f| File.directory?(f) }
+      end
+
+      # Copies all common testing helper files into the suites directory in
+      # the sandbox.
+      #
+      # @api private
+      def prepare_helpers
+        base = File.join(config[:test_base_path], "helpers")
+
+        helper_files.each do |src|
+          dest = File.join(sandbox_suites_dir, src.sub("#{base}/", ""))
+          FileUtils.mkdir_p(File.dirname(dest))
+          FileUtils.cp(src, dest, preserve: true)
+        end
+      end
+
+      # Copies all test suite files into the suites directory in the sandbox.
+      #
+      # @api private
+      def prepare_suites
+        base = File.join(config[:test_base_path], config[:suite_name])
+
+        local_suite_files.each do |src|
+          dest = File.join(sandbox_suites_dir, src.sub("#{base}/", ""))
+          FileUtils.mkdir_p(File.dirname(dest))
+          FileUtils.cp(src, dest, preserve: true)
+        end
+      end
+
+      # @return [String] path to suites directory under sandbox path
+      # @api private
+      def sandbox_suites_dir
+        File.join(sandbox_path, "suites")
+      end
     end
   end
 end

--- a/lib/kitchen/verifier/busser.rb
+++ b/lib/kitchen/verifier/busser.rb
@@ -187,16 +187,6 @@ module Kitchen
         args
       end
 
-      # Returns an Array of common helper filenames currently residing on the
-      # local workstation.
-      #
-      # @return [Array<String>] array of helper files
-      # @api private
-      def helper_files
-        glob = File.join(config[:test_base_path], "helpers", "*/**/*")
-        Dir.glob(glob).reject { |f| File.directory?(f) }
-      end
-
       def install_command_vars
         ruby = remote_path_join(config[:ruby_bindir], "ruby")
                .tap { |path| path.concat(".exe") if windows_os? }
@@ -239,39 +229,6 @@ module Kitchen
         Dir.glob(glob).reject do |d|
           !File.directory?(d) || non_suite_dirs.include?(File.basename(d))
         end.map { |d| "busser-#{File.basename(d)}" }.sort.uniq
-      end
-
-      # Copies all common testing helper files into the suites directory in
-      # the sandbox.
-      #
-      # @api private
-      def prepare_helpers
-        base = File.join(config[:test_base_path], "helpers")
-
-        helper_files.each do |src|
-          dest = File.join(sandbox_suites_dir, src.sub("#{base}/", ""))
-          FileUtils.mkdir_p(File.dirname(dest))
-          FileUtils.cp(src, dest, preserve: true)
-        end
-      end
-
-      # Copies all test suite files into the suites directory in the sandbox.
-      #
-      # @api private
-      def prepare_suites
-        base = File.join(config[:test_base_path], config[:suite_name])
-
-        local_suite_files.each do |src|
-          dest = File.join(sandbox_suites_dir, src.sub("#{base}/", ""))
-          FileUtils.mkdir_p(File.dirname(dest))
-          FileUtils.cp(src, dest, preserve: true)
-        end
-      end
-
-      # @return [String] path to suites directory under sandbox path
-      # @api private
-      def sandbox_suites_dir
-        File.join(sandbox_path, "suites")
       end
     end
   end

--- a/lib/kitchen/verifier/shell.rb
+++ b/lib/kitchen/verifier/shell.rb
@@ -35,12 +35,30 @@ module Kitchen
       default_config :shellout_opts, {}
       default_config :live_stream, $stdout
       default_config :remote_exec, false
+      default_config :transfer_files, false
 
       # (see Base#call)
       def call(state)
         info("[#{name}] Verify on instance=#{instance} with state=#{state}")
         sleep_if_set
         merge_state_to_env(state)
+        if config[:transfer_files]
+          create_sandbox
+          sandbox_dirs = Dir.glob(File.join(sandbox_path, "*"))
+          begin
+            instance.transport.connection(state) do |conn|
+              conn.execute(install_command)
+              conn.execute(init_command)
+              info("Transferring files to #{instance.to_str}")
+              conn.upload(sandbox_dirs, config[:root_path])
+              debug("Transfer complete")
+            end
+          rescue Kitchen::Transport::TransportFailed => ex
+            raise ActionFailed, ex.message
+          ensure
+            cleanup_sandbox
+          end
+        end
         if config[:remote_exec]
           instance.transport.connection(state) do |conn|
             conn.execute(config[:command])
@@ -59,6 +77,13 @@ module Kitchen
           shellout
           nil
         end
+      end
+
+      # (see Base#create_sandbox)
+      def create_sandbox
+        super
+        prepare_helpers
+        prepare_suites
       end
 
       private
@@ -93,6 +118,59 @@ module Kitchen
           env_state[:environment]["KITCHEN_" + key.to_s.upcase] = value.to_s
         end
         config[:shellout_opts].merge!(env_state)
+      end
+
+      # Returns an Array of common helper filenames currently residing on the
+      # local workstation.
+      #
+      # @return [Array<String>] array of helper files
+      # @api private
+      def helper_files
+        glob = File.join(config[:test_base_path], "helpers", "*/**/*")
+        Dir.glob(glob).reject { |f| File.directory?(f) }
+      end
+
+      # Returns an Array of test suite filenames for the related suite currently
+      # residing on the local workstation. No files are excluded.
+      #
+      # @return [Array<String>] array of suite files
+      # @api private
+      def local_suite_files
+        glob = File.join(config[:test_base_path], config[:suite_name], "*/**/*")
+        Dir.glob(glob).reject { |f| File.directory?(f) }
+      end
+
+      # Copies all common testing helper files into the suites directory in
+      # the sandbox.
+      #
+      # @api private
+      def prepare_helpers
+        base = File.join(config[:test_base_path], "helpers")
+
+        helper_files.each do |src|
+          dest = File.join(sandbox_suites_dir, src.sub("#{base}/", ""))
+          FileUtils.mkdir_p(File.dirname(dest))
+          FileUtils.cp(src, dest, preserve: true)
+        end
+      end
+
+      # Copies all test suite files into the suites directory in the sandbox.
+      #
+      # @api private
+      def prepare_suites
+        base = File.join(config[:test_base_path], config[:suite_name])
+
+        local_suite_files.each do |src|
+          dest = File.join(sandbox_suites_dir, src.sub("#{base}/", ""))
+          FileUtils.mkdir_p(File.dirname(dest))
+          FileUtils.cp(src, dest, preserve: true)
+        end
+      end
+
+      # @return [String] path to suites directory under sandbox path
+      # @api private
+      def sandbox_suites_dir
+        File.join(sandbox_path, "suites")
       end
     end
   end

--- a/lib/kitchen/verifier/shell.rb
+++ b/lib/kitchen/verifier/shell.rb
@@ -120,16 +120,6 @@ module Kitchen
         config[:shellout_opts].merge!(env_state)
       end
 
-      # Returns an Array of common helper filenames currently residing on the
-      # local workstation.
-      #
-      # @return [Array<String>] array of helper files
-      # @api private
-      def helper_files
-        glob = File.join(config[:test_base_path], "helpers", "*/**/*")
-        Dir.glob(glob).reject { |f| File.directory?(f) }
-      end
-
       # Returns an Array of test suite filenames for the related suite currently
       # residing on the local workstation. No files are excluded.
       #
@@ -138,39 +128,6 @@ module Kitchen
       def local_suite_files
         glob = File.join(config[:test_base_path], config[:suite_name], "*/**/*")
         Dir.glob(glob).reject { |f| File.directory?(f) }
-      end
-
-      # Copies all common testing helper files into the suites directory in
-      # the sandbox.
-      #
-      # @api private
-      def prepare_helpers
-        base = File.join(config[:test_base_path], "helpers")
-
-        helper_files.each do |src|
-          dest = File.join(sandbox_suites_dir, src.sub("#{base}/", ""))
-          FileUtils.mkdir_p(File.dirname(dest))
-          FileUtils.cp(src, dest, preserve: true)
-        end
-      end
-
-      # Copies all test suite files into the suites directory in the sandbox.
-      #
-      # @api private
-      def prepare_suites
-        base = File.join(config[:test_base_path], config[:suite_name])
-
-        local_suite_files.each do |src|
-          dest = File.join(sandbox_suites_dir, src.sub("#{base}/", ""))
-          FileUtils.mkdir_p(File.dirname(dest))
-          FileUtils.cp(src, dest, preserve: true)
-        end
-      end
-
-      # @return [String] path to suites directory under sandbox path
-      # @api private
-      def sandbox_suites_dir
-        File.join(sandbox_path, "suites")
       end
     end
   end


### PR DESCRIPTION
When using shell verifier with option: `remote_exec: true`, I find out that it did not transfer any test files into test-kitchen instance. Thus, I added boolean option: `transfer_files` to shell verifier. See the 1st commit message. I think this is an essential option for this verifier.

In the 2nd commit I wanted to avoid repetition, so I moved some methods into base verifier and removed  them from busser and shell verifiers. I don't know if you would like that commit.
