### PR TITLE
post_create_command for executing arbitrary commands after create action

### DIFF
--- a/lib/kitchen/driver/base.rb
+++ b/lib/kitchen/driver/base.rb
@@ -150,6 +150,18 @@ module Kitchen
         end
       end
 
+      # Run command if config[:post_create_command] is set
+      def post_create_command
+        if config[:post_create_command]
+          begin
+            run_command(config[:post_create_command])
+          rescue ShellCommandFailed => error
+            raise ActionFailed,
+              "post_create_command '#{config[:post_create_command]}' failed to execute #{error}"
+          end
+        end
+      end
+
       # Intercepts any bare #puts calls in subclasses and issues an INFO log
       # event instead.
       #

--- a/lib/kitchen/driver/base.rb
+++ b/lib/kitchen/driver/base.rb
@@ -30,6 +30,7 @@ module Kitchen
       include ShellOut
 
       default_config :pre_create_command, nil
+      default_config :post_create_command, nil
 
       # Creates a new Driver object using the provided configuration data
       # which will be merged with any default configuration.

--- a/spec/kitchen/driver/base_spec.rb
+++ b/spec/kitchen/driver/base_spec.rb
@@ -106,6 +106,24 @@ describe Kitchen::Driver::Base do
     end
   end
 
+  describe ".post_create_command" do
+    it "run command" do
+      Kitchen::Driver::Base.any_instance.stubs(:run_command).returns(true)
+
+      config[:post_create_command] = "echo works 2&>1 > /dev/null"
+      driver.expects(:run_command).with("echo works 2&>1 > /dev/null")
+      driver.send(:post_create_command)
+    end
+
+    it "error if cannot run" do
+      class ShellCommandFailed < Kitchen::ShellOut::ShellCommandFailed; end
+      Kitchen::Driver::Base.any_instance.stubs(:run_command).raises(ShellCommandFailed, "Expected process to exit with [0], but received '1'")
+
+      config[:post_create_command] = "touch /this/dir/does/not/exist 2&>1 > /dev/null"
+      proc { driver.send(:post_create_command) }.must_raise Kitchen::ActionFailed
+    end
+  end
+
   describe ".no_parallel_for" do
     it "registers no serial actions when none are declared" do
       Kitchen::Driver::Speedy.serial_actions.must_be_nil


### PR DESCRIPTION
Hello!

I thought Test Kitchen might need this.

I haven't wrote any Ruby in a few years. So, forgive my lack of incite. This is basically copy/paste from the `pre_create_command` hook.

I have used this successfully through the `kitchen-google` driver. See [blbradley/kitchen-google@hook-post_create_command](https://github.com/blbradley/kitchen-google/tree/hook-post_create_command).