### PR TITLE
Honor retries when ssh proxy returns an error

### DIFF
--- a/lib/kitchen/transport/ssh.rb
+++ b/lib/kitchen/transport/ssh.rb
@@ -232,7 +232,7 @@ module Kitchen
           Errno::EACCES, Errno::EALREADY, Errno::EADDRINUSE, Errno::ECONNREFUSED, Errno::ETIMEDOUT,
           Errno::ECONNRESET, Errno::ENETUNREACH, Errno::EHOSTUNREACH, Errno::EPIPE,
           Net::SSH::Disconnect, Net::SSH::AuthenticationFailed, Net::SSH::ConnectionTimeout,
-          Timeout::Error
+          Net::SSH::Proxy::ConnectError, Timeout::Error
         ].freeze
 
         # @return [Integer] cap on number of parallel ssh sessions we can use


### PR DESCRIPTION
Using `test-kitchen (1.16.0)` and `ProxyCommand` in ssh config works.
Using `test-kitchen (1.24.0)`  and `ProxyCommand` in ssh config does not work.

```
E, [2019-03-19T18:04:24.929835 #339] ERROR -- Kitchen: ---Nested Exception---
E, [2019-03-19T18:04:24.929850 #339] ERROR -- Kitchen: Class: Kitchen::ActionFailed
E, [2019-03-19T18:04:24.929865 #339] ERROR -- Kitchen: Message: Failed to complete #create action: [command failed: ssh bastion nc -q0 -w 60 1.2.3.4 22]
E, [2019-03-19T18:04:24.929880 #339] ERROR -- Kitchen: ----------------------
E, [2019-03-19T18:04:24.929896 #339] ERROR -- Kitchen: ------Backtrace-------
E, [2019-03-19T18:04:24.929910 #339] ERROR -- Kitchen: /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/net-ssh-4.2.0/lib/net/ssh/proxy/command.rb:68:in `rescue in open'
E, [2019-03-19T18:04:24.929926 #339] ERROR -- Kitchen: /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/net-ssh-4.2.0/lib/net/ssh/proxy/command.rb:57:in `open'
E, [2019-03-19T18:04:24.929942 #339] ERROR -- Kitchen: /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/net-ssh-4.2.0/lib/net/ssh/transport/session.rb:67:in `initialize'
E, [2019-03-19T18:04:24.929958 #339] ERROR -- Kitchen: /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/net-ssh-4.2.0/lib/net/ssh.rb:237:in `new'
E, [2019-03-19T18:04:24.929973 #339] ERROR -- Kitchen: /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/net-ssh-4.2.0/lib/net/ssh.rb:237:in `start'
E, [2019-03-19T18:04:24.929989 #339] ERROR -- Kitchen: /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/test-kitchen-1.24.0/lib/kitchen/transport/ssh.rb:336:in `block in establish_connection'
E, [2019-03-19T18:04:24.930005 #339] ERROR -- Kitchen: /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/test-kitchen-1.24.0/lib/kitchen/transport/ssh.rb:355:in `retry_connection'
E, [2019-03-19T18:04:24.930021 #339] ERROR -- Kitchen: /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/test-kitchen-1.24.0/lib/kitchen/transport/ssh.rb:335:in `establish_connection'
E, [2019-03-19T18:04:24.930037 #339] ERROR -- Kitchen: /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/test-kitchen-1.24.0/lib/kitchen/transport/ssh.rb:434:in `session'
E, [2019-03-19T18:04:24.930053 #339] ERROR -- Kitchen: /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/test-kitchen-1.24.0/lib/kitchen/transport/ssh.rb:218:in `wait_until_ready'
E, [2019-03-19T18:04:24.930068 #339] ERROR -- Kitchen: /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/kitchen-ec2-2.4.0/lib/kitchen/driver/ec2.rb:285:in `create'
...
```

__~/.ssh/config__ for Debian system:
```
Host *
ProxyCommand ssh bastion nc -q0 -w 60 %h %p
```

It breaks because the remote host may not be immediately available in which case the proxy command may not exit code 0. Because the exception is not rescued, there is no retries and `kitchen` fails.

Retrying should be honored like other cases.