### PR TITLE
Catch 'Operation already in progress' as seen on Ubuntu on WSL

### DIFF
--- a/lib/kitchen/transport/ssh.rb
+++ b/lib/kitchen/transport/ssh.rb
@@ -229,7 +229,7 @@ module Kitchen
         PING_COMMAND = "echo '[SSH] Established'".freeze
 
         RESCUE_EXCEPTIONS_ON_ESTABLISH = [
-          Errno::EACCES, Errno::EADDRINUSE, Errno::ECONNREFUSED, Errno::ETIMEDOUT,
+          Errno::EACCES, Errno::EALREADY, Errno::EADDRINUSE, Errno::ECONNREFUSED, Errno::ETIMEDOUT,
           Errno::ECONNRESET, Errno::ENETUNREACH, Errno::EHOSTUNREACH, Errno::EPIPE,
           Net::SSH::Disconnect, Net::SSH::AuthenticationFailed, Net::SSH::ConnectionTimeout,
           Timeout::Error

--- a/spec/kitchen/transport/ssh_spec.rb
+++ b/spec/kitchen/transport/ssh_spec.rb
@@ -695,8 +695,8 @@ describe Kitchen::Transport::Ssh::Connection do
 
   describe "establishing a connection" do
     [
-      Errno::EACCES, Errno::EADDRINUSE, Errno::ECONNREFUSED, Errno::ETIMEDOUT,
-      Errno::ECONNRESET, Errno::ENETUNREACH, Errno::EHOSTUNREACH,
+      Errno::EACCES, Errno::EALREADY, Errno::EADDRINUSE, Errno::ECONNREFUSED, Errno::ETIMEDOUT,
+      Errno::ECONNRESET, Errno::ENETUNREACH, Errno::EHOSTUNREACH, Errno::EPIPE,
       Net::SSH::Disconnect, Net::SSH::AuthenticationFailed, Net::SSH::ConnectionTimeout,
       Timeout::Error
     ].each do |klass|


### PR DESCRIPTION
Issue:
```
Waiting for SSH service on 10.0.0.165:22, retrying in 3 seconds
Waiting for SSH service on 10.0.0.165:22, retrying in 3 seconds
Waiting for SSH service on 10.0.0.165:22, retrying in 3 seconds
Errno::EALREADY: Operation already in progress - connect(2) for 10.0.0.165:22
```

Adding `Errno::EALREADY` to the rescue'ables for retry seems to make it go away.

Probably some type of race condition -- [This issue seems very similar.](https://github.com/celluloid/celluloid/issues/436)

Signed-off-by: Brian Dwyer <brian.dwyer@broadridge.com>