### PR TITLE
Configuration Deprecation warnings

### DIFF
--- a/lib/kitchen/lazy_hash.rb
+++ b/lib/kitchen/lazy_hash.rb
@@ -124,6 +124,14 @@ module Kitchen
       to_hash.each(&block)
     end
 
+    # Returns a new Hash after deleting the key-value pairs for which the block
+    # returns true.
+    #
+    # @return [Hash] a new hash
+    def delete_if(&block)
+      to_hash.delete_if(&block)
+    end
+
     private
 
     # Returns an object or invokes call with context if object is callable.

--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -133,6 +133,27 @@ module Kitchen
 
       default_config :checksum
 
+      # Deprecate config attributes
+      deprecate_config_for :require_chef_omnibus, Util.outdent!(<<-MSG)
+        Message here!
+      MSG
+
+      deprecate_config_for :chef_omnibus_url, Util.outdent!(<<-MSG)
+        Message here!
+      MSG
+
+      deprecate_config_for :chef_omnibus_install_options, Util.outdent!(<<-MSG)
+        Message here!
+      MSG
+
+      deprecate_config_for :install_msi_url, Util.outdent!(<<-MSG)
+        Message here!
+      MSG
+
+      deprecate_config_for :chef_metadata_url, Util.outdent!(<<-MSG)
+        Message here!
+      MSG
+
       # Reads the local Chef::Config object (if present).  We do this because
       # we want to start bring Chef config and ChefDK tool config closer
       # together.  For example, we want to configure proxy settings in 1

--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -468,7 +468,6 @@ module Kitchen
             opts[:install_command_options][:checksum] = config[:checksum] if config[:checksum]
           end
 
-          # TODO Validate! Discovered when deprecating chef_omnibus_install_options
           if instance.driver.cache_directory
             download_dir_option = windows_os? ? :download_directory : :cmdline_dl_dir
             opts[:install_command_options][download_dir_option] = instance.driver.cache_directory

--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -139,38 +139,41 @@ module Kitchen
           Util.outdent!(<<-MSG)
             The 'require_chef_omnibus' attribute with value of 'false' will
             change to use the new 'install_strategy' attribute with a value of 'skip'.
-            'product_name' must be set in order to use 'install_strategy'.
+
+            Note: 'product_name' must be set in order to use 'install_strategy'.
             Although this seems counterintuitive, it is necessary until
             'product_name' replaces 'require_chef_omnibus' as the default.
 
-              # New Usage #
-              provisioner:
-                product_name: <chef or chefdk>
-                install_strategy: skip
+            # New Usage #
+            provisioner:
+              product_name: <chef or chefdk>
+              install_strategy: skip
           MSG
         when provisioner[:require_chef_omnibus].to_s.match(/\d/)
           Util.outdent!(<<-MSG)
             The 'require_chef_omnibus' attribute with version values will change
             to use the new 'product_version' attribute.
-            'product_name' must be set in order to use 'product_version'
+
+            Note: 'product_name' must be set in order to use 'product_version'
             until 'product_name' replaces 'require_chef_omnibus' as the default.
 
-              # New Usage #
-              provisioner:
-                product_name: <chef or chefdk>
-                product_version: #{provisioner[:require_chef_omnibus]}
+            # New Usage #
+            provisioner:
+              product_name: <chef or chefdk>
+              product_version: #{provisioner[:require_chef_omnibus]}
           MSG
         when provisioner[:require_chef_omnibus] == "latest"
           Util.outdent!(<<-MSG)
             The 'require_chef_omnibus' attribute with value of 'latest' will change
             to use the new 'install_strategy' attribute with a value of 'always'.
-            'product_name' must be set in order to use 'install_strategy'
+
+            Note: 'product_name' must be set in order to use 'install_strategy'
             until 'product_name' replaces 'require_chef_omnibus' as the default.
 
-              # New Usage #
-              provisioner:
-                product_name: <chef or chefdk>
-                install_strategy: always
+            # New Usage #
+            provisioner:
+              product_name: <chef or chefdk>
+              install_strategy: always
           MSG
         end
       end
@@ -180,11 +183,40 @@ module Kitchen
         be removed in a future version.
       MSG
 
-      deprecate_config_for :chef_omnibus_install_options, "chef_omnibus_install_options doc message"
+      deprecate_config_for :chef_omnibus_install_options, Util.outdent!(<<-MSG)
+        The 'chef_omnibus_install_options' attribute will be replaced by using
+        'product_name' and 'channel' attributes.
 
-      deprecate_config_for :install_msi_url, "install_msi_urldoc message"
+        Note: 'product_name' must be set in order to use 'channel'
+        until 'product_name' replaces 'require_chef_omnibus' as the default.
 
