### PR TITLE
Fixing two issues with the ChefDK build

### DIFF
--- a/test-kitchen.gemspec
+++ b/test-kitchen.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.homepage      = "https://kitchen.ci/"
 
   # The gemfile and gemspec are necessary for appbundler in Chef-DK / Workstation
-  gem.files         = %w{LICENSE test-kitchen.gemspec Gemfile} + Dir.glob("{bin,lib,templates,support}/**/*")
+  gem.files         = %w{LICENSE test-kitchen.gemspec Gemfile Rakefile} + Dir.glob("{bin,lib,templates,support}/**/*")
   gem.executables   = %w{kitchen}
   gem.require_paths = ["lib"]
 
@@ -34,7 +34,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency "winrm-fs", "~> 1.1"
 
   gem.add_development_dependency "rb-readline"
-  gem.add_development_dependency "overcommit", "= 0.33.0"
 
   gem.add_development_dependency "bundler"
   gem.add_development_dependency "rake"


### PR DESCRIPTION
1) Missing Rakefile is causing `chef verify test-kitchen --unit` to fail
2) The `overcommit` gem is required in the gemspec and as a dependency
   of the github_changelog_generator. Overcommit is a TK development
   dependency so does not end up in the ChefDK Gemfile.lock. But when
   appbundler creates the lockfile it wants to include it, causing TK
   commands to fail because overcommit was not installed into the
   ChefDK bundle. We can just get rid of the pin anyways because newer
   versions now work on Windows (the original reason for the pin).

Signed-off-by: tyler-ball <tball@chef.io>