### PR TITLE
Upgrades to the shell provisioner

### DIFF
--- a/lib/kitchen/provisioner/shell.rb
+++ b/lib/kitchen/provisioner/shell.rb
@@ -37,12 +37,9 @@ module Kitchen
       end
       expand_path_for :script
 
-      # Override for the initialization command.
-      default_config :init_command, nil
-      # Override for the converge command.
-      default_config :run_command, nil
-      # Special override to set run_command and disable init_command.
+      # Run a single command instead of managing and running a script.
       default_config :command, nil
+
       # Add extra arguments to the converge script.
       default_config :arguments, []
 
@@ -50,24 +47,6 @@ module Kitchen
         provisioner.calculate_path("data")
       end
       expand_path_for :data_path
-
-      # Process `command` config option, which is like setting `run_command`
-      # and disabling `init_command`.
-      #
-      # @api private
-      # @see Configurable#finalize_config!
-      def finalize_config!(instance)
-        super.tap do
-          if config[:command]
-            # Check that the user didn't set overlapping stuff.
-            if config[:run_command] || config[:init_command]
-              raise UserError, "Cannot set both `command` and `run_command` or `init_command` for the shell provisioner"
-            end
-            config[:run_command] = config[:command]
-            config[:init_command] = false
-          end
-        end
-      end
 
       # (see Base#create_sandbox)
       def create_sandbox
@@ -78,8 +57,7 @@ module Kitchen
 
       # (see Base#init_command)
       def init_command
-        return nil if config[:init_command] == false
-        return prefix_command(wrap_shell_code(config[:init_command])) if config[:init_command]
+        return nil if config[:command]
         root = config[:root_path]
         data = remote_path_join(root, "data")
 
@@ -101,8 +79,7 @@ module Kitchen
 
       # (see Base#run_command)
       def run_command
-        return nil if config[:run_command] == false
-        return prefix_command(wrap_shell_code(config[:run_command])) if config[:run_command]
+        return prefix_command(wrap_shell_code(config[:command])) if config[:command]
         return unless config[:script]
         script = remote_path_join(
           config[:root_path],

--- a/lib/kitchen/provisioner/shell.rb
+++ b/lib/kitchen/provisioner/shell.rb
@@ -16,6 +16,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "shellwords"
+
 require "kitchen/provisioner/base"
 require "kitchen/version"
 
@@ -35,6 +37,13 @@ module Kitchen
       end
       expand_path_for :script
 
+      # Override for the initialization command.
+      default_config :init_command, nil
+      # Override for the converge command.
+      default_config :run_command, nil
+      # Add extra arguments to the converge script.
+      default_config :arguments, []
+
       default_config :data_path do |provisioner|
         provisioner.calculate_path("data")
       end
@@ -49,6 +58,7 @@ module Kitchen
 
       # (see Base#init_command)
       def init_command
+        return prefix_command(wrap_shell_code(config[:init_command])) if config[:init_command]
         root = config[:root_path]
         data = remote_path_join(root, "data")
 
@@ -65,18 +75,24 @@ module Kitchen
                  "#{sudo('rm')} -rf #{data} ; mkdir -p #{root}"
                end
 
-        wrap_shell_code(code)
+        prefix_command(wrap_shell_code(code))
       end
 
       # (see Base#run_command)
       def run_command
+        return prefix_command(wrap_shell_code(config[:run_command])) if config[:run_command]
+        return unless config[:script]
         script = remote_path_join(
           config[:root_path],
           File.basename(config[:script])
         )
 
         if config[:arguments]
-          script.concat(" ").concat(config[:arguments])
+          if config[:arguments].is_a?(Array)
+            script = Shellwords.join([script] + config[:arguments])
+          else
+            script.concat(" ").concat(config[:arguments].to_s)
+          end
         end
 
         code = powershell_shell? ? %{& "#{script}"} : sudo(script)
@@ -111,30 +127,14 @@ module Kitchen
         if config[:script]
           debug("Using script from #{config[:script]}")
           FileUtils.cp_r(config[:script], sandbox_path)
+          FileUtils.chmod(0755,
+                          File.join(sandbox_path, File.basename(config[:script])))
         else
-          prepare_stubbed_script
+          info("No provisioner script file specified, skipping")
         end
 
-        FileUtils.chmod(0755,
-                        File.join(sandbox_path, File.basename(config[:script])))
       end
 
-      # Creates a minimal, no-op script in the sandbox path.
-      #
-      # @api private
-      def prepare_stubbed_script
-        base = powershell_shell? ? "bootstrap.ps1" : "bootstrap.sh"
-        config[:script] = File.join(sandbox_path, base)
-        info("#{File.basename(config[:script])} not found " \
-          "so Kitchen will run a stubbed script. Is this intended?")
-        File.open(config[:script], "wb") do |file|
-          if powershell_shell?
-            file.write(%{Write-Host "NO BOOTSTRAP SCRIPT PRESENT`n"\n})
-          else
-            file.write(%{#!/bin/sh\necho "NO BOOTSTRAP SCRIPT PRESENT"\n})
-          end
-        end
-      end
     end
   end
 end

--- a/lib/kitchen/provisioner/shell.rb
+++ b/lib/kitchen/provisioner/shell.rb
@@ -87,7 +87,7 @@ module Kitchen
           File.basename(config[:script])
         )
 
-        if config[:arguments]
+        if config[:arguments] && !config[:arguments].empty?
           if config[:arguments].is_a?(Array)
             script = Shellwords.join([script] + config[:arguments])
           else

--- a/lib/kitchen/provisioner/shell.rb
+++ b/lib/kitchen/provisioner/shell.rb
@@ -132,7 +132,6 @@ module Kitchen
         else
           info("No provisioner script file specified, skipping")
         end
-
       end
 
     end

--- a/spec/kitchen/provisioner/shell_spec.rb
+++ b/spec/kitchen/provisioner/shell_spec.rb
@@ -469,6 +469,10 @@ describe Kitchen::Provisioner::Shell do
       describe "with no :script file" do
         before { config[:script] = nil }
 
+        it "has no run command" do
+          provisioner.run_command.must_be_nil
+        end
+
         describe "for bourne shells" do
           before { platform.stubs(:shell_type).returns("bourne") }
 
@@ -482,20 +486,13 @@ describe Kitchen::Provisioner::Shell do
             provisioner.create_sandbox
 
             logged_output.string.must_match info_line(
-              "bootstrap.sh not found so Kitchen will run a stubbed script. " \
-              "Is this intended?")
+              "No provisioner script file specified, skipping")
           end
 
-          it "creates a file in the sandbox directory" do
+          it "does not create a file in the sandbox directory" do
             provisioner.create_sandbox
 
-            sandbox_path("bootstrap.sh").file?.must_equal true
-            unless running_tests_on_windows?
-              # Windows doesn't have the concept of executable
-              sandbox_path("bootstrap.sh").executable?.must_equal true
-            end
-            IO.read(sandbox_path("bootstrap.sh"))
-              .must_match(/NO BOOTSTRAP SCRIPT PRESENT/)
+            sandbox_path("bootstrap.sh").file?.must_equal false
           end
         end
 
@@ -512,20 +509,13 @@ describe Kitchen::Provisioner::Shell do
             provisioner.create_sandbox
 
             logged_output.string.must_match info_line(
-              "bootstrap.ps1 not found so Kitchen will run a stubbed script. " \
-              "Is this intended?")
+              "No provisioner script file specified, skipping")
           end
 
