### PR TITLE
Basic framework for kitchen doctor

### DIFF
--- a/lib/kitchen/cli.rb
+++ b/lib/kitchen/cli.rb
@@ -248,6 +248,16 @@ module Kitchen
       perform("package", "package", args)
     end
 
+    desc "doctor INSTANCE|REGEXP", "Check for common system problems"
+    log_options
+    method_option :all,
+                  aliases: "-a",
+                  desc: "Check all instances"
+    def doctor(*args)
+      update_config!
+      perform("doctor", "doctor", args)
+    end
+
     desc "exec INSTANCE|REGEXP -c REMOTE_COMMAND",
          "Execute command on one or more instance"
     method_option :command,

--- a/lib/kitchen/command/doctor.rb
+++ b/lib/kitchen/command/doctor.rb
@@ -1,0 +1,39 @@
+# -*- encoding: utf-8 -*-
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "kitchen/command"
+
+module Kitchen
+  module Command
+    # Check for common system or configuration problems.
+    #
+    class Doctor < Kitchen::Command::Base
+      # Invoke the command.
+      def call
+        results = parse_subcommand(args.first)
+        if results.empty?
+          error("No instances configured, cannot check configuration. Please check your .kitchen.yml and confirm it has platform and suites sections.")
+          exit(1)
+        end
+        # By default only doctor the first instance to avoid output spam.
+        results = [results.first] unless options[:all]
+        results.each do |instance|
+          debug "Doctor on #{instance.name}."
+          instance.doctor_action
+        end
+      end
+    end
+  end
+end

--- a/lib/kitchen/command/doctor.rb
+++ b/lib/kitchen/command/doctor.rb
@@ -29,10 +29,11 @@ module Kitchen
         end
         # By default only doctor the first instance to avoid output spam.
         results = [results.first] unless options[:all]
-        results.each do |instance|
+        failed = results.any? do |instance|
           debug "Doctor on #{instance.name}."
           instance.doctor_action
         end
+        exit(1) if failed
       end
     end
   end

--- a/lib/kitchen/driver/base.rb
+++ b/lib/kitchen/driver/base.rb
@@ -56,6 +56,14 @@ module Kitchen
       def package(state) # rubocop:disable Lint/UnusedMethodArgument
       end
 
+      # Check system and configuration for common errors.
+      #
+      # @param state [Hash] mutable instance and driver state
+      # @returns [Boolean] Return true if a problem is found.
+      def doctor(state)
+        false
+      end
+
       class << self
         # @return [Array<Symbol>] an array of action method names that cannot
         #   be run concurrently and must be run in serial via a shared mutex

--- a/lib/kitchen/instance.rb
+++ b/lib/kitchen/instance.rb
@@ -237,10 +237,9 @@ module Kitchen
     #
     def doctor_action
       banner "The doctor is in"
-      failed = [driver, provisioner, transport, verifier].any? do |obj|
+      [driver, provisioner, transport, verifier].any? do |obj|
         obj.doctor(state_file.read)
       end
-      exit(1) if failed
     end
 
     # Returns a Hash of configuration and other useful diagnostic information.

--- a/lib/kitchen/instance.rb
+++ b/lib/kitchen/instance.rb
@@ -233,6 +233,16 @@ module Kitchen
       driver.package(state_file.read)
     end
 
+    # Check system and configuration for common errors.
+    #
+    def doctor_action
+      banner "The doctor is in"
+      failed = [driver, provisioner, transport, verifier].any? do |obj|
+        obj.doctor(state_file.read)
+      end
+      exit(1) if failed
+    end
+
     # Returns a Hash of configuration and other useful diagnostic information.
     #
     # @return [Hash] a diagnostic hash

--- a/lib/kitchen/provisioner/base.rb
+++ b/lib/kitchen/provisioner/base.rb
@@ -85,6 +85,14 @@ module Kitchen
         cleanup_sandbox
       end
 
+      # Check system and configuration for common errors.
+      #
+      # @param state [Hash] mutable instance state
+      # @returns [Boolean] Return true if a problem is found.
+      def doctor(state)
+        false
+      end
+
       # Generates a command string which will install and configure the
       # provisioner software on an instance. If no work is required, then `nil`
       # will be returned.

--- a/lib/kitchen/transport/base.rb
+++ b/lib/kitchen/transport/base.rb
@@ -64,6 +64,14 @@ module Kitchen
         raise ClientError, "#{self.class}#connection must be implemented"
       end
 
+      # Check system and configuration for common errors.
+      #
+      # @param state [Hash] mutable instance state
+      # @returns [Boolean] Return true if a problem is found.
+      def doctor(state)
+        false
+      end
+
       # Closes the connection, if it is still active.
       #
       # @return [void]

--- a/lib/kitchen/verifier/base.rb
+++ b/lib/kitchen/verifier/base.rb
@@ -82,6 +82,14 @@ module Kitchen
         cleanup_sandbox
       end
 
+      # Check system and configuration for common errors.
+      #
+      # @param state [Hash] mutable instance state
+      # @returns [Boolean] Return true if a problem is found.
+      def doctor(state)
+        false
+      end
+
       # Deletes the sandbox path. Without calling this method, the sandbox path
       # will persist after the process terminates. In other words, cleanup is
       # explicit. This method is safe to call multiple times.


### PR DESCRIPTION
Not sure if there is much to do in the core plugins, maybe some config debugging for common issues with the Chef provisioners? I can't really think of any, but once we start the `require_chef_omnibus` migration, we could throw in something for that.

Major use cases are in places like kitchen-vagrant for checking versions of vbox/vagrant and kitchen-docker/dokken for checking that docker is working.