### PR TITLE
Pin to net-ssh 4.1.0 for now

### DIFF
--- a/.kitchen.ci.yml
+++ b/.kitchen.ci.yml
@@ -11,7 +11,6 @@ provisioner:
   name: chef_zero
 
 platforms:
-  - name: ubuntu-14.04
   - name: windows-2012R2
     transport:
       name: winrm

--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -1,0 +1,31 @@
+---
+driver:
+  name: dokken
+  privileged: true # because Docker and SystemD/Upstart
+
+provisioner:
+  name: dokken
+
+transport:
+  name: dokken
+
+verifier:
+  name: inspec
+
+platforms:
+- name: ubuntu-16.04
+  driver:
+    image: dokken/ubuntu-16.04
+    pid_one_command: /bin/systemd
+    intermediate_instructions:
+      - RUN /usr/bin/apt-get update
+
+- name: centos-7
+  driver:
+    image: dokken/centos-7
+    pid_one_command: /usr/lib/systemd/systemd
+
+suites:
+  - name: default
+    run_list:
+      - recipe[test_cookbook::default]

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,21 +3,19 @@ dist: trusty
 services: docker
 
 language: ruby
-cache: bundler
 
 rvm:
   - 2.3
-  - 2.4
+  - 2.4.2
   - ruby-head
 
 
 before_install:
   - gem --version
 
-bundler_args: --without changelog pry docs
+bundler_args: --with integration --without changelog debug docs
 
 script:
-  - bundle install --with integration
   - bundle exec rake
   - export KITCHEN_YAML=.kitchen.dokken.yml
   - bundle exec kitchen test

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ rvm:
 
 
 before_install:
+  - gem install kitchen-vagrant 
   - gem --version
 
 bundler_args: --without changelog pry docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,17 @@
+sudo: required
+dist: trusty
+services: docker
+
 language: ruby
+cache: bundler
 
 rvm:
   - 2.3
   - 2.4
   - ruby-head
 
-env:
-  - global:
-    - machine_user=travis
-    - machine_pass=travis
-    - machine_port=22
-
-dist: precise
-sudo: required
-#cache: bundler
 
 before_install:
-  - sudo usermod -p `openssl passwd -1 'travis'` travis
   - gem --version
 
 bundler_args: --without changelog pry docs
@@ -24,8 +19,8 @@ bundler_args: --without changelog pry docs
 script:
   - bundle exec rake
   - bundle install --with integration
-  - export KITCHEN_YAML=.kitchen.ci.yml
-  - bundle exec kitchen verify ubuntu
+  - export KITCHEN_YAML=.kitchen.dokken.yml
+  - bundle exec kitchen test
 
 branches:
   only:
@@ -33,7 +28,7 @@ branches:
 
 matrix:
   include:
-    - rvm: 2.3.4
+    - rvm: 2.4
       # To run the proxy tests we need additional gems than what Test Kitchen normally uses
       # for testing
       gemfile: Gemfile.proxy_tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ before_install:
 bundler_args: --without changelog pry docs
 
 script:
-  - bundle exec rake
   - bundle install --with integration
+  - bundle exec rake
   - export KITCHEN_YAML=.kitchen.dokken.yml
   - bundle exec kitchen test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ rvm:
 
 
 before_install:
-  - gem install kitchen-vagrant 
   - gem --version
 
 bundler_args: --without changelog pry docs

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ group :integration do
   gem "berkshelf"
   gem "kitchen-inspec"
   gem "kitchen-dokken"
+  gem "kitchen-vagrant"
 end
 
 group :changelog do

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem "train", "~> 0.22"
 group :integration do
   gem "berkshelf"
   gem "kitchen-inspec"
+  gem "kitchen-dokken"
 end
 
 group :changelog do

--- a/test-kitchen.gemspec
+++ b/test-kitchen.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "mixlib-shellout", ">= 1.2", "< 3.0"
   gem.add_dependency "net-scp",         "~> 1.1"
-  gem.add_dependency "net-ssh",         ">= 2.9", "< 5.0"
+  gem.add_dependency "net-ssh",         ">= 2.9", "<= 4.1.0"
   gem.add_dependency "net-ssh-gateway", "~> 1.2"
   gem.add_dependency "safe_yaml",       "~> 1.0"
   gem.add_dependency "thor",            "~> 0.19", "< 0.19.2"


### PR DESCRIPTION
Due to an upstream language change in https://github.com/net-ssh/net-ssh/pull/524 we are pinning to `<= 4.1.0` like https://github.com/chef/chef-dk/pull/1406 until we can update related projects like `train`. This will fix the DK while we update the world and if we can contribute an upstream fix as the code should only warn, not break.

Signed-off-by: Seth Thomas <sthomas@chef.io>