### PR TITLE
Fix Dir.glob usage

### DIFF
--- a/lib/kitchen/driver/ssh_base.rb
+++ b/lib/kitchen/driver/ssh_base.rb
@@ -70,7 +70,7 @@ module Kitchen
       def converge(state) # rubocop:disable Metrics/AbcSize
         provisioner = instance.provisioner
         provisioner.create_sandbox
-        sandbox_dirs = Dir.glob("#{provisioner.sandbox_path}/*")
+        sandbox_dirs = Util.list_directory(provisioner.sandbox_path)
 
         instance.transport.connection(backcompat_merged_state(state)) do |conn|
           conn.execute(env_cmd(provisioner.install_command))
@@ -102,7 +102,7 @@ module Kitchen
       def verify(state) # rubocop:disable Metrics/AbcSize
         verifier = instance.verifier
         verifier.create_sandbox
-        sandbox_dirs = Dir.glob(File.join(verifier.sandbox_path, "*"))
+        sandbox_dirs = Util.list_directory(verifier.sandbox_path)
 
         instance.transport.connection(backcompat_merged_state(state)) do |conn|
           conn.execute(env_cmd(verifier.init_command))

--- a/lib/kitchen/generator/init.rb
+++ b/lib/kitchen/generator/init.rb
@@ -119,7 +119,7 @@ module Kitchen
       #   initialized
       # @api private
       def init_test_dir?
-        Dir.glob("test/integration/*").select { |d| File.directory?(d) }.empty?
+        Util.list_directory("test/integration/").select { |d| File.directory?(d) }.empty?
       end
 
       # @return [true,false] whether or not a `.gitignore` file needs to be

--- a/lib/kitchen/provisioner/base.rb
+++ b/lib/kitchen/provisioner/base.rb
@@ -63,7 +63,7 @@ module Kitchen
       # rubocop:disable Metrics/AbcSize
       def call(state)
         create_sandbox
-        sandbox_dirs = Dir.glob(File.join(sandbox_path, "*"))
+        sandbox_dirs = Util.list_directory(sandbox_path)
 
         instance.transport.connection(state) do |conn|
           conn.execute(install_command)

--- a/lib/kitchen/provisioner/chef/common_sandbox.rb
+++ b/lib/kitchen/provisioner/chef/common_sandbox.rb
@@ -81,7 +81,7 @@ module Kitchen
         # @api private
         def all_files_in_cookbooks
           Util.list_directory(tmpbooks_dir, include_dot: true, recurse: true)
-             .select { |fn| File.file?(fn) && ! %w{. ..}.include?(fn) }
+             .select { |fn| File.file?(fn) }
         end
 
         # @return [String] an absolute path to a Policyfile, relative to the

--- a/lib/kitchen/provisioner/shell.rb
+++ b/lib/kitchen/provisioner/shell.rb
@@ -93,7 +93,7 @@ module Kitchen
 
         tmpdata_dir = File.join(sandbox_path, "data")
         FileUtils.mkdir_p(tmpdata_dir)
-        FileUtils.cp_r(Dir.glob("#{config[:data_path]}/*"), tmpdata_dir)
+        FileUtils.cp_r(Util.list_directory(config[:data_path]), tmpdata_dir)
       end
 
       # Copies the executable script to the sandbox directory or creates a

--- a/lib/kitchen/util.rb
+++ b/lib/kitchen/util.rb
@@ -143,7 +143,7 @@ module Kitchen
     end
 
     # Lists the contents of the given directory. path will be prepended
-    # to the list returned
+    # to the list returned. '.' and '..' are never returned.
     #
     # @param path [String] the directory to list
     # @param include_dot [Boolean] if true, dot files will be included
@@ -171,9 +171,9 @@ module Kitchen
                 else
                   []
                 end
-        Dir.glob(glob_pattern, *flags).map do |f|
-          File.join(path, f)
-        end
+        Dir.glob(glob_pattern, *flags)
+          .reject { |f| [".", ".."].include?(f) }
+          .map { |f| File.join(path, f) }
       end
     end
 

--- a/lib/kitchen/util.rb
+++ b/lib/kitchen/util.rb
@@ -141,5 +141,59 @@ module Kitchen
                 File.dirname(__FILE__), %w{.. .. support download_helpers.sh}
       ))
     end
