### PR TITLE
Mildy modernize the kitchen driver init templates

### DIFF
--- a/templates/driver/gemspec.erb
+++ b/templates/driver/gemspec.erb
@@ -18,9 +18,9 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'test-kitchen', '~> 1.0.0.alpha.3'
+  spec.add_dependency 'test-kitchen', '~> 1.0.0'
 
-  spec.add_development_dependency 'bundler', '~> 1.3'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
 
   spec.add_development_dependency 'cane'

--- a/templates/driver/travis.yml.erb
+++ b/templates/driver/travis.yml.erb
@@ -1,9 +1,9 @@
 language: ruby
 
 rvm:
-- 2.0.0
-- 1.9.3
-- 1.9.2
+- 2.4
+- 2.5
+- 2.6
 - ruby-head
 
 matrix:


### PR DESCRIPTION
Setup travis on modern ruby platforms
Don't constraint the bundler dep so it works on bundler 2
Require at least Kitchen 1.0

Signed-off-by: Tim Smith <tsmith@chef.io>