### PR TITLE
[MSYS-721] Added KITCHEN_SSH_PROXY feature to connect via http proxy

### DIFF
--- a/lib/kitchen/transport/ssh.rb
+++ b/lib/kitchen/transport/ssh.rb
@@ -480,7 +480,7 @@ module Kitchen
           options_http_proxy = {}
           options_http_proxy[:user] = data[:http_proxy_user]
           options_http_proxy[:password] = data[:http_proxy_password]
-          opts[:proxy] = Net::SSH::Proxy::HTTP.new("#{data[:kitchen_ssh_proxy]}", data[:http_proxy_port], options_http_proxy)
+          opts[:proxy] = Net::SSH::Proxy::HTTP.new(data[:kitchen_ssh_proxy], data[:http_proxy_port], options_http_proxy)
         end
 
         if data[:ssh_key_only]

--- a/lib/kitchen/transport/ssh.rb
+++ b/lib/kitchen/transport/ssh.rb
@@ -21,6 +21,7 @@ require "kitchen"
 require "fileutils"
 require "net/ssh"
 require "net/ssh/gateway"
+require "net/ssh/proxy/http"
 require "net/scp"
 require "timeout"
 require "benchmark"
@@ -54,6 +55,11 @@ module Kitchen
 
       default_config :ssh_gateway, nil
       default_config :ssh_gateway_username, nil
+
+      default_config :kitchen_ssh_proxy, nil
+      default_config :http_proxy_port, nil
+      default_config :http_proxy_user, nil
+      default_config :http_proxy_password, nil
 
       default_config :ssh_key, nil
       expand_path_for :ssh_key
@@ -271,6 +277,26 @@ module Kitchen
         # @api private
         attr_reader :ssh_gateway_username
 
+        # @return [String] The kitchen ssh proxy to use when connecting to the
+        #   remote SSH host via http proxy
+        # @api private
+        attr_reader :kitchen_ssh_proxy
+
+        # @return [Integer] The port to use when using an kitchen ssh proxy
+        #   remote SSH host via http proxy
+        # @api private
+        attr_reader :http_proxy_port
+
+        # @return [String] The username to use when using an kitchen ssh proxy
+        #   remote SSH host via http proxy
+        # @api private
+        attr_reader :http_proxy_user
+
+        # @return [String] The password to use when using an kitchen ssh proxy
+        #   remote SSH host via http proxy
+        # @api private
+        attr_reader :http_proxy_password
+
         # Establish an SSH session on the remote host using a gateway host.
         #
         # @param opts [Hash] retry options
@@ -380,6 +406,10 @@ module Kitchen
           @max_wait_until_ready   = @options.delete(:max_wait_until_ready)
           @ssh_gateway            = @options.delete(:ssh_gateway)
           @ssh_gateway_username   = @options.delete(:ssh_gateway_username)
+          @kitchen_ssh_proxy      = @options.delete(:kitchen_ssh_proxy)
+          @http_proxy_user        = @options.delete(:http_proxy_user)
+          @http_proxy_password    = @options.delete(:http_proxy_password)
+          @http_proxy_port        = @options.delete(:http_proxy_port)
         end
 
         # Returns a connection session, or establishes one when invoked the
@@ -444,6 +474,13 @@ module Kitchen
           opts[:keys_only] = true
           opts[:keys] = Array(data[:ssh_key])
           opts[:auth_methods] = ["publickey"]
+        end
+
+        if data[:kitchen_ssh_proxy]
+          options_http_proxy = {}
+          options_http_proxy[:user] = data[:http_proxy_user]
+          options_http_proxy[:password] = data[:http_proxy_password]
+          opts[:proxy] = Net::SSH::Proxy::HTTP.new("#{data[:kitchen_ssh_proxy]}", data[:http_proxy_port], options_http_proxy)
         end
 
         if data[:ssh_key_only]

--- a/lib/kitchen/transport/ssh.rb
+++ b/lib/kitchen/transport/ssh.rb
@@ -56,10 +56,10 @@ module Kitchen
       default_config :ssh_gateway, nil
       default_config :ssh_gateway_username, nil
 
-      default_config :kitchen_ssh_proxy, nil
-      default_config :http_proxy_port, nil
-      default_config :http_proxy_user, nil
-      default_config :http_proxy_password, nil
+      default_config :ssh_http_proxy, nil
+      default_config :ssh_http_proxy_port, nil
+      default_config :ssh_http_proxy_user, nil
+      default_config :ssh_http_proxy_password, nil
 
       default_config :ssh_key, nil
       expand_path_for :ssh_key
@@ -280,22 +280,22 @@ module Kitchen
         # @return [String] The kitchen ssh proxy to use when connecting to the
         #   remote SSH host via http proxy
         # @api private
-        attr_reader :kitchen_ssh_proxy
+        attr_reader :ssh_http_proxy
 
         # @return [Integer] The port to use when using an kitchen ssh proxy
         #   remote SSH host via http proxy
         # @api private
