### PR TITLE
Remove extraneous bash shebang.

### DIFF
--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -409,7 +409,6 @@ module Kitchen
       def install_from_file(command)
         install_file = "/tmp/chef-installer.sh"
         script = ["cat > #{install_file} <<\"EOL\""]
-        script << "#!/bin/bash"
         script << command
         script << "EOL"
         script << "chmod +x #{install_file}"


### PR DESCRIPTION
On some platforms the additional bash shebang would result in an immediate failure to install chef. This removes the bash shebang in favor of the shebang and script generated by mixlib-install.

Signed-off-by: Ryan Hass <rhass@users.noreply.github.com>