### PR TITLE
install after init and transfer

### DIFF
--- a/lib/kitchen/provisioner/base.rb
+++ b/lib/kitchen/provisioner/base.rb
@@ -66,11 +66,11 @@ module Kitchen
         sandbox_dirs = Util.list_directory(sandbox_path)
 
         instance.transport.connection(state) do |conn|
-          conn.execute(install_command)
           conn.execute(init_command)
           info("Transferring files to #{instance.to_str}")
           conn.upload(sandbox_dirs, config[:root_path])
           debug("Transfer complete")
+          conn.execute(install_command)
           conn.execute(prepare_command)
           conn.execute_with_retry(
             run_command,

--- a/spec/kitchen/provisioner/base_spec.rb
+++ b/spec/kitchen/provisioner/base_spec.rb
@@ -183,8 +183,8 @@ describe Kitchen::Provisioner::Base do
 
     it "invokes the provisioner commands over the transport" do
       order = sequence("order")
-      connection.expects(:execute).with("install").in_sequence(order)
       connection.expects(:execute).with("init").in_sequence(order)
+      connection.expects(:execute).with("install").in_sequence(order)
       connection.expects(:execute).with("prepare").in_sequence(order)
       connection.expects(:execute_with_retry).with("run", [], 1, 30).in_sequence(order)
 


### PR DESCRIPTION
This allows for adding an artifact to the sandbox, and then having it
uploaded when the sandbox is transferred.  That artifact can then be
used with the installation method.

Used here https://github.com/saltstack/kitchen-salt/pull/164/commits/d9048deba6822d64687a06ac55b53e7aa9e6c151

Thanks,
Daniel