### PR TITLE
Improve environment variables in lifecycle hooks

### DIFF
--- a/lib/kitchen/lifecycle_hooks.rb
+++ b/lib/kitchen/lifecycle_hooks.rb
@@ -91,8 +91,11 @@ module Kitchen
         "KITCHEN_INSTANCE_NAME" => instance.name,
         "KITCHEN_SUITE_NAME" => instance.suite.name,
         "KITCHEN_PLATFORM_NAME" => instance.platform.name,
-        "KITCHEN_INSTANCE_HOSTNAME" => state[:hostname].to_s,
       }
+      # Make state also available through the environment
+      state.each_pair do |k, v|
+        environment["KITCHEN_INSTANCE_#{k.to_s.upcase}"] = v.to_s
+      end
       # If the user specified env vars too, fix them up because symbol keys
       # make mixlib-shellout sad.
       if hook[:environment]


### PR DESCRIPTION
Let populate whole state via KITCHEN_INSTACE_variable. For example,
with vagrant driver you will get the following variables:

* KITCHEN_INSTANCE_HOSTNAME
* KITCHEN_INSTANCE_PORT
* KITCHEN_INSTANCE_USERNAME
* KITCHEN_INSTANCE_SSH_KEY
* KITCHEN_INSTANCE_LAST_ACTION
* KITCHEN_INSTANCE_LAST_ERROR