### PR TITLE
adding download support to the base transport and provisioner

### DIFF
--- a/lib/kitchen/driver/ssh_base.rb
+++ b/lib/kitchen/driver/ssh_base.rb
@@ -80,6 +80,12 @@ module Kitchen
           debug("Transfer complete")
           conn.execute(env_cmd(provisioner.prepare_command))
           conn.execute(env_cmd(provisioner.run_command))
+          info("Downloading files from #{instance.to_str}")
+          provisioner[:downloads].to_h.each do |remotes, local|
+            debug("Downloading #{Array(remotes).join(', ')} to #{local}")
+            conn.download(remotes, local)
+          end
+          debug("Download complete")
         end
       rescue Kitchen::Transport::TransportFailed => ex
         raise ActionFailed, ex.message

--- a/lib/kitchen/provisioner/base.rb
+++ b/lib/kitchen/provisioner/base.rb
@@ -47,6 +47,8 @@ module Kitchen
 
       default_config :command_prefix, nil
 
+      default_config :downloads, {}
+
       expand_path_for :test_base_path
 
       # Constructs a new provisioner by providing a configuration hash.

--- a/lib/kitchen/provisioner/base.rb
+++ b/lib/kitchen/provisioner/base.rb
@@ -78,6 +78,12 @@ module Kitchen
             config[:max_retries],
             config[:wait_for_retry]
           )
+          info("Downloading files from #{instance.to_str}")
+          config[:downloads].to_h.each do |remotes, local|
+            debug("Downloading #{Array(remotes).join(', ')} to #{local}")
+            conn.download(remotes, local)
+          end
+          debug("Download complete")
         end
       rescue Kitchen::Transport::TransportFailed => ex
         raise ActionFailed, ex.message

--- a/lib/kitchen/transport/base.rb
+++ b/lib/kitchen/transport/base.rb
@@ -166,7 +166,9 @@ module Kitchen
         # Download remote files or directories to local host.
         #
         # @param remotes [Array<String>] paths to remote files or directories
-        # @param local [String] path to local destination
+        # @param local [String] path to local destination. If `local` is an
+        #   existing directory, `remote` will be downloaded into the directory
+        #   using its original name
         # @raise [TransportFailed] if the files could not all be downloaded
         #   successfully, which may vary by implementation
         def download(remotes, local) # rubocop:disable Lint/UnusedMethodArgument

--- a/lib/kitchen/transport/base.rb
+++ b/lib/kitchen/transport/base.rb
@@ -163,6 +163,16 @@ module Kitchen
           raise ClientError, "#{self.class}#upload must be implemented"
         end
 
+        # Download remote files or directories to local host.
+        #
+        # @param remotes [Array<String>] paths to remote files or directories
+        # @param local [String] path to local destination
+        # @raise [TransportFailed] if the files could not all be downloaded
+        #   successfully, which may vary by implementation
+        def download(remotes, local) # rubocop:disable Lint/UnusedMethodArgument
+          raise ClientError, "#{self.class}#download must be implemented"
+        end
+
         # Block and return only when the remote host is prepared and ready to
         # execute command and upload files. The semantics and details will
         # vary by implementation, but a round trip through the hosted

--- a/lib/kitchen/transport/dummy.rb
+++ b/lib/kitchen/transport/dummy.rb
@@ -51,6 +51,10 @@ module Kitchen
           report(:upload, "#{locals.inspect} => #{remote}")
         end
 
+        def download(remotes, local)
+          report(:download, "#{remotes.inspect} => #{local}")
+        end
+
         private
 
         # Report what action is taking place, sleeping if so configured, and

--- a/lib/kitchen/transport/ssh.rb
+++ b/lib/kitchen/transport/ssh.rb
@@ -184,7 +184,9 @@ module Kitchen
 
         # (see Base::Connection#download)
         def download(remotes, local)
-          FileUtils.mkdir_p(local)
+          # ensure the parent dir of the local target exists
+          FileUtils.mkdir_p(File.dirname(local))
+
           Array(remotes).each do |file|
             begin
               logger.debug("Attempting to download '#{file}' as file")

