### PR TITLE
Exec driver

### DIFF
--- a/lib/kitchen/configurable.rb
+++ b/lib/kitchen/configurable.rb
@@ -304,7 +304,7 @@ module Kitchen
     # @return [String] wrapped shell code
     # @api private
     def wrap_shell_code(code)
-      return env_wrapped code if powershell_shell?
+      return env_wrapped(code) if powershell_shell?
       Util.wrap_command((env_wrapped code))
     end
 

--- a/lib/kitchen/driver/base.rb
+++ b/lib/kitchen/driver/base.rb
@@ -81,7 +81,7 @@ module Kitchen
       # @param methods [Array<Symbol>] one or more actions as symbols
       # @raise [ClientError] if any method is not a valid action method name
       def self.no_parallel_for(*methods)
-        action_methods = [:create, :setup, :verify, :destroy]
+        action_methods = [:create, :setup, :converge, :verify, :destroy]
 
         Array(methods).each do |meth|
           next if action_methods.include?(meth)

--- a/lib/kitchen/driver/exec.rb
+++ b/lib/kitchen/driver/exec.rb
@@ -31,7 +31,9 @@ module Kitchen
 
       no_parallel_for :create, :converge, :destroy
 
-      # Hack to inject to Exec transport in too.
+      # Hack to force using the exec transport when using this driver.
+      # If someone comes up with a use case for using the driver with a different
+      # transport, please let us know.
       #
       # @api private
       def finalize_config!(instance)

--- a/lib/kitchen/driver/exec.rb
+++ b/lib/kitchen/driver/exec.rb
@@ -1,0 +1,64 @@
+# -*- encoding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "kitchen"
+require "kitchen/version"
+require "kitchen/transport/exec"
+
+module Kitchen
+  module Driver
+    # Simple driver that runs commands locally. As with the proxy driver, this
+    # has no isolation in general.
+    class Exec < Kitchen::Driver::Base
+      plugin_version Kitchen::VERSION
+
+      default_config :reset_command, nil
+
+      no_parallel_for :create, :destroy
+
+      def finalize_config!(instance)
+        super.tap do
+          instance.transport = Kitchen::Transport::Exec.new
+        end
+      end
+
+      # (see Base#create)
+      def create(state)
+        reset_instance(state)
+      end
+
+      # (see Base#destroy)
+      def destroy(state)
+        return if state[:hostname].nil?
+        reset_instance(state)
+        state.delete(:hostname)
+      end
+
+      private
+
+      # Resets the non-Kitchen managed instance using by issuing a command
+      # over SSH.
+      #
+      # @param state [Hash] the state hash
+      # @api private
+      def reset_instance(state)
+        if cmd = config[:reset_command]
+          info("Resetting instance state with command: #{cmd}")
+          ssh(build_ssh_args(state), cmd)
+        end
+      end
+    end
+  end
+end

--- a/lib/kitchen/instance.rb
+++ b/lib/kitchen/instance.rb
@@ -54,20 +54,20 @@ module Kitchen
 
     # @return [Driver::Base] driver object which will manage this instance's
     #   lifecycle actions
-    attr_reader :driver
+    attr_accessor :driver
 
     # @return [Provisioner::Base] provisioner object which will the setup
     #   and invocation instructions for configuration management and other
     #   automation tools
-    attr_reader :provisioner
+    attr_accessor :provisioner
 
     # @return [Transport::Base] transport object which will communicate with
     #   an instance.
-    attr_reader :transport
+    attr_accessor :transport
 
     # @return [Verifier] verifier object for instance to manage the verifier
     #   installation on this instance
-    attr_reader :verifier
+    attr_accessor :verifier
 
     # @return [Logger] the logger for this instance
     attr_reader :logger

--- a/lib/kitchen/transport/exec.rb
+++ b/lib/kitchen/transport/exec.rb
@@ -39,7 +39,8 @@ module Kitchen
 
         # (see Base#execute)
         def execute(command)
-          run_command(command) if command && command != ''
+          return if command.nil?
+          run_command(command)
         end
 
         # "Upload" the files by copying them locally.

--- a/lib/kitchen/transport/exec.rb
+++ b/lib/kitchen/transport/exec.rb
@@ -1,0 +1,58 @@
+# -*- encoding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "fileutils"
+
+require "kitchen/shell_out"
+require "kitchen/transport/base"
+require "kitchen/version"
+
+module Kitchen
+  module Transport
+    # Exec transport for Kitchen. This transport runs all commands locally.
+    #
+    # @since 1.19
+    class Exec < Kitchen::Transport::Base
+      kitchen_transport_api_version 1
+
+      plugin_version Kitchen::VERSION
+
+      def connection(state, &block)
+        options = config.to_hash.merge(state)
+        Kitchen::Transport::Exec::Connection.new(options, &block)
+      end
+
+      # Fake connection which just does local operations.
+      class Connection < Kitchen::Transport::Base::Connection
+        include ShellOut
+
+        # (see Base#execute)
+        def execute(command)
+          run_command(command) if command && command != ''
+        end
+
+        # "Upload" the files by copying them locally.
+        #
+        # @see Base#upload
+        def upload(locals, remote)
+          FileUtils.mkdir_p(remote)
+          Array(locals).each do |local|
+            FileUtils.cp_r(local, remote)
+          end
+        end
+
+      end
+    end
+  end
+end

