### PR TITLE
Shell Verifier rewrite

### DIFF
--- a/lib/kitchen/verifier/shell.rb
+++ b/lib/kitchen/verifier/shell.rb
@@ -84,15 +84,14 @@ module Kitchen
       end
 
       def state_to_env(state)
-        env_state = { environment: {} }
-        env_state[:environment]["KITCHEN_INSTANCE"] = instance.name
-        env_state[:environment]["KITCHEN_PLATFORM"] = instance.platform.name
-        env_state[:environment]["KITCHEN_SUITE"] = instance.suite.name
-        state.each_pair do |key, value|
-          env_state[:environment]["KITCHEN_" + key.to_s.upcase] = value.to_s
-        end
-        env_state.tap do |retval|
-          retval[:environment].merge! config[:shellout_opts][:environment] || {}
+        config[:shellout_opts].to_hash.dup.tap do |env_state|
+          env_state[:environment] ||= {}
+          env_state[:environment]["KITCHEN_INSTANCE"] = instance.name
+          env_state[:environment]["KITCHEN_PLATFORM"] = instance.platform.name
+          env_state[:environment]["KITCHEN_SUITE"] = instance.suite.name
+          state.each_pair do |key, value|
+            env_state[:environment]["KITCHEN_" + key.to_s.upcase] = value.to_s
+          end
         end
       end
     end

--- a/lib/kitchen/verifier/shell.rb
+++ b/lib/kitchen/verifier/shell.rb
@@ -73,7 +73,7 @@ module Kitchen
 
       def shellout_opts
         config[:shellout_opts].dup.tap do |options|
-          options[:environment] = merged_environment.merge(options[:environment]) if options.key? :environment
+          options[:environment] = merged_environment.merge(options[:environment] || {})
         end
       end
 
@@ -90,7 +90,7 @@ module Kitchen
 
       def remote_command
         command = "env"
-        merged_environment.each { |k, v| command << " #{k}='#{v.gsub("'", "\\\\'")}'" }
+        merged_environment.each { |k, v| command << " #{k}='#{v.gsub("'", "'\"'\"'")}'" }
         command << " " << config[:command]
       end
 

--- a/spec/kitchen/verifier/shell_spec.rb
+++ b/spec/kitchen/verifier/shell_spec.rb
@@ -84,13 +84,17 @@ describe Kitchen::Verifier::Shell do
         state[:hostname] = "testhost"
         state[:server_id] = "i-xxxxxx"
         state[:port] = 22
-        new_opts = verifier.send :state_to_env, state
+        config[:shellout_opts] = {}
+        config[:shellout_opts][:environment] = { FOO: "bar" }
+
+        new_opts = verifier.send :merge_state_to_env, state
         new_opts[:environment]["KITCHEN_HOSTNAME"].must_equal "testhost"
         new_opts[:environment]["KITCHEN_SERVER_ID"].must_equal "i-xxxxxx"
         new_opts[:environment]["KITCHEN_PORT"].must_equal "22"
         new_opts[:environment]["KITCHEN_INSTANCE"].must_equal "coolbeans-fries"
         new_opts[:environment]["KITCHEN_PLATFORM"].must_equal "coolbeans"
         new_opts[:environment]["KITCHEN_SUITE"].must_equal "fries"
+        new_opts[:environment][:FOO].must_equal "bar"
       end
 
       it "raises ActionFailed if set false to :command" do
@@ -141,17 +145,6 @@ describe Kitchen::Verifier::Shell do
         transport.expects(:connection).with(state).yields(connection)
         verifier.call(state)
       end
-    end
-  end
-
-  describe "#run_command" do
-    it "execute localy and returns nil" do
-      verifier.run_command
-    end
-
-    it "returns string when remote_exec" do
-      config[:remote_exec] = true
-      verifier.run_command.must_equal "true"
     end
   end
 end

--- a/spec/kitchen/verifier/shell_spec.rb
+++ b/spec/kitchen/verifier/shell_spec.rb
@@ -151,6 +151,7 @@ describe Kitchen::Verifier::Shell do
       before do
         transport.stubs(:connection).yields(connection)
         connection.stubs(:execute)
+        connection.stubs(:upload)
 
         config[:remote_exec] = true
       end
@@ -165,8 +166,8 @@ describe Kitchen::Verifier::Shell do
 
         verifier.call(state)
         command = verifier.send :remote_command
