### PR TITLE
idempotent_check: Allow specificaton of enforce_idempotency

### DIFF
--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -460,13 +460,13 @@ module Kitchen
           file.write(format_config_file(data))
         end
 
-        prepare_config_idempotency_check if config[:enforce_idempotency]
+        prepare_config_idempotency_check(data) if config[:enforce_idempotency]
       end
 
       # Writes a configuration file to the sandbox directory
       # to check for idempotency of the run.
       # @api private
-      def prepare_config_idempotency_check
+      def prepare_config_idempotency_check(data)
         handler_filename = "chef-client-fail-if-update-handler.rb"
         source = File.join(
           File.dirname(__FILE__), %w{.. .. .. support }, handler_filename

--- a/spec/kitchen/provisioner/chef_solo_spec.rb
+++ b/spec/kitchen/provisioner/chef_solo_spec.rb
@@ -98,6 +98,10 @@ describe Kitchen::Provisioner::ChefSolo do
         IO.read(sandbox_path("solo.rb")).lines.map(&:chomp)
       end
 
+      let(:file_no_updated_resources) do
+        IO.read(sandbox_path("client_no_updated_resources.rb")).lines.map(&:chomp)
+      end
+
       it "creates a solo.rb" do
         provisioner.create_sandbox
 
@@ -274,6 +278,14 @@ describe Kitchen::Provisioner::ChefSolo do
 
         file.must_include %{foo false}
         file.must_include %{bar true}
+      end
+
+      it "supports idempotency check " do
+        config[:multiple_converge] = 2
+        config[:enforce_idempotency] = true
+        provisioner.create_sandbox
+
+        file_no_updated_resources.join.must_match /handler_file =.*chef-client-fail-if-update-handler.rb/
       end
     end
 

--- a/spec/kitchen/provisioner/chef_zero_spec.rb
+++ b/spec/kitchen/provisioner/chef_zero_spec.rb
@@ -123,6 +123,10 @@ describe Kitchen::Provisioner::ChefZero do
         IO.read(sandbox_path("client.rb")).lines.map(&:chomp)
       end
 
+      let(:file_no_updated_resources) do
+        IO.read(sandbox_path("client_no_updated_resources.rb")).lines.map(&:chomp)
+      end
+
       it "creates a client.rb" do
         provisioner.create_sandbox
 
@@ -299,6 +303,14 @@ describe Kitchen::Provisioner::ChefZero do
 
         file.must_include %{foo false}
         file.must_include %{bar true}
+      end
+
+      it "supports idempotency check " do
+        config[:multiple_converge] = 2
+        config[:enforce_idempotency] = true
+        provisioner.create_sandbox
+
+        file_no_updated_resources.join.must_match /handler_file =.*chef-client-fail-if-update-handler.rb/
       end
     end
 


### PR DESCRIPTION
Currently specifying enforce_idmempotency as an option will cause an error, data is undefined.
Fix the code and add tests to detect the condition and that a client rb file with the handler
that checks for idempotency is generated.

A rebase of #1252 was requested.  This does the rebase and includes tests.  This PR should replace #1280 and part of #1068.

Thanks,
  Mark