--- a/spec/kitchen/driver/exec_spec.rb
+++ b/spec/kitchen/driver/exec_spec.rb
@@ -22,7 +22,7 @@ describe Kitchen::Driver::Exec do
   let(:state)         { Hash.new }
 
   let(:config) do
-    {reset_command: "mulligan"}
+    { reset_command: "mulligan" }
   end
 
   let(:instance) do
@@ -38,7 +38,7 @@ describe Kitchen::Driver::Exec do
   end
 
   it "sets the transport to exec" do
-    instance.expects(:"transport=").with {|v| v.is_a?(Kitchen::Transport::Exec) }
+    instance.expects(:"transport=").with { |v| v.is_a?(Kitchen::Transport::Exec) }
     driver
   end
 

--- a/spec/kitchen/driver/exec_spec.rb
+++ b/spec/kitchen/driver/exec_spec.rb
@@ -1,0 +1,75 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require_relative "../../spec_helper"
+
+require "kitchen/driver/exec"
+
+describe Kitchen::Driver::Exec do
+  let(:logged_output) { StringIO.new }
+  let(:logger)        { Logger.new(logged_output) }
+  let(:state)         { Hash.new }
+
+  let(:config) do
+    {reset_command: "mulligan"}
+  end
+
+  let(:instance) do
+    stub(name: "coolbeans", logger: logger, to_str: "instance", :"transport=" => nil)
+  end
+
+  let(:driver) do
+    Kitchen::Driver::Exec.new(config).finalize_config!(instance)
+  end
+
+  it "plugin_version is set to Kitchen::VERSION" do
+    driver.diagnose_plugin[:version].must_equal Kitchen::VERSION
+  end
+
+  it "sets the transport to exec" do
+    instance.expects(:"transport=").with {|v| v.is_a?(Kitchen::Transport::Exec) }
+    driver
+  end
+
+  describe "#create" do
+    it "runs the reset command" do
+      driver.expects(:run_command).with("mulligan")
+
+      driver.create(state)
+    end
+
+    it "skips the reset command if :reset_command is falsey" do
+      config[:reset_command] = false
+      driver.expects(:run_command).never
+
+      driver.create(state)
+    end
+  end
+
+  describe "#destroy" do
+    it "calls the reset command" do
+      driver.expects(:run_command).with("mulligan")
+
+      driver.destroy(state)
+    end
+
+    it "skips reset command if :reset_command is falsey" do
+      config[:reset_command] = false
+      driver.expects(:run_command).never
+
+      driver.destroy(state)
+    end
+  end
+
+end

--- a/spec/kitchen/transport/exec_spec.rb
+++ b/spec/kitchen/transport/exec_spec.rb
@@ -50,7 +50,7 @@ describe Kitchen::Transport::Exec::Connection do
   let(:logger)          { Logger.new(logged_output) }
 
   let(:options) do
-    {logger: logger}
+    { logger: logger }
   end
 
   let(:connection) do

--- a/spec/kitchen/transport/exec_spec.rb
+++ b/spec/kitchen/transport/exec_spec.rb
@@ -1,0 +1,79 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require_relative "../../spec_helper"
+
+require "kitchen/transport/exec"
+
+describe Kitchen::Transport::Ssh do
+  let(:logged_output) { StringIO.new }
+  let(:logger)        { Logger.new(logged_output) }
+  let(:config)        { Hash.new }
+  let(:state)         { Hash.new }
+
+  let(:instance) do
+    stub(name: "coolbeans", logger: logger, to_str: "instance")
+  end
+
+  let(:transport) do
+    Kitchen::Transport::Exec.new(config).finalize_config!(instance)
+  end
+
+  it "provisioner api_version is 1" do
+    transport.diagnose_plugin[:api_version].must_equal 1
+  end
+
+  it "plugin_version is set to Kitchen::VERSION" do
+    transport.diagnose_plugin[:version].must_equal Kitchen::VERSION
+  end
+
+  describe "#connection" do
+    it "returns a Kitchen::Transport::Exec::Connection object" do
+      transport.connection(state).must_be_kind_of Kitchen::Transport::Exec::Connection
+    end
+  end
+end
+
+describe Kitchen::Transport::Exec::Connection do
+  let(:logged_output)   { StringIO.new }
+  let(:logger)          { Logger.new(logged_output) }
+
+  let(:options) do
+    {logger: logger}
+  end
+
+  let(:connection) do
+    Kitchen::Transport::Exec::Connection.new(options)
+  end
+
+  describe "#execute" do
+    it "runs the command" do
+      connection.expects(:run_command).with("do the thing")
+      connection.execute("do the thing")
+    end
+
+    it "ignores nil" do
+      connection.expects(:run_command).never
+      connection.execute(nil)
+    end
+  end
+
+  describe "#upload" do
+    it "copies files" do
+      FileUtils.expects(:mkdir_p).with("/tmp/kitchen")
+      FileUtils.expects(:cp_r).with("/tmp/sandbox/cookbooks", "/tmp/kitchen")
+      connection.upload(%w{/tmp/sandbox/cookbooks}, "/tmp/kitchen")
+    end
+  end
+end


### PR DESCRIPTION
As discussed at the summit, a driver (and transport) for running everything locally.

Also we should probably use this pattern over in dokken too, for making the driver force the use of a specific transport (or other plugin). It's weird but it seems to work.