### PR TITLE
support net-ssh >= 5.0

### DIFF
--- a/lib/kitchen/transport/ssh.rb
+++ b/lib/kitchen/transport/ssh.rb
@@ -498,9 +498,9 @@ module Kitchen
         opts[:forward_agent] = data[:forward_agent] if data.key?(:forward_agent)
         opts[:verbose] = data[:verbose].to_sym      if data.key?(:verbose)
 
-        # disable host key verification. The hash key to use
-        # depends on the version of net-ssh in use.
-        opts[verify_host_key_option] = false
+        # disable host key verification. The hash key and value to use
+        # depend on the version of net-ssh in use
+        opts[verify_host_key_option] = verify_host_key_value
 
         opts
       end
@@ -522,6 +522,18 @@ module Kitchen
         new_option_version = Net::SSH::Version[4, 2, 0]
 
         current_net_ssh >= new_option_version ? :verify_host_key : :paranoid
+      end
+
+      #
+      # Returns the correct host-key-verification option value to use depending
+      # on what version of net-ssh is in use. In net-ssh <= 5, the supported
+      # parameter is false but in 5.0, it became `:never`
+      #
+      def verify_host_key_value
+        current_net_ssh = Net::SSH::Version::CURRENT
+        new_option_version = Net::SSH::Version[5, 0, 0]
+
+        current_net_ssh >= new_option_version ? :never : false
       end
 
       # Creates a new SSH Connection instance and save it for potential future

--- a/spec/kitchen/transport/ssh_spec.rb
+++ b/spec/kitchen/transport/ssh_spec.rb
@@ -187,9 +187,11 @@ describe Kitchen::Transport::Ssh do
         make_connection
       end
 
-      it "sets the :verify_host_key flag to false" do
+      it "sets the :verify_host_key flag to false or :never if >= 5.0.0" do
         klass.expects(:new).with do |hash|
-          hash[:verify_host_key] == false
+          old_version = Net::SSH::Version::CURRENT < Net::SSH::Version[5, 0, 0]
+
+          hash[:verify_host_key] == old_version ? false : :never
         end
 
         make_connection

--- a/test-kitchen.gemspec
+++ b/test-kitchen.gemspec
@@ -25,8 +25,8 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "mixlib-shellout", ">= 1.2", "< 3.0"
   gem.add_dependency "net-scp",         "~> 1.1"
-  gem.add_dependency "net-ssh", ">= 2.9", "< 5.0"
-  gem.add_dependency "net-ssh-gateway", "~> 1.2"
+  gem.add_dependency "net-ssh",         ">= 2.9"
+  gem.add_dependency "net-ssh-gateway", ">= 1.2"
   gem.add_dependency "thor",            "~> 0.19"
   gem.add_dependency "mixlib-install",  "~> 3.6"
   gem.add_dependency "winrm", "~> 2.0"


### PR DESCRIPTION
Can be tested with following files and **ansible**/**vagrant**/**virtualbox** installed (will use **kitchen-ansiblepush** and **kitchen-vagrant** gems):
* `.kitchen.yml`

    ```YAML
    ---
    driver:
      name: vagrant
      require_chef_omnibus: false
      platform: debian
      use_sudo: false

    provisioner:
      name: ansible_push
      playbook: site.yml
      sudo: true
      sudo_user: root
      ask_vault_pass: false
      chef_bootstrap_url: nil

    platforms:
      - name: stretch64
        driver:
          box: debian/stretch64
          box_check_update: false
          provision: true
          synced_folders:
            - ['.', '/vagrant', 'disabled: true']

    suites:
      - name: foo
        verifier:
          patterns:
            - sshd_spec.rb

    verifier:
      name: serverspec
      remote_exec: false
    ```
* `Gemfile`

    ```Ruby
    source 'https://rubygems.org'

    gem 'kitchen-ansiblepush',                                                                   require: false
    gem 'kitchen-vagrant',                                                                       require: false
    gem 'kitchen-verifier-serverspec',                                                           require: false
    gem 'test-kitchen', git: 'https://github.com/Val/test-kitchen', branch: 'support_net-ssh_5', require: false
    gem 'bcrypt_pbkdf',                                                                          require: false
    gem 'ed25519',                                                                               require: false
    gem 'net-ssh', '>= 5.0.2',                                                                   require: false
    gem 'rspec',                                                                                 require: false
    gem 'serverspec',                                                                            require: false
    ```
* `site.yml`

    ```YAML
    --- 
    - name: sample Ansible site file
      hosts: all
      gather_facts: No
      tasks:
        - debug:
          var: ansible_ssh_user
    ...
    ```
* `sshd_spec.rb`

    ```Ruby
    require 'serverspec'
    require 'specinfra'

    set(:host, ENV['KITCHEN_HOSTNAME'])
    set(:ssh_options,
        user: ENV['KITCHEN_USERNAME'],
        port: ENV['KITCHEN_PORT'],
        auth_methods: %w[publickey],
        keys: [ENV['KITCHEN_SSH_KEY']],
        keys_only: true,
        compression: false,
        keepalive: true,
        non_interactive: true)
    set(:backend, :ssh)
    set(:request_pty, false)

    describe service('ssh') do
      it { is_expected.to be_enabled }
      it { is_expected.to be_running }
    end
    ```

# Test

```Shell
vagrant box add --provider=virtualbox debian/stretch64
bundle
bundle exec kitchen test
```