### PR TITLE
Shell Provisioner: make script executable

### DIFF
--- a/lib/kitchen/provisioner/shell.rb
+++ b/lib/kitchen/provisioner/shell.rb
@@ -77,6 +77,22 @@ module Kitchen
         prefix_command(wrap_shell_code(code))
       end
 
+      # (see Base#prepare_command)
+      def prepare_command
+        # On a windows host, the supplied script does not get marked as executable
+        # due to windows not having the concept of an executable flag
+        #
+        # When the guest instance is *nix, `chmod +x` the script in the guest, prior to executing
+        return unless unix_os? && config[:script] && !config[:command]
+
+        debug "Marking script as executable"
+        script = remote_path_join(
+          config[:root_path],
+          File.basename(config[:script])
+        )
+        prefix_command(wrap_shell_code(sudo("chmod +x #{script}")))
+      end
+
       # (see Base#run_command)
       def run_command
         return prefix_command(wrap_shell_code(config[:command])) if config[:command]

--- a/lib/kitchen/provisioner/shell.rb
+++ b/lib/kitchen/provisioner/shell.rb
@@ -142,8 +142,6 @@ module Kitchen
         if config[:script]
           debug("Using script from #{config[:script]}")
           FileUtils.cp_r(config[:script], sandbox_path)
-          FileUtils.chmod(0755,
-                          File.join(sandbox_path, File.basename(config[:script])))
         else
           info("No provisioner script file specified, skipping")
         end

--- a/spec/kitchen/provisioner/shell_spec.rb
+++ b/spec/kitchen/provisioner/shell_spec.rb
@@ -520,10 +520,6 @@ describe Kitchen::Provisioner::Shell do
           provisioner.create_sandbox
 
           sandbox_path("my_script").file?.must_equal true
-          unless running_tests_on_windows?
-            # Windows doesn't have the concept of executable
-            sandbox_path("my_script").executable?.must_equal true
-          end
           IO.read(sandbox_path("my_script")).must_equal "gonuts"
         end
 


### PR DESCRIPTION
Resolves #931 and runs `chmod +x ...` in the guest, prior to executing the script

Based off of #442 but includes a guest OS check and only runs the command on *nix