### PR TITLE
🚧 WIP: adds sending telemetry on TK actions 🚧

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,8 @@ gemspec
 
 gem "train", "~> 0.22"
 
+gem "chef-telemetry", git: "https://github.com/thommay/chef-telemetry.git"
+
 group :integration do
   gem "berkshelf"
   gem "kitchen-inspec"

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gemspec
 
 gem "train", "~> 0.22"
 
-gem "chef-telemetry", git: "https://github.com/thommay/chef-telemetry.git"
+gem "chef-telemetry", git: "https://github.com/chef/chef-telemetry.git"
 
 group :integration do
   gem "berkshelf"

--- a/lib/kitchen.rb
+++ b/lib/kitchen.rb
@@ -24,6 +24,7 @@ require "kitchen/logger"
 require "kitchen/logging"
 require "kitchen/shell_out"
 require "kitchen/configurable"
+require "kitchen/telemetry"
 require "kitchen/util"
 
 require "kitchen/provisioner"

--- a/lib/kitchen.rb
+++ b/lib/kitchen.rb
@@ -24,7 +24,7 @@ require "kitchen/logger"
 require "kitchen/logging"
 require "kitchen/shell_out"
 require "kitchen/configurable"
-require "kitchen/telemetry"
+require "kitchen/telemeter"
 require "kitchen/util"
 
 require "kitchen/provisioner"

--- a/lib/kitchen/cli.rb
+++ b/lib/kitchen/cli.rb
@@ -47,6 +47,9 @@ module Kitchen
           shell: shell,
         }.merge(additional_options)
 
+        event = { event: "command-line", properties: { action: task, class: command, args: args } }
+        Kitchen::Telemetry.send(event)
+
         str_const = Thor::Util.camel_case(command)
         klass = ::Kitchen::Command.const_get(str_const)
         klass.new(args, options, command_options).call

--- a/lib/kitchen/cli.rb
+++ b/lib/kitchen/cli.rb
@@ -48,11 +48,11 @@ module Kitchen
         }.merge(additional_options)
 
         event = { event: "command-line", properties: { action: task, class: command, args: args } }
-        Kitchen::Telemetry.send(event)
-
-        str_const = Thor::Util.camel_case(command)
-        klass = ::Kitchen::Command.const_get(str_const)
-        klass.new(args, options, command_options).call
+        Kitchen::Telemeter.measure_elapsed_time(event) do
+          str_const = Thor::Util.camel_case(command)
+          klass = ::Kitchen::Command.const_get(str_const)
+          klass.new(args, options, command_options).call
+        end
       end
     end
 

--- a/lib/kitchen/configurable.rb
+++ b/lib/kitchen/configurable.rb
@@ -133,6 +133,16 @@ module Kitchen
       result
     end
 
+    # Returns a Hash of useful information for telemetry
+    #
+    # @return [Hash] a hash of interesting stuff
+    def telemetry
+      {
+        driver_name: name,
+        driver_version: self.class.version,
+      }
+    end
+
     # Returns the name of this plugin, suitable for display in a CLI.
     #
     # @return [String] name of this plugin
@@ -419,6 +429,9 @@ module Kitchen
         @plugin_version = version
       end
 
+      def version
+        @plugin_version
+      end
       # Returns a Hash of configuration and other useful diagnostic
       # information.
       #

--- a/lib/kitchen/configurable.rb
+++ b/lib/kitchen/configurable.rb
@@ -138,8 +138,8 @@ module Kitchen
     # @return [Hash] a hash of interesting stuff
     def telemetry
       {
-        driver_name: name,
-        driver_version: self.class.version,
+        plugin_name: name,
+        plugin_version: self.class.version,
       }
     end
 

--- a/lib/kitchen/configurable.rb
+++ b/lib/kitchen/configurable.rb
@@ -432,6 +432,7 @@ module Kitchen
       def version
         @plugin_version
       end
+
       # Returns a Hash of configuration and other useful diagnostic
       # information.
       #

--- a/lib/kitchen/instance.rb
+++ b/lib/kitchen/instance.rb
@@ -18,6 +18,7 @@
 
 require "benchmark"
 require "fileutils"
