### PR TITLE
Adds pre_create_command for running arbitrary commands

### DIFF
--- a/lib/kitchen/driver/base.rb
+++ b/lib/kitchen/driver/base.rb
@@ -17,6 +17,7 @@
 # limitations under the License.
 
 require "kitchen/lazy_hash"
+require "kitchen/shell_out"
 
 module Kitchen
   module Driver
@@ -26,6 +27,9 @@ module Kitchen
     class Base
       include Configurable
       include Logging
+      include ShellOut
+
+      default_config :pre_create_command, nil
 
       # Creates a new Driver object using the provided configuration data
       # which will be merged with any default configuration.
@@ -33,6 +37,7 @@ module Kitchen
       # @param config [Hash] provided driver configuration
       def initialize(config = {})
         init_config(config)
+        pre_create_command
       end
 
       # Creates an instance.
@@ -124,6 +129,18 @@ module Kitchen
       end
 
       private
+
+      # Run command if config[:pre_create_command] is set
+      def pre_create_command
+        if config[:pre_create_command]
+          begin
+            run_command(config[:pre_create_command])
+          rescue ShellCommandFailed => error
+            raise ActionFailed,
+              "pre_create_command '#{config[:pre_create_command]}' failed to execute #{error}"
+          end
+        end
+      end
 
       # Intercepts any bare #puts calls in subclasses and issues an INFO log
       # event instead.

--- a/spec/kitchen/driver/base_spec.rb
+++ b/spec/kitchen/driver/base_spec.rb
@@ -88,6 +88,24 @@ describe Kitchen::Driver::Base do
     end
   end
 
+  describe ".pre_create_command" do
+    it "run command" do
+      Kitchen::Driver::Base.any_instance.stubs(:run_command).returns(true)
+
+      config[:pre_create_command] = "echo works 2&>1 > /dev/null"
+      driver.expects(:run_command).with("echo works 2&>1 > /dev/null")
+      driver.send(:pre_create_command)
+    end
+
+    it "error if cannot run" do
+      class ShellCommandFailed < Kitchen::ShellOut::ShellCommandFailed; end
+      Kitchen::Driver::Base.any_instance.stubs(:run_command).raises(ShellCommandFailed, "Expected process to exit with [0], but received '1'")
+
+      config[:pre_create_command] = "touch /this/dir/does/not/exist 2&>1 > /dev/null"
+      proc { driver.send(:pre_create_command) }.must_raise Kitchen::ActionFailed
+    end
+  end
+
   describe ".no_parallel_for" do
     it "registers no serial actions when none are declared" do
       Kitchen::Driver::Speedy.serial_actions.must_be_nil


### PR DESCRIPTION
This allows .kitchen.yml to contains the following:

```yaml
driver:
  pre_create_command: echo 'this runs before an instance is created'
```

Adding this to core since the discussion at https://github.com/test-kitchen/kitchen-docker/pull/249 kitchen-vagrant already has this functionally, but this adds it to all drivers.