### PR TITLE
Revert "honor root_path for location of chef installer script"

### DIFF
--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -503,9 +503,8 @@ module Kitchen
       end
 
       def install_from_file(command)
-        install_file = "#{config[:root_path]}/chef-installer.sh"
-        script = ["mkdir -p #{config[:root_path]}"]
-        script << "cat > #{install_file} <<\"EOL\""
+        install_file = "/tmp/chef-installer.sh"
+        script = ["cat > #{install_file} <<\"EOL\""]
         script << command
         script << "EOL"
         script << "chmod +x #{install_file}"


### PR DESCRIPTION
Given https://github.com/test-kitchen/test-kitchen/issues/1402 it's clear we need to think a bit more about fix and also consider that dokken, which we use in Travis testing, didn't catch this since it's not code it executes.

Reverts test-kitchen/test-kitchen#1369