### PR TITLE
Allow net-scp 2.0

### DIFF
--- a/test-kitchen.gemspec
+++ b/test-kitchen.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.3"
 
   gem.add_dependency "mixlib-shellout", ">= 1.2", "< 3.0"
-  gem.add_dependency "net-scp",         "~> 1.1"
+  gem.add_dependency "net-scp",         ">= 1.1", "< 3.0" # pinning until we can confirm 3+ works
   gem.add_dependency "net-ssh",         ">= 2.9", "< 6.0" # pinning until we can confirm 6+ works
   gem.add_dependency "net-ssh-gateway", ">= 1.2", "< 3.0" # pinning until we can confirm 3+ works
   gem.add_dependency "thor",            "~> 0.19"


### PR DESCRIPTION
Allow the new version of this gem in.

Signed-off-by: Tim Smith <tsmith@chef.io>