### PR TITLE
include list of known plugins when one cannot be loaded

### DIFF
--- a/lib/kitchen/driver.rb
+++ b/lib/kitchen/driver.rb
@@ -16,9 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "kitchen/errors"
-require "kitchen/util"
-require "thor/util"
+require "kitchen/plugin"
 
 module Kitchen
   # A driver is responsible for carrying out the lifecycle activities of an
@@ -37,21 +35,7 @@ module Kitchen
     # @raise [ClientError] if a driver instance could not be created
     # @raise [UserError] if the driver's dependencies could not be met
     def self.for_plugin(plugin, config)
-      first_load = require("kitchen/driver/#{plugin}")
-
-      str_const = Thor::Util.camel_case(plugin)
-      klass = const_get(str_const)
-      object = klass.new(config)
-      object.verify_dependencies if first_load
-      object
-    rescue UserError
-      raise
-    rescue LoadError, NameError
-      available_drivers = Kitchen::Util.plugins_available(self) - %w{base}
-      raise ClientError, "Could not load the '#{plugin}' driver from the load path." \
-        " Did you mean: #{available_drivers.join(", ")} ?" \
-        " Please ensure that your driver is installed as a gem or included" \
-        " in your Gemfile if using Bundler."
+      Kitchen::Plugin.load(self, plugin, config)
     end
   end
 end

--- a/lib/kitchen/driver.rb
+++ b/lib/kitchen/driver.rb
@@ -16,6 +16,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "kitchen/errors"
+require "kitchen/util"
 require "thor/util"
 
 module Kitchen
@@ -45,10 +47,11 @@ module Kitchen
     rescue UserError
       raise
     rescue LoadError, NameError
-      raise ClientError,
-            "Could not load the '#{plugin}' driver from the load path." \
-              " Please ensure that your driver is installed as a gem or included" \
-              " in your Gemfile if using Bundler."
+      available_drivers = Kitchen::Util.plugins_available(self) - %w{base}
+      raise ClientError, "Could not load the '#{plugin}' driver from the load path." \
+        " Did you mean: #{available_drivers.join(", ")} ?" \
+        " Please ensure that your driver is installed as a gem or included" \
+        " in your Gemfile if using Bundler."
     end
   end
 end

--- a/lib/kitchen/driver/base.rb
+++ b/lib/kitchen/driver/base.rb
@@ -16,7 +16,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "kitchen/configurable"
+require "kitchen/errors"
 require "kitchen/lazy_hash"
+require "kitchen/logging"
 require "kitchen/shell_out"
 
 module Kitchen

