### PR TITLE
Adds ability to set auth methods for ssh transport

### DIFF
--- a/lib/kitchen/transport/ssh.rb
+++ b/lib/kitchen/transport/ssh.rb
@@ -408,6 +408,8 @@ module Kitchen
           max_wait_until_ready: data[:max_wait_until_ready],
           ssh_gateway: data[:ssh_gateway],
           ssh_gateway_username: data[:ssh_gateway_username],
+          auth_methods: data[:auth_methods] ||
+              %w(publickey hostbased password keyboard-interactive),
         }
 
         if data[:ssh_key] && !data[:password]

--- a/spec/kitchen/transport/ssh_spec.rb
+++ b/spec/kitchen/transport/ssh_spec.rb
@@ -131,6 +131,10 @@ describe Kitchen::Transport::Ssh do
       transport[:max_wait_until_ready].must_equal 600
     end
 
+    it "sets :auth_methods to ssh defaults" do
+      transport[:auth_config].must_equal %w(publickey hostbased password keyboard-interactive)
+    end
+
     it "sets :ssh_key to nil by default" do
       transport[:ssh_key].must_equal nil
     end
@@ -430,6 +434,16 @@ describe Kitchen::Transport::Ssh do
 
         klass.expects(:new).with do |hash|
           hash[:auth_methods] == ["publickey"]
+        end
+
+        make_connection
+      end
+
+      it "sets :auth_methods to to custom provided value if set" do
+        config[:auth_methods] = ["gssapi-with-mic"]
+
+        klass.expects(:new).with do |hash|
+          hash[:auth_methods] == ["gssapi-with-mic"]
         end
 
         make_connection


### PR DESCRIPTION
  * Previously the user was not able to set the auth_method to be
    used by ssh.  So if a third party gem implemented a
    new net::ssh auth_method there was no way to use the gem
    because the auth_method could not be changed.  Additionally,
    NET::SSH is not able to read local ssh config files either.

  * This code fixes that by allowing the user to set an auth_method
    of their choosing.  Example: 'gssapi-with-mic' method
    http://www.rubydoc.info/gems/net-ssh-krb/0.4.0

  * As a side affect with using gssapi-with-mic anybody wanting
    kerberos ticket authentication will now have the ability to do
    so when specifying 'gssapi-with-mic' as the auth method.  Although
    you must also install the net-ssh-krb gem.