### PR TITLE
Add a --debug command line option

### DIFF
--- a/lib/kitchen/cli.rb
+++ b/lib/kitchen/cli.rb
@@ -180,6 +180,13 @@ module Kitchen
           [Future DEPRECATION, use --concurrency]
           Run a #{action} against all matching instances concurrently.
         DESC
+      if action == :converge || action == :verify
+        method_option :debug,
+                      aliases: "-D",
+                      type: :boolean,
+                      default: false,
+                      desc: "Run the #{action} with debugging enabled."
+      end
       test_base_path
       log_options
       define_method(action) do |*args|
@@ -226,6 +233,11 @@ module Kitchen
                   type: :boolean,
                   default: false,
                   desc: "Invoke init command if .kitchen.yml is missing"
+    method_option :debug,
+                  aliases: "-D",
+                  type: :boolean,
+                  default: false,
+                  desc: "Run the converge and verify with debugging enabled."
     test_base_path
     log_options
     def test(*args)
@@ -368,6 +380,8 @@ module Kitchen
         # ensure we have an absolute path
         @config.test_base_path = File.absolute_path(options[:test_base_path])
       end
+
+      @config.debug = options[:debug]
 
       # Now that we have required configs, lets create our file logger
       Kitchen.logger = Kitchen.default_file_logger(

--- a/lib/kitchen/config.rb
+++ b/lib/kitchen/config.rb
@@ -78,6 +78,10 @@ module Kitchen
     # @api private
     attr_accessor :colorize
 
+    # @return [Boolean] whether to enable debugging in the provisioner/verifier plugin or not
+    # @api private
+    attr_accessor :debug
+
     # Creates a new configuration, representing a particular testing
     # configuration for a project.
     #
@@ -104,6 +108,7 @@ module Kitchen
       @colorize       = options.fetch(:colorize) { Kitchen.tty? }
       @log_root       = options.fetch(:log_root) { default_log_root }
       @test_base_path = options.fetch(:test_base_path) { default_test_base_path }
+      @debug          = options.fetch(:debug) { false }
     end
 
     # @return [Collection<Instance>] all instances, resulting from all
@@ -214,6 +219,7 @@ module Kitchen
         test_base_path: test_base_path,
         log_level: log_level,
         log_overwrite: log_overwrite,
+        debug: debug,
       }
     end
 

--- a/lib/kitchen/data_munger.rb
+++ b/lib/kitchen/data_munger.rb
@@ -80,6 +80,7 @@ module Kitchen
       merged_data_for(:provisioner, suite, platform).tap do |pdata|
         set_kitchen_config_at!(pdata, :kitchen_root)
         set_kitchen_config_at!(pdata, :test_base_path)
+        set_kitchen_config_at!(pdata, :debug)
         combine_arrays!(pdata, :run_list, :platform, :suite)
       end
     end
@@ -118,6 +119,7 @@ module Kitchen
         set_kitchen_config_at!(vdata, :kitchen_root)
         set_kitchen_config_at!(vdata, :test_base_path)
         set_kitchen_config_at!(vdata, :log_level)
+        set_kitchen_config_at!(vdata, :debug)
       end
     end
 

--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -49,7 +49,9 @@ module Kitchen
       default_config :attributes, {}
       default_config :config_path, nil
       default_config :log_file, nil
-      default_config :log_level, "auto"
+      default_config :log_level do |provisioner|
+        provisioner[:debug] ? "debug" : "auto"
+      end
       default_config :profile_ruby, false
       # The older policyfile_zero used `policyfile` so support it for compat.
       default_config :policyfile, nil

--- a/spec/kitchen/config_spec.rb
+++ b/spec/kitchen/config_spec.rb
@@ -63,6 +63,7 @@ describe Kitchen::Config do
       log_level: :debug,
       log_overwrite: false,
       colorize: false,
+      debug: true,
     }
   end
 
@@ -165,6 +166,19 @@ describe Kitchen::Config do
       config.colorize.must_equal true
     end
   end
+
+  describe "#debug" do
+    it "returns its debug" do
+      config.debug.must_equal true
+    end
+
+    it "uses false by default" do
+      opts.delete(:debug)
+
+      config.debug.must_equal false
+    end
+  end
+
 
   describe "#platforms" do
     before do

--- a/spec/kitchen/config_spec.rb
+++ b/spec/kitchen/config_spec.rb
@@ -179,7 +179,6 @@ describe Kitchen::Config do
     end
   end
 
-
   describe "#platforms" do
     before do
       Kitchen::DataMunger.stubs(:new).returns(munger)

--- a/spec/kitchen/provisioner/chef_base_spec.rb
+++ b/spec/kitchen/provisioner/chef_base_spec.rb
@@ -90,6 +90,15 @@ describe Kitchen::Provisioner::ChefBase do
       provisioner[:attributes].must_equal Hash.new
     end
 
+    it ":log_level defaults to auto" do
+      provisioner[:log_level].must_equal "auto"
+    end
+
+    it ":log_level is debug when in debug mode" do
+      config[:debug] = true
+      provisioner[:log_level].must_equal "debug"
+    end
+
     it ":log_file defaults to nil" do
       provisioner[:log_file].must_be_nil
     end


### PR DESCRIPTION
This option works with the `converge`, `verify`, and `test` command and enables plugin-specific debugging behavior. I've added support in the Chef provisioners to change the log level of Chef to debug.

The goal is here to make it Very Easy™ to get debugging data when iterating with Test Kitchen. Like `kitchen converge -D`, rather than having to edit the `.kitchen.yml` each time or use fancy Erb tricks.