### PR TITLE
Support cookbook root aliases and VERSION file

### DIFF
--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -62,7 +62,7 @@ module Kitchen
       # backend cookbook downloader on every kitchen run.
       default_config :always_update_cookbooks, false
       default_config :cookbook_files_glob, %w(
-        README.* metadata.{json,rb}
+        README.* VERSION metadata.{json,rb} attributes.rb recipe.rb
         attributes/**/* definitions/**/* files/**/* libraries/**/*
         providers/**/* recipes/**/* resources/**/* templates/**/*
       ).join(",")

--- a/spec/kitchen/provisioner/chef_base_spec.rb
+++ b/spec/kitchen/provisioner/chef_base_spec.rb
@@ -103,8 +103,8 @@ describe Kitchen::Provisioner::ChefBase do
       provisioner[:log_file].must_be_nil
     end
 
-    it ":cookbook_files_glob includes recipes" do
-      provisioner[:cookbook_files_glob].must_match %r{,recipes/}
+    it ":cookbook_files_glob includes a metadata file" do
+      provisioner[:cookbook_files_glob].must_match %r{,metadata.\{json,rb\}}
     end
 
     it ":data_path uses calculate_path and is expanded" do


### PR DESCRIPTION
Fix #537 and #1230 - `cookbook_files_glob` really needs to die but until then we should support cookbook root aliases,`attributes.rb` and `recipe.rb` in root of cookbook, and VERSION files which are often read by `metadata.rb`.

Signed-off-by: Seth Thomas <sthomas@chef.io>