### PR TITLE
Require Ruby 2.2.2+ and bump test deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ branches:
 
 matrix:
   include:
-    - rvm: 2.2.5
+    - rvm: 2.2.6
       # To run the proxy tests we need additional gems than what Test Kitchen normally uses
       # for testing
       gemfile: Gemfile.proxy_tests

--- a/Gemfile
+++ b/Gemfile
@@ -1,13 +1,12 @@
 # -*- encoding: utf-8 -*-
 source "https://rubygems.org"
 gemspec
-gem "rack", "< 2.0"
 
-gem "train", "~> 0.19.0"
+gem "train", "~> 0.22.0"
 
 group :integration do
-  gem "berkshelf", "~> 4.3"
-  gem "kitchen-inspec", "~> 0.15.1"
+  gem "berkshelf", "~> 5.6"
+  gem "kitchen-inspec", "~> 0.17.0"
 end
 
 group :test do

--- a/lib/kitchen/loader/yaml.rb
+++ b/lib/kitchen/loader/yaml.rb
@@ -18,12 +18,6 @@
 
 require "erb"
 require "vendor/hash_recursive_merge"
-
-if RUBY_VERSION <= "1.9.3"
-  # ensure that Psych and not Syck is used for Ruby 1.9.2
-  require "yaml"
-  YAML::ENGINE.yamler = "psych"
-end
 require "safe_yaml/load"
 
 module Kitchen

--- a/lib/kitchen/state_file.rb
+++ b/lib/kitchen/state_file.rb
@@ -16,11 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if RUBY_VERSION <= "1.9.3"
-  # ensure that Psych and not Syck is used for Ruby 1.9.2
-  require "yaml"
-  YAML::ENGINE.yamler = "psych"
-end
 require "safe_yaml/load"
 
 module Kitchen

--- a/test-kitchen.gemspec
+++ b/test-kitchen.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 1.9.1"
+  gem.required_ruby_version = ">= 2.2.2"
 
   gem.add_dependency "mixlib-shellout", ">= 1.2", "< 3.0"
   gem.add_dependency "net-scp",         "~> 1.1"
@@ -42,7 +42,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "bundler"
   gem.add_development_dependency "rake"
-  gem.add_development_dependency "github_changelog_generator", "1.11.3"
+  gem.add_development_dependency "github_changelog_generator", "1.14.3"
 
   gem.add_development_dependency "aruba",     "~> 0.11"
   gem.add_development_dependency "fakefs",    "~> 0.4"
@@ -56,6 +56,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "simplecov"
   gem.add_development_dependency "yard"
 
-  # Replacing finstyle in favor of chefstyle
   gem.add_development_dependency "chefstyle"
 end


### PR DESCRIPTION
We're constraining deps as the Ruby world moves on. It's time to require
Ruby 2.2.2 as all other tooling in the Chef ecosystem does.

Signed-off-by: Tim Smith <tsmith@chef.io>