### PR TITLE
use a more efficient sort for gem specs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,5 @@
 Style/FileName:
   Exclude:
     - 'support/**/*'
+Layout/EndOfLine:
+  EnforcedStyle: lf

--- a/lib/kitchen/command/driver_discover.rb
+++ b/lib/kitchen/command/driver_discover.rb
@@ -42,7 +42,7 @@ module Kitchen
         end
         ChefConfig::Config.export_proxies if defined?(ChefConfig::Config.export_proxies)
 
-        specs = fetch_gem_specs.sort { |x, y| x[0] <=> y[0] }
+        specs = fetch_gem_specs.sort_by { |spec| spec[0] }
         specs = specs[0, 49].push(["...", "..."]) if specs.size > 49
         specs = specs.unshift(["Gem Name", "Latest Stable Release"])
         print_table(specs, indent: 4)


### PR DESCRIPTION
Rubocop barked about an inefficient sort. Use sort_by instead. OK.