--- a/lib/kitchen/plugin.rb
+++ b/lib/kitchen/plugin.rb
@@ -1,0 +1,77 @@
+# -*- encoding: utf-8 -*-
+#
+# Author:: Fletcher Nichol (<fnichol@nichol.ca>)
+#
+# Copyright (C) 2012, Fletcher Nichol
+# Copyright (C) 2018, Chef Software
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "kitchen/errors"
+require "kitchen/util"
+
+module Kitchen
+  module Plugin
+    # Returns an instance of a plugin given a type, name, and config.
+    #
+    # @param type [Module] a Kitchen::<Module> of one of the plugin types
+    #   (Driver, Provisioner, Transport, Verifier)
+    # @param plugin [String] a plugin name, which will be constantized
+    # @param config [Hash] a configuration hash to initialize the plugin
+    # @return [Kitchen::<Module>::Base] a plugin instance
+    # @raise [ClientError] if a plugin instance could not be created
+    # @raise [UserError] if the plugin's dependencies could not be met
+    def self.load(type, plugin, config)
+      type_name = Kitchen::Util.snake_case(type.name.split("::").last)
+      first_load = require("kitchen/#{type_name}/#{plugin}")
+
+      str_const = Kitchen::Util.camel_case(plugin)
+      klass = type.const_get(str_const)
+      object = klass.new(config)
+      object.verify_dependencies if first_load
+      object
+    rescue UserError
+      raise
+    rescue NameError => e
+      raise ClientError, "Could not load the '#{plugin}' #{type_name}. Error: #{e.message}"
+    rescue LoadError => e
+      available_plugins = plugins_available(type_name)
+      error_message = if available_plugins.include?(plugin)
+                        e.message
+                      else
+                        " Did you mean: #{available_plugins.join(", ")} ?" \
+                        " Please ensure that your #{type_name} is installed as a gem or included" \
+                        " in your Gemfile if using Bundler."
+                      end
+      raise ClientError, "Could not load the '#{plugin}' #{type_name} from the load path." + error_message
+    end
+
+    # given a type of plugin, searches the Ruby load path for plugins of that
+    # type based on the path+naming convention that plugin loading is based upon
+    #
+    # @param plugin_type [String] the name of a plugin type (e.g. driver,
+    #   provisioner, transport, verifier)
+    # @return [Array<String>] a collection of Ruby filenames that are probably
+    #   plugins of the given type
+    def self.plugins_available(plugin_type)
+      $LOAD_PATH.map { |load_path| Dir[File.expand_path("kitchen/#{plugin_type}/*.rb", load_path)] }
+                .reject { |plugin_paths| plugin_paths.empty? }
+                .flatten
+                .uniq
+                .select { |plugin_path| File.readlines(plugin_path).grep(/^\s*class \w* </).any? }
+                .map { |plugin_path| File.basename(plugin_path).gsub(/\.rb$/, "") }
+                .reject { |plugin_name| plugin_name == "base" }
+                .sort
+    end
+  end
+end

--- a/lib/kitchen/provisioner.rb
+++ b/lib/kitchen/provisioner.rb
@@ -16,6 +16,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "kitchen/errors"
+require "kitchen/util"
 require "thor/util"
 
 module Kitchen
@@ -43,10 +45,11 @@ module Kitchen
       object.verify_dependencies if first_load
       object
     rescue LoadError, NameError
-      raise ClientError,
-            "Could not load the '#{plugin}' provisioner from the load path." \
-              " Please ensure that your provisioner is installed as a gem or" \
-              " included in your Gemfile if using Bundler."
+      available_provisioners = Kitchen::Util.plugins_available(self) - %w{base chef_base}
+      raise ClientError, "Could not load the '#{plugin}' provisioner from the load path." \
+         " Did you mean: #{available_provisioners.join(", ")} ?" \
+         " Please ensure that your provisioner is spelled correctly, installed as a gem, or" \
+         " is included in your Gemfile if using Bundler."
     end
   end
 end

--- a/lib/kitchen/provisioner.rb
+++ b/lib/kitchen/provisioner.rb
@@ -16,9 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "kitchen/errors"
-require "kitchen/util"
-require "thor/util"
+require "kitchen/plugin"
 
 module Kitchen
   # A provisioner is responsible for generating the commands necessary to
@@ -37,19 +35,7 @@ module Kitchen
     # @return [Provisioner::Base] a provisioner instance
     # @raise [ClientError] if a provisioner instance could not be created
     def self.for_plugin(plugin, config)
-      first_load = require("kitchen/provisioner/#{plugin}")
-
-      str_const = Thor::Util.camel_case(plugin)
-      klass = const_get(str_const)
-      object = klass.new(config)
-      object.verify_dependencies if first_load
-      object
-    rescue LoadError, NameError
-      available_provisioners = Kitchen::Util.plugins_available(self) - %w{base chef_base}
-      raise ClientError, "Could not load the '#{plugin}' provisioner from the load path." \
-         " Did you mean: #{available_provisioners.join(", ")} ?" \
-         " Please ensure that your provisioner is spelled correctly, installed as a gem, or" \
-         " is included in your Gemfile if using Bundler."
+      Kitchen::Plugin.load(self, plugin, config)
     end
   end
 end

