### PR TITLE
Move extra dev deps to the Gemfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: ruby
 
 rvm:
-  - 2.3.4
-  - 2.4.1
+  - 2.3
+  - 2.4
   - ruby-head
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
   - sudo usermod -p `openssl passwd -1 'travis'` travis
   - gem --version
 
-bundler_args: --without changelog
+bundler_args: --without changelog pry docs
 
 script:
   - bundle exec rake

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,20 @@ group :changelog do
   gem "github_changelog_generator", "1.11.3"
 end
 
+group :debug do
+  gem "pry"
+  gem "pry-byebug"
+  gem "pry-stack_explorer"
+end
+
+group :chefstyle do
+  gem "chefstyle"
+end
+
+group :docs do
+  gem "yard"
+end
+
 instance_eval(ENV["GEMFILE_MOD"]) if ENV["GEMFILE_MOD"]
 
 # If you want to load debugging tools into the bundle exec sandbox,

--- a/Rakefile
+++ b/Rakefile
@@ -37,7 +37,7 @@ begin
     task.options += ["--display-cop-names", "--no-color"]
   end
 rescue LoadError
-  puts "chefstyle is not available.  gem install chefstyle to do style checking."
+  puts "chefstyle is not available. (sudo) gem install chefstyle to do style checking."
 end
 
 desc "Run all quality tasks"
@@ -64,5 +64,5 @@ begin
   end
 rescue LoadError
   puts "github_changelog_generator is not available." \
-       " gem install github_changelog_generator to generate changelogs"
+       " (sudo) gem install github_changelog_generator to generate changelogs"
 end

--- a/test-kitchen.gemspec
+++ b/test-kitchen.gemspec
@@ -31,9 +31,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency "thor",            "~> 0.19", "< 0.19.2"
   gem.add_dependency "mixlib-install",  "~> 3.5"
 
-  gem.add_development_dependency "pry"
-  gem.add_development_dependency "pry-byebug"
-  gem.add_development_dependency "pry-stack_explorer"
   gem.add_development_dependency "rb-readline"
   gem.add_development_dependency "overcommit", "= 0.33.0"
   gem.add_development_dependency "winrm", "~> 2.0"
@@ -47,12 +44,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "fakefs",    "~> 0.4"
   gem.add_development_dependency "minitest",  "~> 5.3"
   gem.add_development_dependency "mocha",     "~> 1.1"
-
   gem.add_development_dependency "cucumber",  "~> 2.1"
-
   gem.add_development_dependency "countloc",  "~> 0.4"
   gem.add_development_dependency "maruku",    "~> 0.6"
-  gem.add_development_dependency "yard"
-
-  gem.add_development_dependency "chefstyle"
 end


### PR DESCRIPTION
This allows us to skip installing / bundling them

Signed-off-by: Tim Smith <tsmith@chef.io>