-          it "creates a file in the sandbox directory" do
+          it "does not create a file in the sandbox directory" do
             provisioner.create_sandbox
 
-            sandbox_path("bootstrap.ps1").file?.must_equal true
-            unless running_tests_on_windows?
-              # Windows doesn't have the concept of executable
-              sandbox_path("bootstrap.ps1").executable?.must_equal true
-            end
-            IO.read(sandbox_path("bootstrap.ps1"))
-              .must_match(/Write-Host "NO BOOTSTRAP SCRIPT PRESENT`n"/)
+            sandbox_path("bootstrap.ps1").file?.must_equal false
           end
         end
       end

--- a/spec/kitchen/provisioner/shell_spec.rb
+++ b/spec/kitchen/provisioner/shell_spec.rb
@@ -163,6 +163,25 @@ describe Kitchen::Provisioner::Shell do
 
         cmd.must_match regexify("mkdir -p /root/path", :partial_line)
       end
+
+      it "respects init_command" do
+        config[:init_command] = "createthingy.rb"
+
+        cmd.must_match regexify("createthingy.rb", :partial_line)
+        cmd.wont_include "mkdir"
+      end
+
+      it "is disabled when init_command is false" do
+        config[:init_command] = false
+
+        cmd.must_be_nil
+      end
+
+      it "respects command" do
+        config[:command] = "asdf"
+
+        cmd.must_be_nil
+      end
     end
 
     describe "for powershell shells on windows os types" do
@@ -318,6 +337,25 @@ describe Kitchen::Provisioner::Shell do
       it "accepts arguments when configured" do
         config[:arguments] = "--php 70 --mysql 57"
         cmd.must_match(/--php 70 --mysql 57/)
+      end
+
+      it "respects run_command" do
+        config[:run_command] = "dothingy.rb"
+
+        cmd.must_match regexify("dothingy.rb", :partial_line)
+        cmd.wont_include "bootstrap"
+      end
+
+      it "is disabled when run_command is false" do
+        config[:run_command] = false
+
+        cmd.must_be_nil
+      end
+
+      it "respects command" do
+        config[:command] = "dothingy.rb"
+
+        cmd.must_match regexify("dothingy.rb", :partial_line)
       end
     end
 

--- a/spec/kitchen/provisioner/shell_spec.rb
+++ b/spec/kitchen/provisioner/shell_spec.rb
@@ -164,19 +164,6 @@ describe Kitchen::Provisioner::Shell do
         cmd.must_match regexify("mkdir -p /root/path", :partial_line)
       end
 
-      it "respects init_command" do
-        config[:init_command] = "createthingy.rb"
-
-        cmd.must_match regexify("createthingy.rb", :partial_line)
-        cmd.wont_include "mkdir"
-      end
-
-      it "is disabled when init_command is false" do
-        config[:init_command] = false
-
-        cmd.must_be_nil
-      end
-
       it "respects command" do
         config[:command] = "asdf"
 
@@ -337,19 +324,6 @@ describe Kitchen::Provisioner::Shell do
       it "accepts arguments when configured" do
         config[:arguments] = "--php 70 --mysql 57"
         cmd.must_match(/--php 70 --mysql 57/)
-      end
-
-      it "respects run_command" do
-        config[:run_command] = "dothingy.rb"
-
-        cmd.must_match regexify("dothingy.rb", :partial_line)
-        cmd.wont_include "bootstrap"
-      end
-
-      it "is disabled when run_command is false" do
-        config[:run_command] = false
-
-        cmd.must_be_nil
       end
 
       it "respects command" do


### PR DESCRIPTION
Remove the concept of a default script from the shell provisioner, add support for array arguments, and add overrides for both commands if you want to manage things directly in the kitchen config.