### PR TITLE
WIP: Move proxy driver to use Provisioner::Base and not the legacy SSHBase…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,13 +40,12 @@ matrix:
         - sudo apt-get update
         - sudo apt-get -y install squid3 git curl
       env:
-        - global:
-          - machine_user=travis
-          - machine_pass=travis
-          - machine_port=22
-          - PROXY_TESTS_DIR=proxy_tests/files/default/scripts
-          - PROXY_TESTS_REPO=$PROXY_TESTS_DIR/repo
-          - KITCHEN_YAML=/home/travis/build/test-kitchen/test-kitchen/.kitchen.proxy.yml
+        - machine_user=travis
+        - machine_pass=travis
+        - machine_port=22
+        - PROXY_TESTS_DIR=proxy_tests/files/default/scripts
+        - PROXY_TESTS_REPO=$PROXY_TESTS_DIR/repo
+        - KITCHEN_YAML=/home/travis/build/test-kitchen/test-kitchen/.kitchen.proxy.yml
 
       script:
         - bundle exec kitchen --version

--- a/spec/kitchen/driver/proxy_spec.rb
+++ b/spec/kitchen/driver/proxy_spec.rb
@@ -66,24 +66,24 @@ describe Kitchen::Driver::Proxy do
 
   describe "#create" do
     it "sets :hostname in state config" do
-      driver.stubs(:ssh)
+      driver.stubs(:reset_instance)
+      driver.stubs(:wait_until_ready)
       driver.create(state)
 
       state[:hostname].must_equal "foobnoobs.com"
     end
 
     it "calls the reset command over ssh" do
-      driver.expects(:ssh).with do |ssh_args, cmd|
-        ssh_args[0].must_equal "foobnoobs.com"
-        cmd.must_equal "mulligan"
-      end
+      driver.expects(:reset_instance)
+      driver.stubs(:wait_until_ready)
 
       driver.create(state)
     end
 
     it "skips ssh call if :reset_command is falsey" do
       config[:reset_command] = false
-      driver.expects(:ssh).never
+      driver.expects(:reset_instance).never
+      driver.stubs(:wait_until_ready)
 
       driver.create(state)
     end
@@ -95,31 +95,28 @@ describe Kitchen::Driver::Proxy do
     end
 
     it "deletes :hostname in state config" do
-      driver.stubs(:ssh)
+      driver.stubs(:reset_instance)
       driver.destroy(state)
 
       state[:hostname].must_be_nil
     end
 
     it "calls the reset command over ssh" do
-      driver.expects(:ssh).with do |ssh_args, cmd|
-        ssh_args[0].must_equal "beep"
-        cmd.must_equal "mulligan"
-      end
+      driver.expects(:reset_instance)
 
       driver.destroy(state)
     end
 
     it "skips ssh call if :hostname is not in state config" do
       state.delete(:hostname)
-      driver.expects(:ssh).never
+      driver.expects(:reset_instance).never
 
       driver.destroy(state)
     end
 
     it "skips ssh call if :reset_command is falsey" do
       config[:reset_command] = false
-      driver.expects(:ssh).never
+      driver.expects(:reset_instance).never
 
       driver.destroy(state)
     end


### PR DESCRIPTION
🚧 
….  All the defaults from SSH base should be handled elsewhere (like in transport).

This change allows the proxy driver to work with the reboot and continue behavior introduced in 1.10.0.

Signed-off-by: Steven Murawski <steven.murawski@gmail.com>