### PR TITLE
add proxy support when using product_name

### DIFF
--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -374,6 +374,17 @@ module Kitchen
             opts[:install_command_options][:download_url_override] = config[:download_url]
             opts[:install_command_options][:checksum] = config[:checksum] if config[:checksum]
           end
+
+          proxies = {}.tap do |prox|
+            [:http_proxy, :https_proxy, :ftp_proxy, :no_proxy].each do |key|
+              prox[key] = config[key] if config[key]
+            end
+
+            # install.ps1 only supports http_proxy
+            prox.delete_if { |p| [:https_proxy, :ftp_proxy, :no_proxy].include?(p) } if powershell_shell?
+          end
+
+          opts[:install_command_options].merge!(proxies)
         end)
         config[:chef_omnibus_root] = installer.root
         if powershell_shell?

--- a/spec/kitchen/provisioner/chef_base_spec.rb
+++ b/spec/kitchen/provisioner/chef_base_spec.rb
@@ -475,6 +475,37 @@ describe Kitchen::Provisioner::ChefBase do
         end.returns(installer)
         cmd
       end
+
+      it "will set the http_proxy and https_proxy if given" do
+        config[:http_proxy] = "http://url/path:8000"
+        config[:https_proxy] = "http://url/path:8000"
+
+        Mixlib::Install.expects(:new).with do |opts|
+          opts[:install_command_options][:http_proxy].must_equal "http://url/path:8000"
+          opts[:install_command_options][:https_proxy].must_equal "http://url/path:8000"
+        end.returns(installer)
+        cmd
+      end
+
+      it "will set the http_proxy only for powershell" do
+        config[:http_proxy] = "http://url/path:8000"
+        config[:https_proxy] = "http://url/path:8000"
+        platform.stubs(:shell_type).returns("powershell")
+        platform.stubs(:os_type).returns("windows")
+
+        Mixlib::Install.expects(:new).with do |opts|
+          opts[:install_command_options][:http_proxy].must_equal "http://url/path:8000"
+          opts[:install_command_options][:https_proxy].must_be_nil
+        end.returns(installer)
+        cmd
+      end
+
+      it "will not set proxies when not given" do
+        Mixlib::Install.expects(:new).with do |opts|
+          opts[:install_command_options][:http_proxy].must_be_nil
+        end.returns(installer)
+        cmd
+      end
     end
 
     describe "when install_strategy is skipped" do

--- a/test-kitchen.gemspec
+++ b/test-kitchen.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "net-ssh-gateway", "~> 1.2"
   gem.add_dependency "safe_yaml",       "~> 1.0"
   gem.add_dependency "thor",            "~> 0.19", "< 0.19.2"
-  gem.add_dependency "mixlib-install",  "~> 3.5"
+  gem.add_dependency "mixlib-install",  "~> 3.6"
 
   gem.add_development_dependency "rb-readline"
   gem.add_development_dependency "overcommit", "= 0.33.0"


### PR DESCRIPTION
mixlib-install 3.6 adds proxy support to the API and installation scripts. This PR will pass the provisioner proxy settings to the install scripts generated by mixlib-install.

Signed-off-by: Patrick Wright <patrick@chef.io>