### PR TITLE
Require gems needed for ed25519 ssh key support 

### DIFF
--- a/test-kitchen.gemspec
+++ b/test-kitchen.gemspec
@@ -27,6 +27,8 @@ Gem::Specification.new do |gem|
   gem.add_dependency "net-scp",         ">= 1.1", "< 3.0" # pinning until we can confirm 3+ works
   gem.add_dependency "net-ssh",         ">= 2.9", "< 6.0" # pinning until we can confirm 6+ works
   gem.add_dependency "net-ssh-gateway", ">= 1.2", "< 3.0" # pinning until we can confirm 3+ works
+  gem.add_dependency "ed25519",         "~> 1.2" # ed25519 ssh key support
+  gem.add_dependency "bcrypt_pbkdf",    "~> 1.0" # ed25519 ssh key support
   gem.add_dependency "thor",            "~> 0.19"
   gem.add_dependency "mixlib-install",  "~> 3.6"
   gem.add_dependency "winrm",           "~> 2.0"


### PR DESCRIPTION
net-ssh 5 includes support for ed25519 without the need for the rbnacl
mess, but it still requires additional gems to make it work. See https://github.com/net-ssh/net-ssh/issues/565

Signed-off-by: Tim Smith <tsmith@chef.io>