--- a/lib/kitchen/provisioner/base.rb
+++ b/lib/kitchen/provisioner/base.rb
@@ -16,6 +16,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "kitchen/configurable"
+require "kitchen/errors"
+require "kitchen/logging"
+
 module Kitchen
   module Provisioner
     # Base class for a provisioner.

--- a/lib/kitchen/transport.rb
+++ b/lib/kitchen/transport.rb
@@ -16,6 +16,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "kitchen/errors"
+require "kitchen/util"
 require "thor/util"
 
 module Kitchen
@@ -43,10 +45,11 @@ module Kitchen
       object.verify_dependencies if first_load
       object
     rescue LoadError, NameError
-      raise ClientError,
-            "Could not load the '#{plugin}' transport from the load path." \
-              " Please ensure that your transport is installed as a gem or" \
-              " included in your Gemfile if using Bundler."
+      available_transports = Kitchen::Util.plugins_available(self) - %w{base}
+      raise ClientError, "Could not load the '#{plugin}' transport from the load path." \
+        " Did you mean: #{available_transports.join(", ")} ?" \
+        " Please ensure that your transport is installed as a gem or" \
+        " included in your Gemfile if using Bundler."
     end
   end
 end

--- a/lib/kitchen/transport.rb
+++ b/lib/kitchen/transport.rb
@@ -16,9 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "kitchen/errors"
-require "kitchen/util"
-require "thor/util"
+require "kitchen/plugin"
 
 module Kitchen
   # A transport is responsible for the communication with an instance,
@@ -37,19 +35,7 @@ module Kitchen
     # @return [Transport::Base] a transport instance
     # @raise [ClientError] if a transport instance could not be created
     def self.for_plugin(plugin, config)
-      first_load = require("kitchen/transport/#{plugin}")
-
-      str_const = Thor::Util.camel_case(plugin)
-      klass = const_get(str_const)
-      object = klass.new(config)
-      object.verify_dependencies if first_load
-      object
-    rescue LoadError, NameError
-      available_transports = Kitchen::Util.plugins_available(self) - %w{base}
-      raise ClientError, "Could not load the '#{plugin}' transport from the load path." \
-        " Did you mean: #{available_transports.join(", ")} ?" \
-        " Please ensure that your transport is installed as a gem or" \
-        " included in your Gemfile if using Bundler."
+      Kitchen::Plugin.load(self, plugin, config)
     end
   end
 end

--- a/lib/kitchen/transport/base.rb
+++ b/lib/kitchen/transport/base.rb
@@ -17,8 +17,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "kitchen/configurable"
 require "kitchen/errors"
 require "kitchen/lazy_hash"
+require "kitchen/logging"
 require "kitchen/login_command"
 
 module Kitchen

--- a/lib/kitchen/util.rb
+++ b/lib/kitchen/util.rb
@@ -195,5 +195,16 @@ module Kitchen
         Dir.glob(pattern, *flags).map { |f| File.join(path, f) }
       end
     end
+
+    def self.plugins_available(module_class)
+      plugin_type = module_class.name.split("::").last.downcase
+      $LOAD_PATH.map { |load_path| Dir[File.expand_path("kitchen/#{plugin_type}/*.rb", load_path)] }
+                .reject { |plugin_paths| plugin_paths.empty? }
+                .flatten
+                .uniq
+                .select { |plugin_path| File.readlines(plugin_path).grep(/^\s*class \w* </).any? }
+                .map { |plugin_path| File.basename(plugin_path).gsub(/\.rb$/, "") }
+                .sort
+    end
   end
 end

--- a/lib/kitchen/util.rb
+++ b/lib/kitchen/util.rb
@@ -16,6 +16,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "kitchen/errors"
+require "thor/util"
+
 module Kitchen
   # Stateless utility methods used in different contexts. Essentially a mini
   # PassiveSupport library.
@@ -196,15 +199,12 @@ module Kitchen
       end
     end
 