+
+    # Lists the contents of the given directory. path will be prepended
+    # to the list returned
+    #
+    # @param path [String] the directory to list
+    # @param include_dot [Boolean] if true, dot files will be included
+    # @param recurse [Boolean] if true, listing will be recursive
+    # @return A listing of the specified path
+    #
+    # @note You should prefer this method to using Dir.glob directly. The reason is
+    # because Dir.glob behaves strangely on Windows. It wont accept '\'
+    # and doesn't like fake directories (C:\Documents and Settings)
+    # It also does not do any sort of error checking, so things one would
+    # expect to fail just return an empty list
+    def self.list_directory(path, include_dot: false, recurse: false)
+      # Things (such as tests) are relying on this to not blow up if
+      # the directory does not exist
+      return [] if !Dir.exist?(path)
+
+      Dir.chdir(path) do
+        glob_pattern = if recurse
+                         "**/*"
+                       else
+                         "*"
+                       end
+        flags = if include_dot
+                  [File::FNM_DOTMATCH]
+                else
+                  []
+                end
+        Dir.glob(glob_pattern, *flags).map do |f|
+          File.join(path, f)
+        end
+      end
+    end
+
+    # Similar to Dir.glob.
+    #
+    # The difference is this function forces you to specify where to glob from.
+    # You should glob from the path closest to what you want. The reason for this
+    # is because if you have symlinks on windows of any kind, Dir.glob will not
+    # traverse them.
+    #
+    # @param path [String] the directory to glob from
+    # @param pattern [String] The pattern to match
+    # @param flags [Integer] You can specify flags you would have passed to Dir.glob
+    # @return Files matching the specified pattern in the given path
+    def self.safe_glob(path, pattern, *flags)
+      return [] if !Dir.exist?(path)
+
+      Dir.chdir(path) do
+        Dir.glob(pattern, *flags).map { |f| File.join(path, f) }
+      end
+    end
   end
 end

--- a/lib/kitchen/verifier/base.rb
+++ b/lib/kitchen/verifier/base.rb
@@ -65,7 +65,7 @@ module Kitchen
       # @raise [ActionFailed] if the action could not be completed
       def call(state)
         create_sandbox
-        sandbox_dirs = Dir.glob(File.join(sandbox_path, "*"))
+        sandbox_dirs = Util.list_directory(sandbox_path)
 
         instance.transport.connection(state) do |conn|
           conn.execute(install_command)

--- a/lib/kitchen/verifier/busser.rb
+++ b/lib/kitchen/verifier/busser.rb
@@ -193,8 +193,8 @@ module Kitchen
       # @return [Array<String>] array of helper files
       # @api private
       def helper_files
-        glob = File.join(config[:test_base_path], "helpers", "*/**/*")
-        Dir.glob(glob).reject { |f| File.directory?(f) }
+        glob = File.join("helpers", "*/**/*")
+        Util.safe_glob(config[:test_base_path], glob).reject { |f| File.directory?(f) }
       end
 
       def install_command_vars
@@ -221,8 +221,7 @@ module Kitchen
       # @api private
       def local_suite_files
         base = File.join(config[:test_base_path], config[:suite_name])
-        glob = File.join(base, "*/**/*")
-        Dir.glob(glob).reject do |f|
+        Util.safe_glob(base, "*/**/*").reject do |f|
           chef_data_dir?(base, f) || File.directory?(f)
         end
       end
@@ -235,8 +234,7 @@ module Kitchen
       # @api private
       def plugins
         non_suite_dirs = %w{data data_bags environments nodes roles}
-        glob = File.join(config[:test_base_path], config[:suite_name], "*")
-        Dir.glob(glob).reject do |d|
+        Util.list_directory(File.join(config[:test_base_path], config[:suite_name])).reject do |d|
           !File.directory?(d) || non_suite_dirs.include?(File.basename(d))
         end.map { |d| "busser-#{File.basename(d)}" }.sort.uniq
       end

--- a/spec/kitchen/util_spec.rb
+++ b/spec/kitchen/util_spec.rb
@@ -175,10 +175,10 @@ describe Kitchen::Util do
 
     it "lists one level with no dot files by default" do
       listed = Kitchen::Util.list_directory(@root)
-      expected = [
-        "foo",
-        "bar",
-      ].map { |f| File.join(@root, f) }
+      expected = %w{
+        foo
+        bar
+      }.map { |f| File.join(@root, f) }
       (listed - expected).must_equal []
       (expected - listed).must_equal []
     end
@@ -186,11 +186,9 @@ describe Kitchen::Util do
     it "matches dot files only when include_dot" do
       listed = Kitchen::Util.list_directory(@root, include_dot: true)
       expected = [
-        ".",
-        "..",
         "foo",
         ".foo",
-        "bar"
+        "bar",
       ].map { |f| File.join(@root, f) }
       (listed - expected).must_equal []
       (expected - listed).must_equal []
@@ -201,7 +199,7 @@ describe Kitchen::Util do
       expected = [
         "foo",
         "bar",
-        "bar/baz"
+        "bar/baz",
       ].map { |f| File.join(@root, f) }
       (listed - expected).must_equal []
       (expected - listed).must_equal []
@@ -210,13 +208,12 @@ describe Kitchen::Util do
     it "recusivly lists and provides dots when recurse and include_dot" do
       listed = Kitchen::Util.list_directory(@root, recurse: true, include_dot: true)
       expected = [
-        ".",
         "foo",
         ".foo",
         "bar",
         "bar/baz",
         "bar/.",
-        "bar/.baz"
+        "bar/.baz",
       ].map { |f| File.join(@root, f) }
       (listed - expected).must_equal []
       (expected - listed).must_equal []