-        attr_reader :http_proxy_port
+        attr_reader :ssh_http_proxy_port
 
         # @return [String] The username to use when using an kitchen ssh proxy
         #   remote SSH host via http proxy
         # @api private
-        attr_reader :http_proxy_user
+        attr_reader :ssh_http_proxy_user
 
         # @return [String] The password to use when using an kitchen ssh proxy
         #   remote SSH host via http proxy
         # @api private
-        attr_reader :http_proxy_password
+        attr_reader :ssh_http_proxy_password
 
         # Establish an SSH session on the remote host using a gateway host.
         #
@@ -397,19 +397,19 @@ module Kitchen
         # (see Base::Connection#init_options)
         def init_options(options)
           super
-          @username               = @options.delete(:username)
-          @hostname               = @options.delete(:hostname)
-          @port                   = @options[:port] # don't delete from options
-          @connection_retries     = @options.delete(:connection_retries)
-          @connection_retry_sleep = @options.delete(:connection_retry_sleep)
-          @max_ssh_sessions       = @options.delete(:max_ssh_sessions)
-          @max_wait_until_ready   = @options.delete(:max_wait_until_ready)
-          @ssh_gateway            = @options.delete(:ssh_gateway)
-          @ssh_gateway_username   = @options.delete(:ssh_gateway_username)
-          @kitchen_ssh_proxy      = @options.delete(:kitchen_ssh_proxy)
-          @http_proxy_user        = @options.delete(:http_proxy_user)
-          @http_proxy_password    = @options.delete(:http_proxy_password)
-          @http_proxy_port        = @options.delete(:http_proxy_port)
+          @username                = @options.delete(:username)
+          @hostname                = @options.delete(:hostname)
+          @port                    = @options[:port] # don't delete from options
+          @connection_retries      = @options.delete(:connection_retries)
+          @connection_retry_sleep  = @options.delete(:connection_retry_sleep)
+          @max_ssh_sessions        = @options.delete(:max_ssh_sessions)
+          @max_wait_until_ready    = @options.delete(:max_wait_until_ready)
+          @ssh_gateway             = @options.delete(:ssh_gateway)
+          @ssh_gateway_username    = @options.delete(:ssh_gateway_username)
+          @ssh_http_proxy          = @options.delete(:ssh_http_proxy)
+          @ssh_http_proxy_user     = @options.delete(:ssh_http_proxy_user)
+          @ssh_http_proxy_password = @options.delete(:ssh_http_proxy_password)
+          @ssh_http_proxy_port     = @options.delete(:ssh_http_proxy_port)
         end
 
         # Returns a connection session, or establishes one when invoked the
@@ -476,11 +476,11 @@ module Kitchen
           opts[:auth_methods] = ["publickey"]
         end
 
-        if data[:kitchen_ssh_proxy]
+        if data[:ssh_http_proxy]
           options_http_proxy = {}
-          options_http_proxy[:user] = data[:http_proxy_user]
-          options_http_proxy[:password] = data[:http_proxy_password]
-          opts[:proxy] = Net::SSH::Proxy::HTTP.new(data[:kitchen_ssh_proxy], data[:http_proxy_port], options_http_proxy)
+          options_http_proxy[:user] = data[:ssh_http_proxy_user]
+          options_http_proxy[:password] = data[:ssh_http_proxy_password]
+          opts[:proxy] = Net::SSH::Proxy::HTTP.new(data[:ssh_http_proxy], data[:ssh_http_proxy_port], options_http_proxy)
         end
 
         if data[:ssh_key_only]

--- a/spec/kitchen/transport/ssh_spec.rb
+++ b/spec/kitchen/transport/ssh_spec.rb
@@ -120,6 +120,22 @@ describe Kitchen::Transport::Ssh do
     it "sets :max_ssh_sessions to 9 by default" do
       transport[:max_ssh_sessions].must_equal 9
     end
+
+    it "sets :kitchen_ssh_proxy to nil by default" do
+      transport[:kitchen_ssh_proxy].must_be_nil
+    end
+
+    it "sets :http_proxy_port to nil by default" do
+      transport[:http_proxy_port].must_be_nil
+    end
+
+    it "sets :http_proxy_user to nil by default" do
+      transport[:http_proxy_user].must_be_nil
+    end
+
+    it "sets :http_proxy_password to nil by default" do
+      transport[:http_proxy_password].must_be_nil
+    end
   end
 
   describe "#connection" do
@@ -412,6 +428,19 @@ describe Kitchen::Transport::Ssh do
 
         klass.expects(:new).with do |hash|
           hash[:keys_only] == true
+        end
+
+        make_connection
+      end
+
+      it "sets :proxy to proxy if :kitchen_ssh_proxy is set in state" do
+        state[:kitchen_ssh_proxy] = "kitchen_ssh_proxy_from_config"
+        options_http_proxy[:user] = state[:http_proxy_user]
+        options_http_proxy[:password] = state[:http_proxy_password]
+        proxy_conn = Net::SSH::Proxy::HTTP.new("#{state[:kitchen_ssh_proxy]}", state[:http_proxy_port], options_http_proxy)
+
+        klass.expects(:new).with do |hash|
+          hash[:proxy] == proxy_conn
         end
 
         make_connection

