### PR TITLE
enforce_idempotency missing "data" error

### DIFF
--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -415,13 +415,13 @@ module Kitchen
           file.write(format_config_file(data))
         end
 
-        prepare_config_idempotency_check if config[:enforce_idempotency]
+        prepare_config_idempotency_check(data) if config[:enforce_idempotency]
       end
 
       # Writes a configuration file to the sandbox directory
       # to check for idempotency of the run.
       # @api private
-      def prepare_config_idempotency_check
+      def prepare_config_idempotency_check(data)
         handler_filename = "chef-client-fail-if-update-handler.rb"
         source = File.join(
           File.dirname(__FILE__), %w{.. .. .. support }, handler_filename


### PR DESCRIPTION
When the kitchen.yml include
provisioner:
name: chef_zero
enforce_idempotency: true
multiple_converge: 2

Error such as the following is received.

Failed to complete #converge action: [undefined local variable or method `data' for #.........
Pull request 1068 has this fix lumped in with other proxy items. test-kitchen#1068
I am breaking this out into separate PR with just the fix for enforce_idempotency.

Other references to this error can be found in bottom of pull 875 after it was merged.
test-kitchen#875