--- a/lib/kitchen/transport/winrm.rb
+++ b/lib/kitchen/transport/winrm.rb
@@ -139,11 +139,18 @@ module Kitchen
 
         # (see Base::Connection#download)
         def download(remotes, local)
-          # This looks possible with WinRM::FS::FileManager
-          raise(
-            NotImplementedError,
-            "Downloading files from instance not yet implemented for Windows remotes"
-          )
+          # ensure the parent dir of the local target exists
+          FileUtils.mkdir_p(File.dirname(local))
+
+          Array(remotes).each do |remote|
+            file_manager.download(remote, local)
+          end
+        end
+
+        # @return [Winrm::FileManager] a file transporter
+        # @api private
+        def file_manager
+          @file_manager ||= WinRM::FS::FileManager.new(session)
         end
 
         # (see Base::Connection#wait_until_ready)

--- a/lib/kitchen/transport/winrm.rb
+++ b/lib/kitchen/transport/winrm.rb
@@ -137,6 +137,15 @@ module Kitchen
           file_transporter.upload(locals, remote)
         end
 
+        # (see Base::Connection#download)
+        def download(remotes, local)
+          # This looks possible with WinRM::FS::FileManager
+          raise(
+            NotImplementedError,
+            'Downloading files from instance not yet implemented for Windows remotes'
+          )
+        end
+
         # (see Base::Connection#wait_until_ready)
         def wait_until_ready
           delay = 3

--- a/lib/kitchen/transport/winrm.rb
+++ b/lib/kitchen/transport/winrm.rb
@@ -142,7 +142,7 @@ module Kitchen
           # This looks possible with WinRM::FS::FileManager
           raise(
             NotImplementedError,
-            'Downloading files from instance not yet implemented for Windows remotes'
+            "Downloading files from instance not yet implemented for Windows remotes"
           )
         end
 

--- a/spec/kitchen/driver/ssh_base_spec.rb
+++ b/spec/kitchen/driver/ssh_base_spec.rb
@@ -277,8 +277,8 @@ describe Kitchen::Driver::SSHBase do
       state[:username] = "bork"
       provisioner.stubs(:[]).with(:root_path).returns("/rooty")
       provisioner.stubs(:[]).with(:downloads).returns(
-        ['/tmp/kitchen/nodes', '/tmp/kitchen/data_bags'] => './test/fixtures',
-        '/remote' => '/local'
+        ["/tmp/kitchen/nodes", "/tmp/kitchen/data_bags"] => "./test/fixtures",
+        "/remote" => "/local"
       )
       FakeFS.activate!
       FileUtils.mkdir_p("/tmp")
@@ -483,10 +483,10 @@ describe Kitchen::Driver::SSHBase do
 
       it "downloads files" do
         connection.expects(:download).with(
-          ['/tmp/kitchen/nodes', '/tmp/kitchen/data_bags'],
-          './test/fixtures'
+          ["/tmp/kitchen/nodes", "/tmp/kitchen/data_bags"],
+          "./test/fixtures"
         )
-        connection.expects(:download).with('/remote', '/local')
+        connection.expects(:download).with("/remote", "/local")
 
         cmd
       end

--- a/spec/kitchen/driver/ssh_base_spec.rb
+++ b/spec/kitchen/driver/ssh_base_spec.rb
@@ -270,7 +270,7 @@ describe Kitchen::Driver::SSHBase do
 
   describe "#converge" do
     let(:cmd)         { driver.converge(state) }
-    let(:connection)  { stub(execute: true, upload: true) }
+    let(:connection)  { stub(execute: true, upload: true, download: true) }
 
     before do
       state[:hostname] = "fizzy"
@@ -468,6 +468,20 @@ describe Kitchen::Driver::SSHBase do
         connection.stubs(:upload).raises(Kitchen::Transport::SshFailed.new("dang"))
 
         proc { cmd }.must_raise Kitchen::ActionFailed
+      end
+    end
+
+    describe "downloading files" do
+      before do
+        transport.stubs(:connection).yields(connection)
+        connection.stubs(:upload)
+        # create file in sandbox on remote host
+      end
+
+      it "uploads files" do
+        connection.expects(:download).with(["/tmp/sandbox/stuff"], "/rooty")
+
+        cmd
       end
     end
 

