### PR TITLE
remove badges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .yardoc
 binstubs
 Gemfile*.lock
+Gemfile.local
 InstalledFiles
 _yardoc
 coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,8 +64,3 @@ matrix:
 
 notifications:
   irc: "chat.freenode.net#kitchenci"
-
-addons:
-  code_climate:
-    repo_token:
-      secure: "lcqi3hbalLTinxwsl+um1aN1dgijBrODSMseGEJMJGkofz3VZ+Ofuuwp9x9VjvewuiUFHsiPD5SQ6hx8N+L3wXB6qA+HTmIrXecL7VjehbImEyOuu4/++vcTdpTINAd2Qt/KuJ1eY0okSwVmvtX1VD8gYD8yrlMKdj6uexf8Bgs="

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ bundler_args: --without guard integration
 
 script:
   - bundle exec rake
-  - bundle exec codeclimate-test-reporter
   - bundle install --with integration
   - export KITCHEN_YAML=.kitchen.ci.yml
   - bundle exec kitchen verify ubuntu

--- a/Gemfile
+++ b/Gemfile
@@ -9,3 +9,9 @@ group :integration do
   gem "berkshelf"
   gem "kitchen-inspec"
 end
+
+instance_eval(ENV["GEMFILE_MOD"]) if ENV["GEMFILE_MOD"]
+
+# If you want to load debugging tools into the bundle exec sandbox,
+# add these additional dependencies into chef/Gemfile.local
+eval(IO.read(__FILE__ + ".local"), binding) if File.exist?(__FILE__ + ".local")

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,3 @@ group :integration do
   gem "berkshelf"
   gem "kitchen-inspec"
 end
-
-group :test do
-  gem "codeclimate-test-reporter", "~> 1.0", ">= 1.0.3", require: nil
-end

--- a/README.md
+++ b/README.md
@@ -2,10 +2,6 @@
 
 [![Gem Version](https://badge.fury.io/rb/test-kitchen.svg)](http://badge.fury.io/rb/test-kitchen)
 [![Build Status](https://secure.travis-ci.org/test-kitchen/test-kitchen.svg?branch=master)](https://travis-ci.org/test-kitchen/test-kitchen)
-[![Code Climate](https://codeclimate.com/github/test-kitchen/test-kitchen.svg)](https://codeclimate.com/github/test-kitchen/test-kitchen)
-[![Test Coverage](https://codeclimate.com/github/test-kitchen/test-kitchen/coverage.svg)](https://codeclimate.com/github/test-kitchen/test-kitchen)
-[![Dependency Status](https://gemnasium.com/test-kitchen/test-kitchen.svg)](https://gemnasium.com/test-kitchen/test-kitchen)
-[![Inline docs](http://inch-ci.org/github/test-kitchen/test-kitchen.svg?branch=master)](http://inch-ci.org/github/test-kitchen/test-kitchen)
 
 |             |                                               |
 |-------------|-----------------------------------------------|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,7 +18,7 @@
 
 gem "minitest"
 
-if ENV["CODECLIMATE_REPO_TOKEN"] || ENV["COVERAGE"]
+begin
   require "simplecov"
   SimpleCov.profiles.define "gem" do
     command_name "Specs"
@@ -30,6 +30,8 @@ if ENV["CODECLIMATE_REPO_TOKEN"] || ENV["COVERAGE"]
     add_group "Libraries", "/lib/"
   end
   SimpleCov.start "gem"
+rescue LoadError
+  puts "add simplecov to Gemfile.local or GEMFILE_MOD to generate code coverage"
 end
 
 require "fakefs/safe"

--- a/test-kitchen.gemspec
+++ b/test-kitchen.gemspec
@@ -53,9 +53,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "countloc",  "~> 0.4"
   gem.add_development_dependency "maruku",    "~> 0.6"
-  gem.add_development_dependency "simplecov"
   gem.add_development_dependency "yard"
 
-  # Replacing finstyle in favor of chefstyle
   gem.add_development_dependency "chefstyle"
 end


### PR DESCRIPTION
i really want to get rid of the dev dependency on codeclimate.  gem deps are actively harmful if not necessary or maintained.

i'm skeptical that anyone uses any of these though and that they're included more out of religious guilt because we think we 'should' be using them.

- the simple code coverage metric across the project is pretty useless (https://labs.ig.com/code-coverage-100-percent-tragedy)
- nobody is checking the dependency status or we would have caught the fact that we were still using berkshelf 4.x in tests
- code climate is still available, and i tend to see no effort to clean up overly complicated classes
- inline docs is meh