### PR TITLE
Continue to support older net-ssh while fixing 4.2 deprecation

### DIFF
--- a/test-kitchen.gemspec
+++ b/test-kitchen.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "mixlib-shellout", ">= 1.2", "< 3.0"
   gem.add_dependency "net-scp",         "~> 1.1"
-  gem.add_dependency 'net-ssh', '>= 2.9', '< 5.0'
+  gem.add_dependency "net-ssh", ">= 2.9", "< 5.0"
   gem.add_dependency "net-ssh-gateway", "~> 1.2"
   gem.add_dependency "safe_yaml",       "~> 1.0"
   gem.add_dependency "thor",            "~> 0.19", "< 0.19.2"

--- a/test-kitchen.gemspec
+++ b/test-kitchen.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "mixlib-shellout", ">= 1.2", "< 3.0"
   gem.add_dependency "net-scp",         "~> 1.1"
-  gem.add_dependency "net-ssh",         "~> 4.2"
+  gem.add_dependency 'net-ssh', '>= 2.9', '< 5.0'
   gem.add_dependency "net-ssh-gateway", "~> 1.2"
   gem.add_dependency "safe_yaml",       "~> 1.0"
   gem.add_dependency "thor",            "~> 0.19", "< 0.19.2"


### PR DESCRIPTION
In #197, we bumped our dependency on net-ssh to ~> 4.2 to address a deprecation of the paranoid option made in net-ssh 4.2.0. Unfortunately, this is causing users of newer InSpec versions to not be able to use InSpec with Chef v12 due to net-ssh v3 in use in that version.

This change reverts the net-ssh pin to be looser and dynamically chooses the connection option to use depending on the version of net-ssh in use. This will avoid the deprecation warning and allow us to support newer net-ssh versions.

Code and note copied (nearly) verbatim from https://github.com/chef/train/pull/199

Signed-off-by: Seth Thomas <sthomas@chef.io>