--- a/spec/kitchen/provisioner/base_spec.rb
+++ b/spec/kitchen/provisioner/base_spec.rb
@@ -216,14 +216,10 @@ describe Kitchen::Provisioner::Base do
 
       logged_output.string.must_match(/DEBUG -- : Transfer complete$/)
       logged_output.string.must_match(
-        %r{
-          /DEBUG -- : Downloading /tmp/kitchen/nodes, /tmp/kitchen/data_bags to ./test/fixtures$
-        }
+        %r{DEBUG -- : Downloading /tmp/kitchen/nodes, /tmp/kitchen/data_bags to ./test/fixtures$}
       )
       logged_output.string.must_match(
-        %r{
-          /DEBUG -- : Downloading /remote to /local$
-        }
+        %r{DEBUG -- : Downloading /remote to /local$}
       )
       logged_output.string.must_match(/DEBUG -- : Download complete$/)
     end

--- a/spec/kitchen/provisioner/base_spec.rb
+++ b/spec/kitchen/provisioner/base_spec.rb
@@ -151,6 +151,11 @@ describe Kitchen::Provisioner::Base do
       connection.stubs(:execute)
       connection.stubs(:execute_with_retry)
       connection.stubs(:upload)
+      connection.stubs(:download)
+      config[:downloads] = {
+        ['/tmp/kitchen/nodes', '/tmp/kitchen/data_bags'] => './test/fixtures',
+        '/remote' => '/local'
+      }
     end
 
     after do
@@ -196,6 +201,8 @@ describe Kitchen::Provisioner::Base do
 
       logged_output.string
                    .must_match(/INFO -- : Transferring files to instance$/)
+      logged_output.string
+                   .must_match(/INFO -- : Downloading files from instance$/)
     end
 
     it "uploads sandbox files" do
@@ -208,6 +215,28 @@ describe Kitchen::Provisioner::Base do
       cmd
 
       logged_output.string.must_match(/DEBUG -- : Transfer complete$/)
+      logged_output.string.must_match(
+        %r{
+          /DEBUG -- : Downloading /tmp/kitchen/nodes, /tmp/kitchen/data_bags to ./test/fixtures$
+        }
+      )
+      logged_output.string.must_match(
+        %r{
+          /DEBUG -- : Downloading /remote to /local$
+        }
+      )
+      logged_output.string.must_match(/DEBUG -- : Download complete$/)
+    end
+
+    it "downloads files" do
+      connection.expects(:download).with(
+        ['/tmp/kitchen/nodes', '/tmp/kitchen/data_bags'],
+        './test/fixtures'
+      )
+
+      connection.expects(:download).with('/remote', '/local')
+
+      cmd
     end
 
     it "raises an ActionFailed on transfer when TransportFailed is raised" do

--- a/spec/kitchen/provisioner/base_spec.rb
+++ b/spec/kitchen/provisioner/base_spec.rb
@@ -153,8 +153,8 @@ describe Kitchen::Provisioner::Base do
       connection.stubs(:upload)
       connection.stubs(:download)
       config[:downloads] = {
-        ['/tmp/kitchen/nodes', '/tmp/kitchen/data_bags'] => './test/fixtures',
-        '/remote' => '/local'
+        ["/tmp/kitchen/nodes", "/tmp/kitchen/data_bags"] => "./test/fixtures",
+        "/remote" => "/local",
       }
     end
 
@@ -226,11 +226,11 @@ describe Kitchen::Provisioner::Base do
 
     it "downloads files" do
       connection.expects(:download).with(
-        ['/tmp/kitchen/nodes', '/tmp/kitchen/data_bags'],
-        './test/fixtures'
+        ["/tmp/kitchen/nodes", "/tmp/kitchen/data_bags"],
+        "./test/fixtures"
       )
 
-      connection.expects(:download).with('/remote', '/local')
+      connection.expects(:download).with("/remote", "/local")
 
       cmd
     end

--- a/spec/kitchen/transport/base_spec.rb
+++ b/spec/kitchen/transport/base_spec.rb
@@ -97,6 +97,11 @@ describe Kitchen::Transport::Base::Connection do
       .must_raise Kitchen::ClientError
   end
 