-      deprecate_config_for :chef_metadata_url, "chef_metadata_url doc message"
+        # Deprecated Example #
+        provisioner:
+          chef_omnibus_install_options: -P chefdk -c current
+
+        # New Usage #
+        provisioner:
+          product_name: chefdk
+          channel: current
+      MSG
+
+      deprecate_config_for :install_msi_url, Util.outdent!(<<-MSG)
+        The 'install_msi_url' will be relaced by the 'download_url' attribute.
+        'download_url' will be applied to Bourne and Powershell download scripts.
+
+        Note: 'product_name' must be set in order to use 'download_url'
+        until 'product_name' replaces 'require_chef_omnibus' as the default.
+
+        # New Usage #
+        provisioner:
+          product_name: <chef or chefdk>
+          download_url: http://direct-download-url
+      MSG
+
+      deprecate_config_for :chef_metadata_url, Util.outdent!(<<-MSG)
+        The 'chef_metadata_url' will be removed. The Windows metadata URL will be
+        fully managed by using attribute settings.
+      MSG
 
       # Reads the local Chef::Config object (if present).  We do this because
       # we want to start bring Chef config and ChefDK tool config closer
@@ -434,6 +466,12 @@ module Kitchen
           if config[:download_url]
             opts[:install_command_options][:download_url_override] = config[:download_url]
             opts[:install_command_options][:checksum] = config[:checksum] if config[:checksum]
+          end
+
+          # TODO Validate! Discovered when deprecating chef_omnibus_install_options
+          if instance.driver.cache_directory
+            download_dir_option = windows_os? ? :download_directory : :cmdline_dl_dir
+            opts[:install_command_options][download_dir_option] = instance.driver.cache_directory
           end
 
           proxies = {}.tap do |prox|

--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -134,25 +134,45 @@ module Kitchen
       default_config :checksum
 
       # Deprecate config attributes
-      deprecate_config_for :require_chef_omnibus, Util.outdent!(<<-MSG)
-        Message here!
-      MSG
+      deprecate_config_for :require_chef_omnibus do |provisioner|
+        if provisioner[:require_chef_omnibus] != defaults[:require_chef_omnibus]
+          Util.outdent!(<<-MSG)
+            doctor message here
+          MSG
+        end
+      end
 
-      deprecate_config_for :chef_omnibus_url, Util.outdent!(<<-MSG)
-        Message here!
-      MSG
+      deprecate_config_for :chef_omnibus_url do |provisioner|
+        if provisioner[:chef_omnibus_url] != defaults[:chef_omnibus_url]
+          Util.outdent!(<<-MSG)
+            doctor message here
+          MSG
+        end
+      end
 
-      deprecate_config_for :chef_omnibus_install_options, Util.outdent!(<<-MSG)
-        Message here!
-      MSG
+      deprecate_config_for :chef_omnibus_install_options do |provisioner|
+        if provisioner[:chef_omnibus_install_options]
+          Util.outdent!(<<-MSG)
+            doctor message here
+          MSG
+        end
+      end
 
-      deprecate_config_for :install_msi_url, Util.outdent!(<<-MSG)
-        Message here!
-      MSG
+      deprecate_config_for :install_msi_url do |provisioner|
+        if provisioner[:install_msi_url]
+          Util.outdent!(<<-MSG)
+            doctor message here
+          MSG
+        end
+      end
 
-      deprecate_config_for :chef_metadata_url, Util.outdent!(<<-MSG)
-        Message here!
-      MSG
+      deprecate_config_for :chef_metadata_url do |provisioner|
+        if provisioner[:chef_metadata_url]
+          Util.outdent!(<<-MSG)
+            doctor message here
+          MSG
+        end
+      end
 
       # Reads the local Chef::Config object (if present).  We do this because
       # we want to start bring Chef config and ChefDK tool config closer

--- a/spec/kitchen/provisioner/chef_base_spec.rb
+++ b/spec/kitchen/provisioner/chef_base_spec.rb
@@ -515,6 +515,34 @@ describe Kitchen::Provisioner::ChefBase do
         end.returns(installer)
         cmd
       end
+
+      describe "when driver implements the cache_directory" do
+
+        describe "for windows" do
+          before { driver.stubs(:cache_directory).returns('$env:TEMP\\dummy\\place') }
+
+          it "will have the set behavior on windows" do
+            platform.stubs(:shell_type).returns("powershell")
+            platform.stubs(:os_type).returns("windows")
+
+            Mixlib::Install.expects(:new).with do |opts|
+              opts[:install_command_options][:download_directory].must_equal '$env:TEMP\\dummy\\place'
+            end.returns(installer)
+            cmd
+          end
+        end
+
+        describe "for shell" do
+          before { driver.stubs(:cache_directory).returns("/tmp") }
+
+          it "will have the set behavior on non-windows" do
+            Mixlib::Install.expects(:new).with do |opts|
+              opts[:install_command_options][:cmdline_dl_dir].must_equal "/tmp"
+            end.returns(installer)
+            cmd
+          end
+        end
+      end
     end
 
     describe "when install_strategy is skipped" do


### PR DESCRIPTION
This PR is intended to lead a discussion for how to warn users of the upcoming deprecated options (part of [RFC-091](https://github.com/chef/chef-rfc/blob/master/rfc091-deprecate-kitchen-settings.md)). 

This approach is piggy-backing off of the new `kitchen doctor` command.  The change only includes the initial warning for detected deprecation attributes. 