-    def self.plugins_available(module_class)
-      plugin_type = module_class.name.split("::").last.downcase
-      $LOAD_PATH.map { |load_path| Dir[File.expand_path("kitchen/#{plugin_type}/*.rb", load_path)] }
-                .reject { |plugin_paths| plugin_paths.empty? }
-                .flatten
-                .uniq
-                .select { |plugin_path| File.readlines(plugin_path).grep(/^\s*class \w* </).any? }
-                .map { |plugin_path| File.basename(plugin_path).gsub(/\.rb$/, "") }
-                .sort
+    def self.camel_case(a_string)
+      Thor::Util.camel_case(a_string)
+    end
+
+    def self.snake_case(a_string)
+      Thor::Util.snake_case(a_string)
     end
   end
 end

--- a/lib/kitchen/verifier.rb
+++ b/lib/kitchen/verifier.rb
@@ -16,9 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "kitchen/errors"
-require "kitchen/util"
-require "thor/util"
+require "kitchen/plugin"
 
 module Kitchen
   # A verifier is responsible for running tests post-converge to confirm that
@@ -36,19 +34,7 @@ module Kitchen
     # @return [Verifier::Base] a verifier instance
     # @raise [ClientError] if a verifier instance could not be created
     def self.for_plugin(plugin, config)
-      first_load = require("kitchen/verifier/#{plugin}")
-
-      str_const = Thor::Util.camel_case(plugin)
-      klass = const_get(str_const)
-      object = klass.new(config)
-      object.verify_dependencies if first_load
-      object
-    rescue LoadError, NameError
-      available_verifiers = Kitchen::Util.plugins_available(self) - %w{base}
-      raise ClientError, "Could not load the '#{plugin}' verifier from the load path." \
-        " Did you mean: #{available_verifiers.join(", ")} ?" \
-        " Please ensure that your transport is installed as a gem or" \
-        " included in your Gemfile if using Bundler."
+      Kitchen::Plugin.load(self, plugin, config)
     end
   end
 end

--- a/lib/kitchen/verifier.rb
+++ b/lib/kitchen/verifier.rb
@@ -16,9 +16,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "thor/util"
-
 require "kitchen/errors"
+require "kitchen/util"
+require "thor/util"
 
 module Kitchen
   # A verifier is responsible for running tests post-converge to confirm that
@@ -44,10 +44,11 @@ module Kitchen
       object.verify_dependencies if first_load
       object
     rescue LoadError, NameError
-      raise ClientError,
-            "Could not load the '#{plugin}' verifier from the load path." \
-              " Please ensure that your transport is installed as a gem or" \
-              " included in your Gemfile if using Bundler."
+      available_verifiers = Kitchen::Util.plugins_available(self) - %w{base}
+      raise ClientError, "Could not load the '#{plugin}' verifier from the load path." \
+        " Did you mean: #{available_verifiers.join(", ")} ?" \
+        " Please ensure that your transport is installed as a gem or" \
+        " included in your Gemfile if using Bundler."
     end
   end
 end