-        command.must_match(/^env.* FOO='it'"'"'s escaped!' .*#{config[:command]}$/)
-        command.must_match(/^env.* TEST_KITCHEN='1' .*#{config[:command]}$/)
+        command.must_match(/env.* FOO='it'"'"'s escaped!' .*#{config[:command]}/)
+        command.must_match(/env.* TEST_KITCHEN='1' .*#{config[:command]}/)
       end
 
       it "raises ActionFailed if set false to :command" do

--- a/spec/kitchen/verifier/shell_spec.rb
+++ b/spec/kitchen/verifier/shell_spec.rb
@@ -165,7 +165,7 @@ describe Kitchen::Verifier::Shell do
 
         verifier.call(state)
         command = verifier.send :remote_command
-        command.must_match(/^env.* FOO='it\\'s escaped!' .*#{config[:command]}$/)
+        command.must_match(/^env.* FOO='it'"'"'s escaped!' .*#{config[:command]}$/)
         command.must_match(/^env.* TEST_KITCHEN='1' .*#{config[:command]}$/)
       end
 

--- a/spec/kitchen/verifier/shell_spec.rb
+++ b/spec/kitchen/verifier/shell_spec.rb
@@ -84,13 +84,13 @@ describe Kitchen::Verifier::Shell do
         state[:hostname] = "testhost"
         state[:server_id] = "i-xxxxxx"
         state[:port] = 22
-        verifier.call(state)
-        config[:shellout_opts][:environment]["KITCHEN_HOSTNAME"].must_equal "testhost"
-        config[:shellout_opts][:environment]["KITCHEN_SERVER_ID"].must_equal "i-xxxxxx"
-        config[:shellout_opts][:environment]["KITCHEN_PORT"].must_equal "22"
-        config[:shellout_opts][:environment]["KITCHEN_INSTANCE"].must_equal "coolbeans-fries"
-        config[:shellout_opts][:environment]["KITCHEN_PLATFORM"].must_equal "coolbeans"
-        config[:shellout_opts][:environment]["KITCHEN_SUITE"].must_equal "fries"
+        new_opts = verifier.send :state_to_env, state
+        new_opts[:environment]["KITCHEN_HOSTNAME"].must_equal "testhost"
+        new_opts[:environment]["KITCHEN_SERVER_ID"].must_equal "i-xxxxxx"
+        new_opts[:environment]["KITCHEN_PORT"].must_equal "22"
+        new_opts[:environment]["KITCHEN_INSTANCE"].must_equal "coolbeans-fries"
+        new_opts[:environment]["KITCHEN_PLATFORM"].must_equal "coolbeans"
+        new_opts[:environment]["KITCHEN_SUITE"].must_equal "fries"
       end
 
       it "raises ActionFailed if set false to :command" do

--- a/spec/kitchen/verifier/shell_spec.rb
+++ b/spec/kitchen/verifier/shell_spec.rb
@@ -84,17 +84,26 @@ describe Kitchen::Verifier::Shell do
         state[:hostname] = "testhost"
         state[:server_id] = "i-xxxxxx"
         state[:port] = 22
-        config[:shellout_opts] = {}
-        config[:shellout_opts][:environment] = { FOO: "bar" }
 
-        new_opts = verifier.send :merge_state_to_env, state
-        new_opts[:environment]["KITCHEN_HOSTNAME"].must_equal "testhost"
-        new_opts[:environment]["KITCHEN_SERVER_ID"].must_equal "i-xxxxxx"
-        new_opts[:environment]["KITCHEN_PORT"].must_equal "22"
-        new_opts[:environment]["KITCHEN_INSTANCE"].must_equal "coolbeans-fries"
-        new_opts[:environment]["KITCHEN_PLATFORM"].must_equal "coolbeans"
-        new_opts[:environment]["KITCHEN_SUITE"].must_equal "fries"
-        new_opts[:environment][:FOO].must_equal "bar"
+        verifier.call(state)
+        new_env = verifier.send :merged_environment
+        new_env["KITCHEN_HOSTNAME"].must_equal "testhost"
+        new_env["KITCHEN_SERVER_ID"].must_equal "i-xxxxxx"
+        new_env["KITCHEN_PORT"].must_equal "22"
+        new_env["KITCHEN_INSTANCE"].must_equal "coolbeans-fries"
+        new_env["KITCHEN_PLATFORM"].must_equal "coolbeans"
+        new_env["KITCHEN_SUITE"].must_equal "fries"
+      end
+
+      it "includes all environment sources" do
+        config[:environment] = { FOO: "bar" }
+        config[:shellout_opts] = { environment: { FOOBAR: "foobar" } }
+
+        verifier.call(state)
+        new_env = verifier.send(:shellout_opts)[:environment]
+        new_env["KITCHEN_INSTANCE"].must_equal "coolbeans-fries"
+        new_env[:FOO].must_equal "bar"
+        new_env[:FOOBAR].must_equal "foobar"
       end
 
       it "raises ActionFailed if set false to :command" do


### PR DESCRIPTION
Signed-off-by: Sean Zachariasen <thewyzard@hotmail.com>

Addressing #1209

This one needs some love.  This initial commit makes the options merge correctly, but the rest of the verifier needs touched up in some surrounding areas.  There's incongruity between 2 different methods of local execution and no effort has been applied by the OA to make sure the environment gets applied when running remotely