### PR TITLE
Add a pre_install_command to the base provisioner.

### DIFF
--- a/lib/kitchen/provisioner/base.rb
+++ b/lib/kitchen/provisioner/base.rb
@@ -45,6 +45,8 @@ module Kitchen
         provisioner.windows_os? ? nil : "sudo -E"
       end
 
+      default_config :pre_install_command, nil
+
       default_config :command_prefix, nil
 
       default_config :downloads, {}
@@ -68,6 +70,8 @@ module Kitchen
         sandbox_dirs = Util.list_directory(sandbox_path)
 
         instance.transport.connection(state) do |conn|
+          info("Initializing provisioner on #{instance.to_str}")
+          conn.execute(pre_install_command)
           conn.execute(install_command)
           conn.execute(init_command)
           info("Transferring files to #{instance.to_str}")
@@ -99,6 +103,16 @@ module Kitchen
       # @returns [Boolean] Return true if a problem is found.
       def doctor(state)
         false
+      end
+
+      # Generates a command string which will run on an instance prior to the
+      # install_command. By default this comes from
+      # `config[:pre_install_command]`, allowing users to customize provisioner
+      # bootstrapping steps. If no work is required, then return `nil`.
+      #
+      # @return [String, nil] a command string
+      def pre_install_command
+        config[:pre_install_command]
       end
 
       # Generates a command string which will install and configure the

--- a/spec/kitchen/provisioner/base_spec.rb
+++ b/spec/kitchen/provisioner/base_spec.rb
@@ -156,6 +156,7 @@ describe Kitchen::Provisioner::Base do
         ["/tmp/kitchen/nodes", "/tmp/kitchen/data_bags"] => "./test/fixtures",
         "/remote" => "/local",
       }
+      config[:pre_install_command] = "pre-install"
     end
 
     after do
@@ -188,6 +189,7 @@ describe Kitchen::Provisioner::Base do
 
     it "invokes the provisioner commands over the transport" do
       order = sequence("order")
+      connection.expects(:execute).with("pre-install").in_sequence(order)
       connection.expects(:execute).with("install").in_sequence(order)
       connection.expects(:execute).with("init").in_sequence(order)
       connection.expects(:execute).with("prepare").in_sequence(order)
@@ -250,7 +252,7 @@ describe Kitchen::Provisioner::Base do
     end
   end
 
-  [:init_command, :install_command, :prepare_command, :run_command].each do |cmd|
+  [:init_command, :pre_install_command, :install_command, :prepare_command, :run_command].each do |cmd|
     it "has a #{cmd} method" do
       provisioner.public_send(cmd).must_be_nil
     end


### PR DESCRIPTION
This is useful for addressing any kind of bootstrapping problem that
might occur prior to provisioner installation requiring custom code.

For example, it is often useful to coordinate the provisioner
installation with actions that start at boot on an instance via some
kind of init system (e.g. systemd, cloud-init).

Users can by default add a "pre_install_command" script to the kitchen.yml with any commands necessary to run prior to installing the provisioner.

This example pauses the provisioner until systemd has finished booting the instance:

```yaml
provisioner:
  name: chef_zero
  pre_install_command: "while ! systemctl is-system-running; do echo Waiting for system boot to finish; sleep 15; done"
```

If this functionality isn't appropriate for provisioner subclasses, they can override `pre_install_command()` to change the behavior.

Somewhat related to #1385 