### PR TITLE
Pin net-ssh-gateway and net-ssh to prevent the next majors

### DIFF
--- a/test-kitchen.gemspec
+++ b/test-kitchen.gemspec
@@ -25,16 +25,15 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "mixlib-shellout", ">= 1.2", "< 3.0"
   gem.add_dependency "net-scp",         "~> 1.1"
-  gem.add_dependency "net-ssh",         ">= 2.9"
-  gem.add_dependency "net-ssh-gateway", ">= 1.2"
+  gem.add_dependency "net-ssh",         ">= 2.9", "< 6.0" # pinning until we can confirm 6+ works
+  gem.add_dependency "net-ssh-gateway", ">= 1.2", "< 3.0" # pinning until we can confirm 3+ works
   gem.add_dependency "thor",            "~> 0.19"
   gem.add_dependency "mixlib-install",  "~> 3.6"
-  gem.add_dependency "winrm", "~> 2.0"
-  gem.add_dependency "winrm-elevated", "~> 1.0"
-  gem.add_dependency "winrm-fs", "~> 1.1"
+  gem.add_dependency "winrm",           "~> 2.0"
+  gem.add_dependency "winrm-elevated",  "~> 1.0"
+  gem.add_dependency "winrm-fs",        "~> 1.1"
 
   gem.add_development_dependency "rb-readline"
-
   gem.add_development_dependency "bundler"
   gem.add_development_dependency "rake"
 


### PR DESCRIPTION
We don't know what breaking changes they may introduce in these next
versions so let's pin until we can eval. Based on the previous release
of net-ssh it will entirely break things.

Signed-off-by: Tim Smith <tsmith@chef.io>