### PR TITLE
Remove rack pin for Ruby 2.1 & move changelog gen to gemfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
   - sudo usermod -p `openssl passwd -1 'travis'` travis
   - gem --version
 
-bundler_args: --without guard integration
+bundler_args: --without changelog
 
 script:
   - bundle exec rake

--- a/Gemfile
+++ b/Gemfile
@@ -1,13 +1,16 @@
 # -*- encoding: utf-8 -*-
 source "https://rubygems.org"
 gemspec
-gem "rack", "< 2.0"
 
 gem "train", "~> 0.22"
 
 group :integration do
   gem "berkshelf"
   gem "kitchen-inspec"
+end
+
+group :changelog do
+  gem "github_changelog_generator", "1.11.3"
 end
 
 instance_eval(ENV["GEMFILE_MOD"]) if ENV["GEMFILE_MOD"]

--- a/test-kitchen.gemspec
+++ b/test-kitchen.gemspec
@@ -42,7 +42,6 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "bundler"
   gem.add_development_dependency "rake"
-  gem.add_development_dependency "github_changelog_generator", "1.11.3"
 
   gem.add_development_dependency "aruba",     "~> 0.11"
   gem.add_development_dependency "fakefs",    "~> 0.4"


### PR DESCRIPTION
We don't support Ruby 2.1 anymore so this pin isn't necessary. This was due to the changelog generator actually and octokit and the mess that was trying to support Ruby 2.1 when it went into security only mode. This change also moves the changlog generator into the gemfile so we can exclude it with appbundler in ChefDK

Signed-off-by: Tim Smith <tsmith@chef.io>