--- a/spec/kitchen/plugin_spec.rb
+++ b/spec/kitchen/plugin_spec.rb
@@ -1,0 +1,131 @@
+# -*- encoding: utf-8 -*-
+#
+# Author:: Fletcher Nichol (<fnichol@nichol.ca>)
+#
+# Copyright (C) 2013, Fletcher Nichol
+# Copyright (C) 2018, Chef Software
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative "../spec_helper"
+
+require "logger"
+
+require "kitchen/plugin"
+
+module Kitchen
+  module RandoPlugin
+    require "kitchen/configurable"
+
+    class Base
+      include Configurable
+
+      def initialize(config = {})
+        init_config(config)
+      end
+
+      def verify_dependencies
+      end
+    end
+
+    class Coolbeans < Base
+    end
+
+    class ItDepends < Base
+      attr_reader :verify_call_count
+
+      def initialize(config = {})
+        @verify_call_count = 0
+        super
+      end
+
+      def verify_dependencies
+        @verify_call_count += 1
+      end
+    end
+
+    class UnstableDepends < Base
+      def verify_dependencies
+        raise UserError, "Oh noes, you don't have software!"
+      end
+    end
+  end
+end
+
+describe ".load" do
+  before do
+  end
+
+  describe "for a plugin type" do
+    it "returns a plugin" do
+      Kitchen::Plugin.stubs(:require).returns(true)
+      plugin = Kitchen::Plugin.load(Kitchen::RandoPlugin, "coolbeans", {})
+
+      plugin.must_be_kind_of Kitchen::RandoPlugin::Coolbeans
+    end
+
+    it "returns a plugin initialized with its config" do
+      Kitchen::Plugin.stubs(:require).returns(true)
+      plugin = Kitchen::Plugin.load(Kitchen::RandoPlugin, "coolbeans", jelly: "beans")
+
+      plugin[:jelly].must_equal "beans"
+    end
+
+    it "calls #verify_dependencies on the plugin object" do
+      Kitchen::Plugin.stubs(:require).returns(true)
+      driver = Kitchen::Plugin.load(Kitchen::RandoPlugin, "it_depends", {})
+
+      driver.verify_call_count.must_equal 1
+    end
+
+    it "calls #verify_dependencies once per plugin require" do
+      Kitchen::Plugin.stubs(:require).returns(true, false)
+      plugin1 = Kitchen::Plugin.load(Kitchen::RandoPlugin, "it_depends", {})
+      plugin1.verify_call_count.must_equal 1
+      plugin2 = Kitchen::Plugin.load(Kitchen::RandoPlugin, "it_depends", {})
+
+      plugin2.verify_call_count.must_equal 0
+    end
+
+    it "raises ClientError if the plugin could not be required" do
+      Kitchen::Plugin.stubs(:require).raises(LoadError)
+
+      error = assert_raises(Kitchen::ClientError) { Kitchen::Plugin.load(Kitchen::RandoPlugin, "coolbeans", {}) }
+      error.message.must_include "Could not load the 'coolbeans' rando_plugin from the load path."
+      error.message.must_include "Did you mean"
+    end
+
+    it "raises ClientError if plugin is found on load path but require still fails" do
+      Kitchen::Plugin.stubs(:require).raises(LoadError, "Some other problem.")
+      Kitchen::Plugin.stubs(:plugins_available).returns(%w{coolbeans})
+
+      error = assert_raises(Kitchen::ClientError) { Kitchen::Plugin.load(Kitchen::RandoPlugin, "coolbeans", {}) }
+      error.message.must_include "Could not load the 'coolbeans' rando_plugin from the load path."
+      error.message.must_include "Some other problem."
+      error.message.wont_include "Did you mean"
+    end
+
+    it "raises ClientError if the plugin's class constant could not be found" do
+      Kitchen::Plugin.stubs(:require).returns(true) # pretend require worked
+
+      error = assert_raises(Kitchen::ClientError) { Kitchen::Plugin.load(Kitchen::RandoPlugin, "isnt_the_actual_class_name", {}) }
+      error.message.must_include "uninitialized constant Kitchen::RandoPlugin::IsntTheActualClassName"
+    end
+
+    it "raises UserError if #verify_dependencies fails" do
+      Kitchen::Plugin.stubs(:require).returns(true)
+      proc { Kitchen::Plugin.load(Kitchen::RandoPlugin, "unstable_depends", {}) }
+        .must_raise Kitchen::UserError
+    end
+  end
+end

--- a/spec/kitchen/transport_spec.rb
+++ b/spec/kitchen/transport_spec.rb
@@ -18,9 +18,6 @@
 
 require_relative "../spec_helper"
 
-require "kitchen/configurable"
-require "kitchen/errors"
-require "kitchen/logging"
 require "kitchen/transport"
 require "kitchen/transport/base"
 
@@ -28,32 +25,21 @@ module Kitchen
   module Transport
     class Coolbeans < Kitchen::Transport::Base
     end
