### PR TITLE
using preferred config name for list output

### DIFF
--- a/lib/kitchen/loader/yaml.rb
+++ b/lib/kitchen/loader/yaml.rb
@@ -62,7 +62,7 @@ module Kitchen
       # @return [Hash] merged configuration data
       def read
         unless File.exist?(config_file)
-          raise UserError, "Kitchen YAML file #{kitchen_yml} does not exist."
+          raise UserError, "Kitchen YAML file #{config_file} does not exist."
         end
 
         Util.symbolized_hash(combined_hash)

--- a/lib/kitchen/loader/yaml.rb
+++ b/lib/kitchen/loader/yaml.rb
@@ -196,7 +196,7 @@ module Kitchen
           raise UserError, "Both #{kitchen_yml} and #{dot_kitchen_yml} found. Please use the un-dotted variant: #{kitchen_yml}."
         end
 
-        unless File.exist?(kitchen_yml) && File.exist?(dot_kitchen_yml)
+        if !File.exist?(kitchen_yml) && !File.exist?(dot_kitchen_yml)
           return kitchen_yml
         end
 
@@ -225,11 +225,12 @@ module Kitchen
 
         undot_config = default_local_config.sub(/^\./, "")
         dot_config = ".#{undot_config}"
+
         if File.exist?(File.join(config_dir, undot_config)) && File.exist?(File.join(config_dir, dot_config))
           raise UserError, "Both #{undot_config} and #{dot_config} found in #{config_dir}. Please use #{default_local_config} which matches your #{config_file}."
         end
 
-        File.join(config_dir, default_local_config)
+        File.exist?(File.join(config_dir, dot_config)) ? File.join(config_dir, dot_config) : File.join(config_dir, undot_config)
       end
 
       # Determines the default absolute path to the Kitchen global YAML file,

--- a/lib/kitchen/loader/yaml.rb
+++ b/lib/kitchen/loader/yaml.rb
@@ -196,6 +196,10 @@ module Kitchen
           raise UserError, "Both #{kitchen_yml} and #{dot_kitchen_yml} found. Please use the un-dotted variant: #{kitchen_yml}."
         end
 
+        unless File.exist?(kitchen_yml) && File.exist?(dot_kitchen_yml)
+          kitchen_yml
+        end
+
         File.exist?(kitchen_yml) ? kitchen_yml : dot_kitchen_yml
       end
 

--- a/lib/kitchen/loader/yaml.rb
+++ b/lib/kitchen/loader/yaml.rb
@@ -62,7 +62,7 @@ module Kitchen
       # @return [Hash] merged configuration data
       def read
         unless File.exist?(config_file)
-          raise UserError, "Kitchen YAML file #{config_file} does not exist."
+          raise UserError, "Kitchen YAML file #{kitchen_yml} does not exist."
         end
 
         Util.symbolized_hash(combined_hash)

--- a/lib/kitchen/loader/yaml.rb
+++ b/lib/kitchen/loader/yaml.rb
@@ -197,7 +197,7 @@ module Kitchen
         end
 
         unless File.exist?(kitchen_yml) && File.exist?(dot_kitchen_yml)
-          kitchen_yml
+          return kitchen_yml
         end
 
         File.exist?(kitchen_yml) ? kitchen_yml : dot_kitchen_yml

--- a/spec/kitchen/loader/yaml_spec.rb
+++ b/spec/kitchen/loader/yaml_spec.rb
@@ -496,6 +496,7 @@ describe Kitchen::Loader::YAML do
     end
 
     it "skips evaluating kitchen.local.yml through erb if disabled" do
+      stub_file("/tmp/.kitchen.local.yml", {})
       loader = Kitchen::Loader::YAML.new(
         project_config: "/tmp/.kitchen.yml", process_erb: false)
       FileUtils.mkdir_p "/tmp"

--- a/spec/kitchen/loader/yaml_spec.rb
+++ b/spec/kitchen/loader/yaml_spec.rb
@@ -72,14 +72,6 @@ describe Kitchen::Loader::YAML do
       proc { Kitchen::Loader::YAML.new }.must_raise Kitchen::UserError
     end
 
-    it "#read raises Kitchen::UserError when config_file doesn't exist" do
-      loader = proc {
-        yaml = Kitchen::Loader::YAML.new
-        yaml.read
-      }
-      loader.must_raise Kitchen::UserError
-    end
-
     it "sets project_config from parameter, if given" do
       stub_file("/tmp/crazyfunkytown.file", {})
       loader = Kitchen::Loader::YAML.new(

--- a/spec/kitchen/loader/yaml_spec.rb
+++ b/spec/kitchen/loader/yaml_spec.rb
@@ -72,6 +72,14 @@ describe Kitchen::Loader::YAML do
       proc { Kitchen::Loader::YAML.new }.must_raise Kitchen::UserError
     end
 
+    it "#read raises Kitchen::UserError when config_file doesn't exist" do
+      loader = proc {
+        yaml = Kitchen::Loader::YAML.new
+        yaml.read
+      }
+      loader.must_raise Kitchen::UserError
+    end
+
     it "sets project_config from parameter, if given" do
       stub_file("/tmp/crazyfunkytown.file", {})
       loader = Kitchen::Loader::YAML.new(


### PR DESCRIPTION
when config_file doesn't exist, say that kitchen_yml doesn't exist, adding test to check for raised exception when read is used without a config file existing

fixes #1423