### PR TITLE
Adds kitchen-dokken template override when driver specified

### DIFF
--- a/templates/init/kitchen-dokken.yml.erb
+++ b/templates/init/kitchen-dokken.yml.erb
@@ -1,0 +1,33 @@
+---
+driver:
+  name: dokken
+
+provisioner:
+  name: dokken
+
+transport:
+  name: dokken
+
+verifier:
+  name: inspec
+
+platforms:
+  # @see https://github.com/someara/dokken-images
+  # @see https://hub.docker.com/r/dokken/
+  - name: ubuntu-16.04
+    driver:
+      image: dokken/ubuntu-16.04
+  - name: centos-7
+    driver:
+      image: dokken/centos-7
+
+suites:
+  - name: default
+    run_list:
+<% config[:run_list].each do |recipe| -%>
+      - <%= recipe %>
+<% end -%>
+    verifier:
+      inspec_tests:
+        - test/smoke/default
+    attributes:


### PR DESCRIPTION
To provide a better experience for the kitchen dokken users it would be
helpful if there was a way to generate a kitchen configuration with more
of the fields required to make it work. As this plugin is actually several
that act in concert this may be the right approach.

It also may not be the right approach. In the situation that someone wants
to specify multiple drivers. There were also some thoughts about the `init`
command going away completely.

Perhaps this template should instead be the the default of the Chef DK.

Let's discuss.

Signed-off-by: Franklin Webber <franklin@chef.io>