### PR TITLE
add download_url and checksum provisioner options

### DIFF
--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -127,6 +127,10 @@ module Kitchen
 
       default_config :architecture
 
+      default_config :download_url
+
+      default_config :checksum
+
       # Reads the local Chef::Config object (if present).  We do this because
       # we want to start bring Chef config and ChefDK tool config closer
       # together.  For example, we want to configure proxy settings in 1
@@ -364,6 +368,11 @@ module Kitchen
           opts[:shell_type] = :ps1 if powershell_shell?
           [:platform, :platform_version, :architecture].each do |key|
             opts[key] = config[key] if config[key]
+          end
+
+          if config[:download_url]
+            opts[:install_command_options][:download_url_override] = config[:download_url]
+            opts[:install_command_options][:checksum] = config[:checksum] if config[:checksum]
           end
         end)
         config[:chef_omnibus_root] = installer.root

--- a/spec/kitchen/provisioner/chef_base_spec.rb
+++ b/spec/kitchen/provisioner/chef_base_spec.rb
@@ -156,6 +156,14 @@ describe Kitchen::Provisioner::ChefBase do
     it ":architecture default to nil" do
       provisioner[:architecture].must_be_nil
     end
+
+    it ":download_url default to nil" do
+      provisioner[:download_url].must_be_nil
+    end
+
+    it ":checksum default to nil" do
+      provisioner[:checksum].must_be_nil
+    end
   end
 
   describe "#install_command" do
@@ -453,6 +461,17 @@ describe Kitchen::Provisioner::ChefBase do
         config[:install_strategy] = "always"
         Mixlib::Install.expects(:new).with do |opts|
           opts[:install_command_options][:install_strategy].must_equal "always"
+        end.returns(installer)
+        cmd
+      end
+
+      it "will set the download_url and checksum if given" do
+        config[:download_url] = "http://url/path"
+        config[:checksum] = "abcd"
+
+        Mixlib::Install.expects(:new).with do |opts|
+          opts[:install_command_options][:download_url_override].must_equal "http://url/path"
+          opts[:install_command_options][:checksum].must_equal "abcd"
         end.returns(installer)
         cmd
       end

--- a/test-kitchen.gemspec
+++ b/test-kitchen.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "net-ssh-gateway", "~> 1.2"
   gem.add_dependency "safe_yaml",       "~> 1.0"
   gem.add_dependency "thor",            "~> 0.19", "< 0.19.2"
-  gem.add_dependency "mixlib-install",  "~> 3.4"
+  gem.add_dependency "mixlib-install",  "~> 3.5"
 
   gem.add_development_dependency "pry"
   gem.add_development_dependency "pry-byebug"


### PR DESCRIPTION
This PR is part of a series of new features being added to Kitchen based on [RFC-091](https://github.com/chef/chef-rfc/blob/master/rfc091-deprecate-kitchen-settings.md#new-settings)

### New provisioner options `download_url`, `checksum`
Currently only enabled when used with `product_name` setting.

`download_url` is meant to replace `install_msi_url`.

bourne and powershell environments can now download a package from a URL for install.
`checksum` is optional when used with `download_url`.

For those curious how this works checkout https://github.com/chef/mixlib-install/pull/237

Signed-off-by: Patrick Wright <patrick@chef.io>