### PR TITLE
Update to latest train (and net-ssh 4)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 gemspec
 gem "rack", "< 2.0"
 
-gem "train", "~> 0.19.0"
+gem "train", "~> 0.22"
 
 group :integration do
   gem "berkshelf", "~> 4.3"


### PR DESCRIPTION
Net::SSH 4 fixes a lot of the monkey patching we had to do in our tests.

Note: The failing cucumber test is due to readline 5.4.0 (see https://github.com/ConnorAtherton/rb-readline/pull/135). 

Signed-off-by: Tom Duffield <tom@chef.io>