+  it "has an #download method which raises a ClientError" do
+    proc { connection.download(["remote"], "local") }
+      .must_raise Kitchen::ClientError
+  end
+
   it "has a #wait_until_ready method that does nothing" do
     connection.wait_until_ready.must_be_nil
   end

--- a/spec/kitchen/transport/ssh_spec.rb
+++ b/spec/kitchen/transport/ssh_spec.rb
@@ -1099,7 +1099,7 @@ describe Kitchen::Transport::Ssh::Connection do
     before do
       Net::SSH.stubs(:start).returns(conn)
       conn.stubs(:scp).returns(scp)
-      @local_parent = Dir.mktmpdir('dir')
+      @local_parent = Dir.mktmpdir("dir")
       @local = File.join(@local_parent, "local")
     end
 
@@ -1110,40 +1110,40 @@ describe Kitchen::Transport::Ssh::Connection do
     describe "for a file" do
       it "downloads a file from a remote over scp" do
         FileUtils.expects(:mkdir_p).with(@local_parent)
-        scp.expects(:download!).with('/remote', @local)
+        scp.expects(:download!).with("/remote", @local)
 
-        connection.download('/remote', @local)
+        connection.download("/remote", @local)
       end
     end
 
     describe "for a list of files" do
       it "downloads the files from a remote over scp" do
         FileUtils.expects(:mkdir_p).with(@local_parent)
-        scp.expects(:download!).with('/remote-1', @local)
-        scp.expects(:download!).with('/remote-2', @local)
+        scp.expects(:download!).with("/remote-1", @local)
+        scp.expects(:download!).with("/remote-2", @local)
 
-        connection.download(['/remote-1', '/remote-2'], @local)
+        connection.download(["/remote-1", "/remote-2"], @local)
       end
     end
 
     describe "for a directory" do
       it "downloads the directory from a remote over scp" do
         FileUtils.expects(:mkdir_p).with(@local_parent)
-        scp.expects(:download!).with('/remote-dir', @local).raises(Net::SCP::Error)
-        scp.expects(:download!).with('/remote-dir', @local, recursive: true)
+        scp.expects(:download!).with("/remote-dir", @local).raises(Net::SCP::Error)
+        scp.expects(:download!).with("/remote-dir", @local, recursive: true)
 
-        connection.download('/remote-dir', @local)
+        connection.download("/remote-dir", @local)
       end
     end
 
     describe "for a file that does not exist" do
       it "logs a warning" do
         FileUtils.expects(:mkdir_p).with(@local_parent)
-        scp.expects(:download!).with('/remote', @local).raises(Net::SCP::Error)
-        scp.expects(:download!).with('/remote', @local, recursive: true)
+        scp.expects(:download!).with("/remote", @local).raises(Net::SCP::Error)
+        scp.expects(:download!).with("/remote", @local, recursive: true)
           .raises(Net::SCP::Error)
 
