### PR TITLE
honor root_path for location of chef installer script

### DIFF
--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -503,8 +503,9 @@ module Kitchen
       end
 
       def install_from_file(command)
-        install_file = "/tmp/chef-installer.sh"
-        script = ["cat > #{install_file} <<\"EOL\""]
+        install_file = "#{config[:root_path]}/chef-installer.sh"
+        script = ["mkdir -p #{config[:root_path]}"]
+        script << "cat > #{install_file} <<\"EOL\""
         script << command
         script << "EOL"
         script << "chmod +x #{install_file}"


### PR DESCRIPTION
If `/tmp` is mounted with noexec, then the `chmod` and `sudo the_script` that are attempted later fail. Instead of hard-coding the location for the script, write and run it from the provisioner's configured
root_path.

This fixes #1364 for the code path when `product_name` is present in the Chef provisioner config.