--- a/spec/kitchen/transport/ssh_spec.rb
+++ b/spec/kitchen/transport/ssh_spec.rb
@@ -140,6 +140,7 @@ describe Kitchen::Transport::Ssh do
 
   describe "#connection" do
     let(:klass) { Kitchen::Transport::Ssh::Connection }
+    let(:options_http_proxy)    { Hash.new }
 
     # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
     def self.common_connection_specs

--- a/spec/kitchen/transport/ssh_spec.rb
+++ b/spec/kitchen/transport/ssh_spec.rb
@@ -121,20 +121,20 @@ describe Kitchen::Transport::Ssh do
       transport[:max_ssh_sessions].must_equal 9
     end
 
-    it "sets :kitchen_ssh_proxy to nil by default" do
-      transport[:kitchen_ssh_proxy].must_be_nil
+    it "sets :ssh_http_proxy to nil by default" do
+      transport[:ssh_http_proxy].must_be_nil
     end
 
-    it "sets :http_proxy_port to nil by default" do
-      transport[:http_proxy_port].must_be_nil
+    it "sets :ssh_http_proxy_port to nil by default" do
+      transport[:ssh_http_proxy_port].must_be_nil
     end
 
-    it "sets :http_proxy_user to nil by default" do
-      transport[:http_proxy_user].must_be_nil
+    it "sets :ssh_http_proxy_user to nil by default" do
+      transport[:ssh_http_proxy_user].must_be_nil
     end
 
-    it "sets :http_proxy_password to nil by default" do
-      transport[:http_proxy_password].must_be_nil
+    it "sets :ssh_http_proxy_password to nil by default" do
+      transport[:ssh_http_proxy_password].must_be_nil
     end
   end
 
@@ -142,11 +142,11 @@ describe Kitchen::Transport::Ssh do
     let(:klass) { Kitchen::Transport::Ssh::Connection }
     let(:options_http_proxy) { Hash.new }
     let(:proxy_conn) do
-      state[:kitchen_ssh_proxy] = "kitchen_ssh_proxy_from_state"
-      state[:http_proxy_port] = "http_proxy_port_from_state"
-      options_http_proxy[:user] = state[:http_proxy_user]
-      options_http_proxy[:password] = state[:http_proxy_password]
-      Net::SSH::Proxy::HTTP.new(state[:kitchen_ssh_proxy], state[:http_proxy_port], options_http_proxy)
+      state[:ssh_http_proxy]        = "ssh_http_proxy_from_state"
+      state[:ssh_http_proxy_port]   = "http_proxy_port_from_state"
+      options_http_proxy[:user]     = state[:ssh_http_proxy_user]
+      options_http_proxy[:password] = state[:ssh_http_proxy_password]
+      Net::SSH::Proxy::HTTP.new(state[:ssh_http_proxy], state[:ssh_http_proxy_port], options_http_proxy)
     end
 
     # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
@@ -445,8 +445,8 @@ describe Kitchen::Transport::Ssh do
         make_connection
       end
 
-      it "sets :proxy to proxy if :kitchen_ssh_proxy is set in state" do
-        config[:kitchen_ssh_proxy] = true
+      it "sets :proxy to proxy if :ssh_http_proxy is set in state" do
+        config[:ssh_http_proxy] = true
 
         klass.expects(:new).with do |hash|
           hash[:proxy] == proxy_conn

--- a/spec/kitchen/transport/ssh_spec.rb
+++ b/spec/kitchen/transport/ssh_spec.rb
@@ -143,7 +143,7 @@ describe Kitchen::Transport::Ssh do
     let(:options_http_proxy) { Hash.new }
     let(:proxy_conn) do
       state[:ssh_http_proxy]        = "ssh_http_proxy_from_state"
-      state[:ssh_http_proxy_port]   = "http_proxy_port_from_state"
+      state[:ssh_http_proxy_port]   = "ssh_http_proxy_port_from_state"
       options_http_proxy[:user]     = state[:ssh_http_proxy_user]
       options_http_proxy[:password] = state[:ssh_http_proxy_password]
       Net::SSH::Proxy::HTTP.new(state[:ssh_http_proxy], state[:ssh_http_proxy_port], options_http_proxy)


### PR DESCRIPTION
The card [MSYS-721] & PR is related to use an http proxy as documented in https://net-ssh.github.io/ssh/v1/chapter-7.html . The design is that the URL for the https proxy is stored in `KITCHEN_SSH_PROXY` with port in `HTTP_PROXY_PORT`, and the user and password for authentication to the proxy (if required) comes from `HTTP_PROXY_USER` and `HTTP_PROXY_PASSWORD`.