### PR TITLE
Simplify the kitchen vagrant example config in the docs

### DIFF
--- a/docs/content/docs/drivers/vagrant.md
+++ b/docs/content/docs/drivers/vagrant.md
@@ -13,20 +13,19 @@ Full example reference can be found [here](https://github.com/test-kitchen/kitch
 ---
 driver:
   name: vagrant
-  provider: virtualbox
 
 provisioner:
   name: chef_zero
 
 verifier:
-  name: inspec  
+  name: inspec
 
 platforms:
-  - name: ubuntu-16.04
+  - name: ubuntu-18.04
   - name: centos-7
   - name: openbsd-5.6
     driver:
-      box: openbsd-5.6 
+      box: openbsd-5.6
       box_url: http://url.tld/openbsd-5.6.box
 
 suites:


### PR DESCRIPTION
There's no need to specify the provider so skip that in this simple example. Also update it for Ubuntu 18.04.

Signed-off-by: Tim Smith <tsmith@chef.io>