-        connection.download('/remote', @local)
+        connection.download("/remote", @local)
 
         logged_output.string.lines.count do |l|
           l =~ warn_line_with(

--- a/spec/kitchen/transport/ssh_spec.rb
+++ b/spec/kitchen/transport/ssh_spec.rb
@@ -1092,6 +1092,37 @@ describe Kitchen::Transport::Ssh::Connection do
     end
   end
 
+  describe "#download" do
+    describe "for a file" do
+      it "downloads a file from a remote over scp" do
+        true.must_equal false
+      end
+    end
+
+    describe "for a path" do
+      it "downloads a file from a remote over scp" do
+        true.must_equal false
+      end
+    end
+
+    describe "for a failed download" do
+      let(:conn) { mock("session") }
+
+      before do
+        Net::SSH.stubs(:start).returns(conn)
+      end
+
+      it "raises SshFailed when an SSH exception is raised" do
+        conn.stubs(:scp).raises(Net::SSH::Exception)
+
+        e = proc do
+          connection.download("nope", "fail")
+        end.must_raise Kitchen::Transport::SshFailed
+        e.message.must_match regexify("SCP download failed")
+      end
+    end
+  end
+
   describe "#wait_until_ready" do
     before do
       options[:max_wait_until_ready] = 300

--- a/spec/kitchen/transport/ssh_spec.rb
+++ b/spec/kitchen/transport/ssh_spec.rb
@@ -1093,25 +1093,67 @@ describe Kitchen::Transport::Ssh::Connection do
   end
 
   describe "#download" do
+    let(:conn) { mock("session") }
+    let(:scp) { mock("scp") }
+
+    before do
+      Net::SSH.stubs(:start).returns(conn)
+      conn.stubs(:scp).returns(scp)
+      @local_parent = Dir.mktmpdir('dir')
+      @local = File.join(@local_parent, "local")
+    end
+
+    after do
+      FileUtils.remove_entry_secure(@local_parent)
+    end
+
     describe "for a file" do
       it "downloads a file from a remote over scp" do
-        true.must_equal false
+        FileUtils.expects(:mkdir_p).with(@local_parent)
+        scp.expects(:download!).with('/remote', @local)
+
+        connection.download('/remote', @local)
       end
     end
 
-    describe "for a path" do
-      it "downloads a file from a remote over scp" do
-        true.must_equal false
+    describe "for a list of files" do
+      it "downloads the files from a remote over scp" do
+        FileUtils.expects(:mkdir_p).with(@local_parent)
+        scp.expects(:download!).with('/remote-1', @local)
+        scp.expects(:download!).with('/remote-2', @local)
+
+        connection.download(['/remote-1', '/remote-2'], @local)
+      end
+    end
+
+    describe "for a directory" do
+      it "downloads the directory from a remote over scp" do
+        FileUtils.expects(:mkdir_p).with(@local_parent)
+        scp.expects(:download!).with('/remote-dir', @local).raises(Net::SCP::Error)
+        scp.expects(:download!).with('/remote-dir', @local, recursive: true)
+
+        connection.download('/remote-dir', @local)
+      end
+    end
+
+    describe "for a file that does not exist" do
+      it "logs a warning" do
+        FileUtils.expects(:mkdir_p).with(@local_parent)
+        scp.expects(:download!).with('/remote', @local).raises(Net::SCP::Error)
+        scp.expects(:download!).with('/remote', @local, recursive: true)
+          .raises(Net::SCP::Error)
+
+        connection.download('/remote', @local)
+
+        logged_output.string.lines.count do |l|
+          l =~ warn_line_with(
+            "SCP download failed for file or directory '/remote', perhaps it does not exist?"
+          )
+        end.must_equal 1
       end
     end
 
     describe "for a failed download" do
-      let(:conn) { mock("session") }
-
-      before do
-        Net::SSH.stubs(:start).returns(conn)
-      end
-
       it "raises SshFailed when an SSH exception is raised" do
         conn.stubs(:scp).raises(Net::SSH::Exception)
 


### PR DESCRIPTION
I'd like test-kitchen to be able to download files from instances post-converge by specifying them in the kitchen yaml provisioner section:

```yaml
# .kitchen.yml

provisioner:
  downloads:
    /tmp/kitchen/nodes: test/fixtures
    /tmp/kitchen/data_bags: test/fixtures
```

This config would download all of chef-zero's saved nodes and data bags back to `test/fixtures/nodes/node-name.json` and `test/fixtures/data_bags/bag-name/item-name.json`. These changes support:

- downloading a file from a remote path to a local path
- downloading a directory recursively from a remote path to a local path
- specifying the name of the downloaded file / directory or keeping the original name by only specifying a parent directory to download to
- backwards compatible - I run the download against `config[:provisioner][:downloads]`, which defaults to an empty hash resulting in no downloading
- specifying multiple files / directories to be downloaded to the same path with a shorthand:
  ```yaml
  provisioner:
    downloads:
      [/tmp/kitchen/nodes, /tmp/kitchen/data_bags]: test/fixtures
  ```

----

My goal here stems from https://github.com/mwrock/kitchen-nodes/issues/36

Im using the [kitchen-nodes provisioner](https://github.com/mwrock/kitchen-nodes) to allow test-kitchen ec2 instances to know of each other, and load their node data into chef zero at the start of each chef-client. I want to extend that to be able to save updated nodes back to the nodes directory on my workstation after a converge on an instance. These updated nodes will then be copied up to the next instance that is converged.

I'd also like to be able to download data bags for the use case of a node registers itself in a data bag and another node does something to connect to that node using data in the data bag.