### PR TITLE
Stop calling the Chef packages omnibus packages

### DIFF
--- a/spec/kitchen/provisioner/chef_solo_spec.rb
+++ b/spec/kitchen/provisioner/chef_solo_spec.rb
@@ -367,7 +367,7 @@ describe Kitchen::Provisioner::ChefSolo do
                                         ])
       end
 
-      it "does no powershell PATH reloading for older chef omnibus packages" do
+      it "does no powershell PATH reloading for older chef packages" do
         cmd.wont_match regexify(%{[System.Environment]::})
       end
 
@@ -520,7 +520,7 @@ describe Kitchen::Provisioner::ChefSolo do
                                         ])
       end
 
-      it "reloads PATH for older chef omnibus packages" do
+      it "reloads PATH for older chef packages" do
         cmd.must_match regexify("$env:PATH = try {\n" \
         "[System.Environment]::GetEnvironmentVariable('PATH','Machine')\n" \
         "} catch { $env:PATH }")

--- a/spec/kitchen/provisioner/chef_zero_spec.rb
+++ b/spec/kitchen/provisioner/chef_zero_spec.rb
@@ -754,7 +754,7 @@ describe Kitchen::Provisioner::ChefZero do
                                           ])
         end
 
-        it "does no powershell PATH reloading for older chef omnibus packages" do
+        it "does no powershell PATH reloading for older chef packages" do
           cmd.wont_match regexify(%{[System.Environment]::})
         end
 
@@ -829,7 +829,7 @@ describe Kitchen::Provisioner::ChefZero do
                                           ])
         end
 
-        it "reloads PATH for older chef omnibus packages" do
+        it "reloads PATH for older chef packages" do
           cmd.must_match regexify("$env:PATH = try {\n" \
           "[System.Environment]::GetEnvironmentVariable('PATH','Machine')\n" \
           "} catch { $env:PATH }")
@@ -934,7 +934,7 @@ describe Kitchen::Provisioner::ChefZero do
             %{GEM_CACHE="/r/chef-client-zero-gems/cache"; export GEM_CACHE})
         end
 
-        it "does no powershell PATH reloading for older chef omnibus packages" do
+        it "does no powershell PATH reloading for older chef packages" do
           cmd.wont_match regexify(%{[System.Environment]::})
         end
       end
@@ -988,7 +988,7 @@ describe Kitchen::Provisioner::ChefZero do
             %{$env:GEM_CACHE = "\\r\\chef-client-zero-gems\\cache"})
         end
 
-        it "reloads PATH for older chef omnibus packages" do
+        it "reloads PATH for older chef packages" do
           cmd.must_match regexify("$env:PATH = try {\n" \
           "[System.Environment]::GetEnvironmentVariable('PATH','Machine')\n" \
           "} catch { $env:PATH }")

--- a/support/chef_base_install_command.ps1
+++ b/support/chef_base_install_command.ps1
@@ -44,7 +44,7 @@ Function Download-Chef($md_url, $dst) {
 }
 
 Function Install-Chef($msi) {
-  Log "Installing Chef Omnibus package $msi"
+  Log "Installing Chef package $msi"
   $p = Start-Process -FilePath "msiexec.exe" -ArgumentList "/qn /i $msi" -Passthru -Wait
 
   if ($p.ExitCode -ne 0) { throw "msiexec was not successful. Received exit code $($p.ExitCode)" }
@@ -73,11 +73,11 @@ Try {
   $msi = Unresolve-Path $msi
 
   if (Check-UpdateChef $chef_omnibus_root $version) {
-    Write-Host "-----> Installing Chef Omnibus ($pretty_version)`n"
+    Write-Host "-----> Installing Chef package ($pretty_version)`n"
     Download-Chef "$chef_metadata_url" $msi
     Install-Chef $msi
   } else {
-    Write-Host "-----> Chef Omnibus installation detected ($pretty_version)`n"
+    Write-Host "-----> Chef package installation detected ($pretty_version)`n"
 }
 Catch {
   Write-Error ($_ | ft -Property * | out-string) -ErrorAction Continue

--- a/support/chef_base_install_command.sh
+++ b/support/chef_base_install_command.sh
@@ -206,7 +206,7 @@ unable_to_download() {
 main() {
   should_update_chef "$chef_omnibus_root" "$version"
   if test $? -eq 0; then
-    echo "-----> Installing Chef Omnibus (${pretty_version})";
+    echo "-----> Installing Chef package (${pretty_version})";
 
     # solaris 10 lacks recent enough credentials, so http url is used
     platform="`/usr/bin/uname -s 2>/dev/null`";
@@ -218,7 +218,7 @@ main() {
     do_download "$chef_omnibus_url" /tmp/install.sh;
     $sudo_sh /tmp/install.sh $install_flags;
   else
-    echo "-----> Chef Omnibus installation detected (${pretty_version})";
+    echo "-----> Chef package installation detected (${pretty_version})";
   fi
 }
 


### PR DESCRIPTION
This hasn't meant a thing to our end users for YEARS. We've started removing all the references to Omnibus from our docs and we should do the same here. It makes it much more clear what's being installed and it's one less new term users need to try to wrap their heads around for no real reason.

Signed-off-by: Tim Smith <tsmith@chef.io>