### PR TITLE
Pinning the same as berks

### DIFF
--- a/test-kitchen.gemspec
+++ b/test-kitchen.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "net-ssh",         ">= 2.9", "< 5.0"
   gem.add_dependency "net-ssh-gateway", "~> 1.2"
   gem.add_dependency "safe_yaml",       "~> 1.0"
-  gem.add_dependency "thor",            "~> 0.18"
+  gem.add_dependency "thor",            "~> 0.19", "< 0.19.2"
   gem.add_dependency "mixlib-install",  ">= 1.2", "< 3.0"
 
   gem.add_development_dependency "pry"


### PR DESCRIPTION
Prevents fun errors like the below

```
Could not load or activate Berkshelf (Unable to activate berkshelf-5.5.0, because thor-0.19.4 conflicts with thor (< 0.19.2, ~> 0.19))
```

A more comprehensive fix of not depending on the berkshelf gem and simply shelling out should be forthcoming.