### PR TITLE
[MSYS-703] Fix code to validate retry_on_exit_code

### DIFF
--- a/lib/kitchen/transport/base.rb
+++ b/lib/kitchen/transport/base.rb
@@ -138,20 +138,9 @@ module Kitchen
         end
 
         def retry?(current_try, max_retries, retryable_exit_codes, exit_code)
-          retryable_exit_codes_exists = false
-          if !retryable_exit_codes.nil?
-            if retryable_exit_codes.class == String
-              retryable_exit_codes_exists = retryable_exit_codes.include?(exit_code.to_s)
-            elsif retryable_exit_codes[0].class == Array && retryable_exit_codes.class == Array
-              retryable_exit_codes_exists = !retryable_exit_codes.select{|x| x.include?(exit_code)}.empty?
-            elsif retryable_exit_codes[0].class == Integer && retryable_exit_codes.class == Array
-              retryable_exit_codes_exists = retryable_exit_codes.include?(exit_code)
-            else
-              raise TypeError, "Invalid type of retry_on_exit_code"
-            end
-          end
-
-         current_try <= max_retries && retryable_exit_codes_exists
+          current_try <= max_retries &&
+            !retryable_exit_codes.nil? &&
+            retryable_exit_codes.flatten.include?(exit_code)
         end
 
         # Builds a LoginCommand which can be used to open an interactive

--- a/lib/kitchen/transport/base.rb
+++ b/lib/kitchen/transport/base.rb
@@ -138,9 +138,20 @@ module Kitchen
         end
 
         def retry?(current_try, max_retries, retryable_exit_codes, exit_code)
-          current_try <= max_retries &&
-            !retryable_exit_codes.nil? &&
-            retryable_exit_codes.include?(exit_code)
+          retryable_exit_codes_exists = false
+          if !retryable_exit_codes.nil?
+            if retryable_exit_codes.class == String
+              retryable_exit_codes_exists = retryable_exit_codes.include?(exit_code.to_s)
+            elsif retryable_exit_codes[0].class == Array && retryable_exit_codes.class == Array
+              retryable_exit_codes_exists = !retryable_exit_codes.select{|x| x.include?(exit_code)}.empty?
+            elsif retryable_exit_codes[0].class == Integer && retryable_exit_codes.class == Array
+              retryable_exit_codes_exists = retryable_exit_codes.include?(exit_code)
+            else
+              raise TypeError, "Invalid type of retry_on_exit_code"
+            end
+          end
+
+         current_try <= max_retries && retryable_exit_codes_exists
         end
 
         # Builds a LoginCommand which can be used to open an interactive

--- a/spec/kitchen/transport/base_spec.rb
+++ b/spec/kitchen/transport/base_spec.rb
@@ -120,4 +120,16 @@ describe Kitchen::Transport::Base::Connection do
       connection.execute_with_retry("Hi", [123], 3, 1).must_equal "Hello"
     end
   end
+
+    describe "#retry?" do
+      it "raises TypeError with no retries" do
+        proc { connection.execute_with_retry.retry?(2, 2, 35, 35) }
+          .must_raise TypeError
+      end
+
+      it "when value is send in Array in Array" do
+        connection.execute_with_retry.retry?(1, 2, [[35, 1]], 35).must_equal true
+      end
+    end
+
 end

--- a/spec/kitchen/transport/base_spec.rb
+++ b/spec/kitchen/transport/base_spec.rb
@@ -122,12 +122,12 @@ describe Kitchen::Transport::Base::Connection do
   end
 
   describe "#retry?" do
-    it "raises Invalid Type Error for retry_on_exit_code" do
+    it "raises an exception when multiple retryable exit codes are passed as a String" do
       proc { connection.retry?(2, 2, "35 1", 35) }
         .must_raise("undefined method `flatten' for \"35 1\":String")
     end
 
-    it "when value is send in Array in Array" do
+    it "returns true when the retryable exit codes are formatted in a nested array" do
       connection.retry?(1, 2, [[35, 1]], 35).must_equal true
     end
   end

--- a/spec/kitchen/transport/base_spec.rb
+++ b/spec/kitchen/transport/base_spec.rb
@@ -121,15 +121,15 @@ describe Kitchen::Transport::Base::Connection do
     end
   end
 
-    describe "#retry?" do
-      it "raises TypeError with no retries" do
-        proc { connection.execute_with_retry.retry?(2, 2, 35, 35) }
-          .must_raise TypeError
-      end
-
-      it "when value is send in Array in Array" do
-        connection.execute_with_retry.retry?(1, 2, [[35, 1]], 35).must_equal true
-      end
+  describe "#retry?" do
+    it "raises Invalid Type Error for retry_on_exit_code" do
+      proc { connection.retry?(2, 2, "35 1", 35) }
+        .must_raise("undefined method `flatten' for \"35 1\":String")
     end
+
+    it "when value is send in Array in Array" do
+      connection.retry?(1, 2, [[35, 1]], 35).must_equal true
+    end
+  end
 
 end


### PR DESCRIPTION
**Issue reported by the user**:
In kitchen.yml customer was sending the following attributes :
```
 retry_on_exit_code: 
   - [35, 1, 20]
  max_retries: 3
  wait_for_retry: 120 
```
By executing command `kitchen diagnose --all`, found that attribute was sent in 2D Array format as:
 ```    
retry_on_exit_code:
        -  -35
        - 1
        - 20
        max_retries: 3
        wait_for_retry: 120 
```
command ` retryable_exit_codes.include?(exit_code)` was not sufficient to check the 2D Array format (i.e [[35, 1, 20]] ) .
Hence was not able to retry kitchen execution after getting exit code `35` & customer was not able to understand why it is not retrying.

This PR validates & handles such type of issues.