### PR TITLE
new install_strategy option used in conjunction with product_name

### DIFF
--- a/spec/kitchen/provisioner/chef_base_spec.rb
+++ b/spec/kitchen/provisioner/chef_base_spec.rb
@@ -132,6 +132,30 @@ describe Kitchen::Provisioner::ChefBase do
       provisioner[:encrypted_data_bag_secret_key_path]
         .must_equal os_safe_root_path("/rooty/<calculated>/encrypted_data_bag_secret_key")
     end
+
+    it ":product_name default to nil" do
+      provisioner[:product_name].must_be_nil
+    end
+
+    it ":product_version defaults to :latest" do
+      provisioner[:product_version].must_equal :latest
+    end
+
+    it ":channel defaults to :stable" do
+      provisioner[:channel].must_equal :stable
+    end
+
+    it ":platform default to nil" do
+      provisioner[:platform].must_be_nil
+    end
+
+    it ":platform_version default to nil" do
+      provisioner[:platform_version].must_be_nil
+    end
+
+    it ":architecture default to nil" do
+      provisioner[:architecture].must_be_nil
+    end
   end
 
   describe "#install_command" do
@@ -415,6 +439,33 @@ describe Kitchen::Provisioner::ChefBase do
         Mixlib::Install.expects(:new).with do |opts|
           opts[:channel].must_equal :stable
         end.returns(installer)
+        cmd
+      end
+
+      it "will set install_strategy to once when not given" do
+        Mixlib::Install.expects(:new).with do |opts|
+          opts[:install_command_options][:install_strategy].must_equal "once"
+        end.returns(installer)
+        cmd
+      end
+
+      it "will set install_strategy when given" do
+        config[:install_strategy] = "always"
+        Mixlib::Install.expects(:new).with do |opts|
+          opts[:install_command_options][:install_strategy].must_equal "always"
+        end.returns(installer)
+        cmd
+      end
+    end
+
+    describe "when install_strategy is skipped" do
+      before do
+        config[:product_name] = "my_product"
+        config[:install_strategy] = "skip"
+      end
+
+      it "will not return installer when install_strategy is set to skip" do
+        Mixlib::Install.expects(:new).never
         cmd
       end
     end

--- a/test-kitchen.gemspec
+++ b/test-kitchen.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "net-ssh-gateway", "~> 1.2"
   gem.add_dependency "safe_yaml",       "~> 1.0"
   gem.add_dependency "thor",            "~> 0.19", "< 0.19.2"
-  gem.add_dependency "mixlib-install",  ">= 1.2", "< 3.0"
+  gem.add_dependency "mixlib-install",  "~> 3.4"
 
   gem.add_development_dependency "pry"
   gem.add_development_dependency "pry-byebug"


### PR DESCRIPTION
This PR is part of a series of new features being added to Kitchen based on [RFC-091](https://github.com/chef/chef-rfc/blob/master/rfc091-deprecate-kitchen-settings.md#new-settings)

### New provisioner option `install_strategy`
Only enabled when used with `product_name` setting.

| Values | Description |
| ------- | ----------- |
| once (default) | when using product_name Kitchen will no longer reinstall chef/chefdk if it's already installed just like the default require_chef_omnibus behavior |
| always | always install the specified product_version |
| skip | do not install chef/chefdk|

Signed-off-by: Patrick Wright <patrick@chef.io>