### PR TITLE
switch to new gem install parameters to support Ruby 2.6 and Chef 15

### DIFF
--- a/lib/kitchen/verifier/busser.rb
+++ b/lib/kitchen/verifier/busser.rb
@@ -182,7 +182,7 @@ module Kitchen
         # to be under /tmp/verifier
         args = gem
         args += " --version #{version}" if version
-        args += " --no-rdoc --no-ri --no-format-executable -n #{gem_bin}"
+        args += " --no-document --no-format-executable -n #{gem_bin}"
         args += " --no-user-install"
         args
       end

--- a/spec/kitchen/verifier/busser_spec.rb
+++ b/spec/kitchen/verifier/busser_spec.rb
@@ -248,7 +248,7 @@ describe Kitchen::Verifier::Busser do
 
         it "sets gem install arguments" do
           cmd.must_match regexify(
-            'gem_install_args="busser --no-rdoc --no-ri --no-format-executable' \
+            'gem_install_args="busser --no-document --no-format-executable' \
             ' -n /r/bin --no-user-install"'
           )
         end
@@ -296,7 +296,7 @@ describe Kitchen::Verifier::Busser do
 
         it "sets gem install arguments" do
           cmd.must_match regexify(
-            '$gem_install_args = "busser --no-rdoc --no-ri --no-format-executable' \
+            '$gem_install_args = "busser --no-document --no-format-executable' \
             ' -n \\r\\bin --no-user-install"'
           )
         end


### PR DESCRIPTION
This is the only thing I have spotted so far that is needed for Chef 15 support (because it introduces Ruby 2.6), however I'm not clear on how to properly test this with Chef 15, so there's likely to be other issues that I have not yet spotted.