### PR TITLE
Add docs for fixtures and lifecycle hooks

### DIFF
--- a/docs/content/docs/reference/faq.md
+++ b/docs/content/docs/reference/faq.md
@@ -3,7 +3,7 @@ title: "FAQ"
 menu:
   docs:
     parent: reference
-    weight: 20
+    weight: 15
 ---
 
 ### FAQ

--- a/docs/content/docs/reference/fixtures.md
+++ b/docs/content/docs/reference/fixtures.md
@@ -1,0 +1,32 @@
+---
+title: Fixture Cookbooks  
+menu:
+  docs:
+    parent: reference
+    weight: 20
+---
+
+Cookbooks, especially ones that provide resources exclusively, often utilize what are known as "fixture cookbooks". These are cookbooks and recipes included expressly for the purpose of testing. 
+
+Fixture cookbooks are most often made available via a Berksfile:
+
+```
+source 'https://supermarket.chef.io'
+
+metadata
+
+group :integration do
+  cookbook 'test_cookbook', path: './test/cookbooks/test_cookbook'
+end
+```
+
+This will make the cookbook available and it can be called via `run_list`:
+
+```
+suites:
+- name: default
+  run_list:
+    - recipe[test_cookbook::default]
+```
+
+Working examples can be found in many of the chef-cookbooks, like the [openldap cookbok](https://github.com/chef-cookbooks/openldap/tree/master/test/cookbooks/openldap-test)

--- a/docs/content/docs/reference/glossary.md
+++ b/docs/content/docs/reference/glossary.md
@@ -3,7 +3,7 @@ title: Glossary
 menu:
   docs:
     parent: reference
-    weight: 15
+    weight: 25
 ---
 
 Berksfile 

--- a/docs/content/docs/reference/lifecycle-hooks.md
+++ b/docs/content/docs/reference/lifecycle-hooks.md
@@ -1,0 +1,68 @@
+---
+title: Lifecycle Hooks
+menu:
+  docs:
+    parent: reference
+    weight: 30
+---
+
+The life cycle hooks system allows running commands before or after any phase
+of Test Kitchen (`create`, `converge`, `verify`, or `destroy`). Commands can be
+run either locally on your workstation (the default) or remotely on the test instance.
+
+These hooks are configured under a new `lifecycle:` section in `kitchen.yml`:
+
+```yaml
+lifecycle:
+  pre_create: echo before
+  post_create:
+  - echo after
+  - local: echo also after
+  - remote: echo after but in the instance
+```
+
+You can also configure hooks on a single platform or suite:
+
+```yaml
+platforms:
+- name: ubuntu-18.04
+  lifecycle:
+    pre_converge:
+    - remote: apt update
+
+suites:
+- name: default
+  lifecycle:
+    post_verify:
+    - my_coverage_formatter
+```
+
+Local commands automatically get some environment variables with information
+about which instance the hook is evaluating against:
+
+* `KITCHEN_INSTANCE_NAME` - The full name of the instance
+* `KITCHEN_SUITE_NAME` - The name of the suite of the instance
+* `KITCHEN_PLATFORM_NAME` - The name of the platform of the instance
+* `KITCHEN_INSTANCE_HOSTNAME` - The hostname of the instance as reported by the driver plugin
+
+You can also pass additional configuration for local commands:
+
+```yaml
+lifecycle:
+  pre_converge:
+  - local: ./setup.sh
+    environment:
+      API_KEY: asdf1234
+    timeout: 60
+```
+
+Remote commands are normally not allowed during `pre_create` or `post_destroy`
+hooks as there is generally no instance running at that point, but with `pre_destroy`
+hooks you may want to use the `skippable` flag so as to not fail during `kitchen test`:
+
+```yaml
+lifecycle:
+  pre_destroy:
+  - remote: myapp --unregister-license
+    skippable: true
+```

--- a/docs/content/docs/reference/reboots.md
+++ b/docs/content/docs/reference/reboots.md
@@ -3,7 +3,7 @@ title: Reboots
 menu:
   docs:
     parent: reference
-    weight: 5
+    weight: 35
 ---
 
 Test-kitchen has support for enduring reboots initiated by a Chef provisioner. 


### PR DESCRIPTION
- Fix #1457 
- adds a Lifecycle hooks page
- re-order nav entries 

Signed-off-by: Seth Thomas <sthomas@chef.io>