+require "kitchen/telemetry"
 
 module Kitchen
   # An instance of a suite running on a platform. A created instance may be a
@@ -376,6 +377,7 @@ module Kitchen
     # @return [self] this instance, used to chain actions
     # @api private
     def create_action
+      Kitchen::Telemetry.send(event: "create", properties: driver.telemetry)
       perform_action(:create, "Creating")
     end
 

--- a/lib/kitchen/telemetry.rb
+++ b/lib/kitchen/telemetry.rb
@@ -42,7 +42,7 @@ module Kitchen
     def send(data = {})
       data[:properties][:host] = host
       data[:properties][:version] = version
-      @telemetry.send(data)
+      @telemetry.deliver(data)
     end
 
     class << self

--- a/lib/kitchen/telemetry.rb
+++ b/lib/kitchen/telemetry.rb
@@ -1,0 +1,53 @@
+#
+# Copyright:: Copyright (c) 2017 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "telemetry"
+require "singleton"
+require "forwardable"
+
+module Kitchen
+  class Telemetry
+    include Singleton
+
+    def initialize
+      @telemetry = ::Telemetry.new(product: "test-kitchen", origin: "command-line")
+    end
+
+    def version
+      Kitchen::VERSION
+    end
+
+    def host
+      @host ||= case RUBY_PLATFORM
+                when /mswin|mingw|windows/
+                  "windows"
+                else
+                  RUBY_PLATFORM.split("-")[1]
+                end
+    end
+
+    def send(data = {})
+      data[:properties][:host] = host
+      data[:properties][:version] = version
+      @telemetry.send(data)
+    end
+
+    class << self
+      extend Forwardable
+      def_delegators :instance, :send
+    end
+  end
+end

--- a/spec/kitchen/instance_spec.rb
+++ b/spec/kitchen/instance_spec.rb
@@ -57,6 +57,8 @@ class SerialDummyDriver < Kitchen::Driver::Dummy
 
   attr_reader :action_in_mutex
 
+  plugin_version Kitchen::VERSION
+
   def initialize(config = {})
     super(config)
     @action_in_mutex = {}
@@ -80,6 +82,8 @@ end
 
 class LegacyDriver < Kitchen::Driver::SSHBase
   attr_reader :called_converge, :called_setup, :called_verify
+
+  plugin_version Kitchen::VERSION
 
   def converge(_)
     @called_converge

--- a/test-kitchen.gemspec
+++ b/test-kitchen.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "net-ssh-gateway", "~> 1.2"
   gem.add_dependency "thor",            "~> 0.19", "< 0.19.2"
   gem.add_dependency "chef-telemetry"
-  gem.add_dependency "mixlib-install",  "~> 3.6"
+  gem.add_dependency "mixlib-install", "~> 3.6"
   gem.add_dependency "winrm", "~> 2.0"
   gem.add_dependency "winrm-elevated", "~> 1.0"
   gem.add_dependency "winrm-fs", "~> 1.1.0"

--- a/test-kitchen.gemspec
+++ b/test-kitchen.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "net-ssh", ">= 2.9", "< 5.0"
   gem.add_dependency "net-ssh-gateway", "~> 1.2"
   gem.add_dependency "thor",            "~> 0.19", "< 0.19.2"
+  gem.add_dependency "chef-telemetry"
   gem.add_dependency "mixlib-install",  "~> 3.6"
   gem.add_dependency "winrm", "~> 2.0"
   gem.add_dependency "winrm-elevated", "~> 1.0"


### PR DESCRIPTION
🚧 Work In Progress 🚧

Adds the transmission of telemetry to a designated host based on [Chef RFC 95](https://github.com/chef/chef-rfc/blob/master/rfc095-test-kitchen-telemetry.md).

Current implementation wraps the high-level CLI command and each action that command triggers in a timer to send data to a data collector.

### TODO

- [ ] interaction with the user to select opt-in/opt-out
- [ ] notification to the user on opt-in/out status during a run
- [ ] identify a way to log telemetry messages sent so that the user has an opportunity to review