-
-    class ItDepends < Kitchen::Transport::Base
-      attr_reader :verify_call_count
-
-      def initialize(config = {})
-        @verify_call_count = 0
-        super
-      end
-
-      def verify_dependencies
-        @verify_call_count += 1
-      end
-    end
-
-    class UnstableDepends < Kitchen::Transport::Base
-      def verify_dependencies
-        raise UserError, "Oh noes, you don't have software!"
-      end
-    end
   end
 end
 
 describe Kitchen::Transport do
   describe ".for_plugin" do
     before do
-      Kitchen::Transport.stubs(:require).returns(true)
+      Kitchen::Plugin.stubs(:require).returns(true)
+    end
+
+    it "uses Kitchen::Plugin.load" do
+      faux_transport = Object.new
+      Kitchen::Plugin.stubs(:load).returns(faux_transport)
+      transport = Kitchen::Transport.for_plugin("faux", {})
+
+      transport.must_equal faux_transport
     end
 
     it "returns a transport object of the correct class" do
@@ -68,23 +54,8 @@ describe Kitchen::Transport do
       transport[:foo].must_equal "bar"
     end
 
-    it "calls #verify_dependencies on the transport object" do
-      transport = Kitchen::Transport.for_plugin("it_depends", {})
-
-      transport.verify_call_count.must_equal 1
-    end
-
-    it "calls #verify_dependencies once per transport require" do
-      Kitchen::Transport.stubs(:require).returns(true, false)
-      transport1 = Kitchen::Transport.for_plugin("it_depends", {})
-      transport1.verify_call_count.must_equal 1
-      transport2 = Kitchen::Transport.for_plugin("it_depends", {})
-
-      transport2.verify_call_count.must_equal 0
-    end
-
     it "raises ClientError if the transport could not be required" do
-      Kitchen::Transport.stubs(:require).raises(LoadError)
+      Kitchen::Plugin.stubs(:require).raises(LoadError)
 
       proc { Kitchen::Transport.for_plugin("coolbeans", {}) }
         .must_raise Kitchen::ClientError
@@ -92,15 +63,10 @@ describe Kitchen::Transport do
 
     it "raises ClientError if the transport's class constant was not found" do
       # pretend require worked
-      Kitchen::Transport.stubs(:require).returns(true)
+      Kitchen::Plugin.stubs(:require).returns(true)
 
       proc { Kitchen::Transport.for_plugin("nope", {}) }
         .must_raise Kitchen::ClientError
-    end
-
-    it "raises UserError if #verify_dependencies failes" do
-      proc { Kitchen::Transport.for_plugin("unstable_depends", {}) }
-        .must_raise Kitchen::UserError
     end
   end
 end


### PR DESCRIPTION
In an effort to be friendlier, let's include a list of plugins kitchen can find when it cannot load the one named in a config.

Because the require assumes the plugin will be in the load path at `kitchen/{plugin-type}`, that is what is used to walk the load path looking for any Ruby file present at that location that defines a class.

Closes #879

## Examples of output:

### Driver

Could not load the 'nope' driver from the load path. Did you mean: dokken, dummy, exec, proxy, vagrant ? Please ensure that your driver is installed as a gem or included in your Gemfile if using Bundler.

### Provisioner

Could not load the 'nope' provisioner from the load path. Did you mean: chef_apply, chef_solo, chef_zero, dokken, dummy, shell ? Please ensure that your provisioner is spelled correctly, installed as a gem, or is included in your Gemfile if using Bundler.

### Transport

Could not load the 'nope' transport from the load path. Did you mean: dokken, dummy, exec, ssh, winrm ? Please ensure that your transport is installed as a gem or included in your Gemfile if using Bundler.

### Verifier

Could not load the 'nope' verifier from the load path. Did you mean: busser, dummy, inspec, shell ? Please ensure that your transport is installed as a gem or included in your Gemfile if using Bundler.

## TODO

- [x] filter out known base classes that don't actually implement a full plugin