### PR TITLE
[SHACK-295] ChefDK 2.x uses an old version of net-ssh

### DIFF
--- a/lib/kitchen/generator/init.rb
+++ b/lib/kitchen/generator/init.rb
@@ -18,6 +18,7 @@
 
 require "rubygems/gem_runner"
 require "thor/group"
+require "kitchen"
 
 module Kitchen
   module Generator

--- a/lib/kitchen/transport/ssh.rb
+++ b/lib/kitchen/transport/ssh.rb
@@ -517,11 +517,15 @@ module Kitchen
       # net-ssh to ~> 4.2, this will prevent InSpec from being used in
       # Chef v12 because of it pinning to a v3 of net-ssh.
       #
-      def verify_host_key_option
+      def self.verify_host_key_option
         current_net_ssh = Net::SSH::Version::CURRENT
         new_option_version = Net::SSH::Version[4, 2, 0]
 
         current_net_ssh >= new_option_version ? :verify_host_key : :paranoid
+      end
+
+      def verify_host_key_option
+        self.class.verify_host_key_option
       end
 
       # Creates a new SSH Connection instance and save it for potential future

--- a/spec/kitchen/transport/ssh_spec.rb
+++ b/spec/kitchen/transport/ssh_spec.rb
@@ -188,8 +188,9 @@ describe Kitchen::Transport::Ssh do
       end
 
       it "sets the :verify_host_key flag to false" do
+        verify_host_key_option = Kitchen::Transport::Ssh.verify_host_key_option
         klass.expects(:new).with do |hash|
-          hash[:verify_host_key] == false
+          hash[verify_host_key_option] == false
         end
 
         make_connection


### PR DESCRIPTION
So we need to update these tests to account for that if we want to use
this version of TK in ChefDK 2.x.

Also added a missing require that is causing failing tests from within
'chef verify'.

Signed-off-by: tyler-ball <tball@chef.io>