--- a/spec/kitchen/util_spec.rb
+++ b/spec/kitchen/util_spec.rb
@@ -159,7 +159,6 @@ describe Kitchen::Util do
       @root = Dir.mktmpdir
       FileUtils.touch(File.join(@root, "foo"))
       Dir.mkdir(File.join(@root, "bar"))
-      FileUtils.touch(File.join(@root, "foo"))
       FileUtils.touch(File.join(@root, ".foo"))
       FileUtils.touch(File.join(@root, "bar", "baz"))
       FileUtils.touch(File.join(@root, "bar", ".baz"))
@@ -217,6 +216,35 @@ describe Kitchen::Util do
       ].map { |f| File.join(@root, f) }
       (listed - expected).must_equal []
       (expected - listed).must_equal []
+    end
+  end
+
+  describe ".safe_glob" do
+    before do
+      @root = Dir.mktmpdir
+      FileUtils.touch(File.join(@root, "foo"))
+      Dir.mkdir(File.join(@root, "bar"))
+      FileUtils.touch(File.join(@root, "foo"))
+      FileUtils.touch(File.join(@root, "foo.rb"))
+      FileUtils.touch(File.join(@root, "bar", "baz.rb"))
+    end
+
+    after do
+      FileUtils.remove_entry(@root)
+    end
+
+    it "globs without parameters" do
+      Kitchen::Util.safe_glob(@root, "**/*").must_equal Dir.glob(File.join(@root, "**/*"))
+    end
+
+    it "globs with parameters" do
+      Kitchen::Util.safe_glob(@root, "**/*", File::FNM_DOTMATCH).must_equal(
+        Dir.glob(File.join(@root, "**/*"), File::FNM_DOTMATCH))
+    end
+
+    it "globs a folder that does not exist" do
+      dne_dir = File.join(@root, "notexist")
+      Kitchen::Util.safe_glob(dne_dir, "**/*").must_equal Dir.glob(File.join(dne_dir, "**/*"))
     end
   end
 end

--- a/spec/kitchen/util_spec.rb
+++ b/spec/kitchen/util_spec.rb
@@ -153,4 +153,73 @@ describe Kitchen::Util do
       Regexp.new("^ +" + Regexp.escape(str) + "$")
     end
   end
+
+  describe ".list_directory" do
+    before do
+      @root = Dir.mktmpdir
+      FileUtils.touch(File.join(@root, "foo"))
+      Dir.mkdir(File.join(@root, "bar"))
+      FileUtils.touch(File.join(@root, "foo"))
+      FileUtils.touch(File.join(@root, ".foo"))
+      FileUtils.touch(File.join(@root, "bar", "baz"))
+      FileUtils.touch(File.join(@root, "bar", ".baz"))
+    end
+
+    after do
+      FileUtils.remove_entry(@root)
+    end
+
+    it "returns [] when the directory does not exist" do
+      Kitchen::Util.list_directory(File.join(@root, "notexist")).must_equal []
+    end
+
+    it "lists one level with no dot files by default" do
+      listed = Kitchen::Util.list_directory(@root)
+      expected = [
+        "foo",
+        "bar",
+      ].map { |f| File.join(@root, f) }
+      (listed - expected).must_equal []
+      (expected - listed).must_equal []
+    end
+
+    it "matches dot files only when include_dot" do
+      listed = Kitchen::Util.list_directory(@root, include_dot: true)
+      expected = [
+        ".",
+        "..",
+        "foo",
+        ".foo",
+        "bar"
+      ].map { |f| File.join(@root, f) }
+      (listed - expected).must_equal []
+      (expected - listed).must_equal []
+    end
+
+    it "recusivly lists only when recurse" do
+      listed = Kitchen::Util.list_directory(@root, recurse: true)
+      expected = [
+        "foo",
+        "bar",
+        "bar/baz"
+      ].map { |f| File.join(@root, f) }
+      (listed - expected).must_equal []
+      (expected - listed).must_equal []
+    end
+
+    it "recusivly lists and provides dots when recurse and include_dot" do
+      listed = Kitchen::Util.list_directory(@root, recurse: true, include_dot: true)
+      expected = [
+        ".",
+        "foo",
+        ".foo",
+        "bar",
+        "bar/baz",
+        "bar/.",
+        "bar/.baz"
+      ].map { |f| File.join(@root, f) }
+      (listed - expected).must_equal []
+      (expected - listed).must_equal []
+    end
+  end
 end


### PR DESCRIPTION
Dir.glob is broken on Windows in a variety of ways. Changing to the
directory you want to glob before doing any sort of globbing is the safest
way to use it from past experience.

Related to https://github.com/test-kitchen/test-kitchen/issues/1238 in
that it is the very next error one would run into with berkshelf being
fixed.