### PR TITLE
Chef provisioners should prompt for license acceptance

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,6 @@
 source "https://rubygems.org"
 gemspec
 
-# TODO delete after that is released
-gem "license-acceptance", git: "https://github.com/chef/license-acceptance.git", branch: "tk_license", glob: "components/ruby/*.gemspec"
-
 group :integration do
   gem "berkshelf"
   gem "kitchen-inspec"

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,9 @@
 source "https://rubygems.org"
 gemspec
 
+# TODO delete after that is released
+gem "license-acceptance", git: "https://github.com/chef/license-acceptance.git", branch: "tk_license", glob: "components/ruby/*.gemspec"
+
 group :integration do
   gem "berkshelf"
   gem "kitchen-inspec"

--- a/lib/kitchen/provisioner/base.rb
+++ b/lib/kitchen/provisioner/base.rb
@@ -70,6 +70,7 @@ module Kitchen
       def call(state)
         create_sandbox
         sandbox_dirs = Util.list_directory(sandbox_path)
+        check_license
 
         instance.transport.connection(state) do |conn|
           conn.execute(install_command)
@@ -103,6 +104,12 @@ module Kitchen
       # @returns [Boolean] Return true if a problem is found.
       def doctor(state)
         false
+      end
+
+      # Certain products that Test Kitchen uses to provision require accepting
+      # a license to use. Overwrite this method in the specific provisioner
+      # to implement this check.
+      def check_license
       end
 
       # Generates a command string which will install and configure the

--- a/lib/kitchen/provisioner/chef_apply.rb
+++ b/lib/kitchen/provisioner/chef_apply.rb
@@ -107,6 +107,7 @@ module Kitchen
             "--no-color",
           ]
           args << "--logfile #{config[:log_file]}" if config[:log_file]
+          args << "--chef-license #{config[:chef_license]}" if config[:chef_license]
 
           lines << wrap_shell_code(
             [cmd, *args].join(" ")

--- a/lib/kitchen/provisioner/chef_solo.rb
+++ b/lib/kitchen/provisioner/chef_solo.rb
@@ -72,7 +72,7 @@ module Kitchen
         args << "--logfile #{config[:log_file]}" if config[:log_file]
         args << "--profile-ruby" if config[:profile_ruby]
         args << "--legacy-mode" if config[:legacy_mode]
-
+        args << "--chef-license #{config[:chef_license]}" if config[:chef_license]
         args
       end
     end

--- a/lib/kitchen/provisioner/chef_zero.rb
+++ b/lib/kitchen/provisioner/chef_zero.rb
@@ -82,6 +82,9 @@ module Kitchen
           args << "--chef-zero-port #{config[:chef_zero_port]}"
         end
         args << "--profile-ruby" if config[:profile_ruby]
+        if config[:chef_license]
+          args << "--chef-license #{config[:chef_license]}"
+        end
       end
       # rubocop:enable Metrics/CyclomaticComplexity
 

--- a/spec/kitchen/provisioner/base_spec.rb
+++ b/spec/kitchen/provisioner/base_spec.rb
@@ -163,6 +163,12 @@ describe Kitchen::Provisioner::Base do
       FakeFS::FileSystem.clear
     end
 
+    it "checks the license" do
+      provisioner.expects(:check_license)
+
+      cmd
+    end
+
     it "creates the sandbox" do
       provisioner.expects(:create_sandbox)
 

--- a/spec/kitchen/provisioner/chef_apply_spec.rb
+++ b/spec/kitchen/provisioner/chef_apply_spec.rb
@@ -120,6 +120,12 @@ describe Kitchen::Provisioner::ChefApply do
       it "sets no color flag on chef-apply" do
         cmd.must_match regexify(" --no-color", :partial_line)
       end
+
+      it "accepts the chef license" do
+        config[:chef_license] = "accept-no-persist"
+
+        cmd.must_match regexify(" --chef-license accept-no-persist", :partial_line)
+      end
     end
   end
 

--- a/spec/kitchen/provisioner/chef_solo_spec.rb
+++ b/spec/kitchen/provisioner/chef_solo_spec.rb
@@ -311,6 +311,12 @@ describe Kitchen::Provisioner::ChefSolo do
 
         cmd.wont_match(/\Amy_prefix /)
       end
+
+      it "accepts the chef license" do
+        config[:chef_license] = "accept-no-persist"
+
+        cmd.must_match regexify(" --chef-license accept-no-persist", :partial_line)
+      end
     end
 
     describe "for bourne shells" do

--- a/spec/kitchen/provisioner/chef_zero_spec.rb
+++ b/spec/kitchen/provisioner/chef_zero_spec.rb
@@ -415,6 +415,12 @@ describe Kitchen::Provisioner::ChefZero do
 
         cmd.wont_match(/\Amy_prefix /)
       end
+
+      it "accepts the chef license" do
+        config[:chef_license] = "accept-no-persist"
+
+        cmd.must_match regexify(" --chef-license accept-no-persist", :partial_line)
+      end
     end
     # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 

--- a/test-kitchen.gemspec
+++ b/test-kitchen.gemspec
@@ -23,17 +23,18 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.3"
 
-  gem.add_dependency "mixlib-shellout", ">= 1.2", "< 3.0"
-  gem.add_dependency "net-scp",         ">= 1.1", "< 3.0" # pinning until we can confirm 3+ works
-  gem.add_dependency "net-ssh",         ">= 2.9", "< 6.0" # pinning until we can confirm 6+ works
-  gem.add_dependency "net-ssh-gateway", ">= 1.2", "< 3.0" # pinning until we can confirm 3+ works
-  gem.add_dependency "ed25519",         "~> 1.2" # ed25519 ssh key support
-  gem.add_dependency "bcrypt_pbkdf",    "~> 1.0" # ed25519 ssh key support
-  gem.add_dependency "thor",            "~> 0.19"
-  gem.add_dependency "mixlib-install",  "~> 3.6"
-  gem.add_dependency "winrm",           "~> 2.0"
-  gem.add_dependency "winrm-elevated",  "~> 1.0"
-  gem.add_dependency "winrm-fs",        "~> 1.1"
+  gem.add_dependency "mixlib-shellout",    ">= 1.2", "< 3.0"
+  gem.add_dependency "net-scp",            ">= 1.1", "< 3.0" # pinning until we can confirm 3+ works
+  gem.add_dependency "net-ssh",            ">= 2.9", "< 6.0" # pinning until we can confirm 6+ works
+  gem.add_dependency "net-ssh-gateway",    ">= 1.2", "< 3.0" # pinning until we can confirm 3+ works
+  gem.add_dependency "ed25519",            "~> 1.2" # ed25519 ssh key support
+  gem.add_dependency "bcrypt_pbkdf",       "~> 1.0" # ed25519 ssh key support
+  gem.add_dependency "thor",               "~> 0.19"
+  gem.add_dependency "mixlib-install",     "~> 3.6"
+  gem.add_dependency "winrm",              "~> 2.0"
+  gem.add_dependency "winrm-elevated",     "~> 1.0"
+  gem.add_dependency "winrm-fs",           "~> 1.1"
+  gem.add_dependency "license-acceptance", "~> 0.2"
 
   gem.add_development_dependency "rb-readline"
   gem.add_development_dependency "bundler"

--- a/test-kitchen.gemspec
+++ b/test-kitchen.gemspec
@@ -34,7 +34,9 @@ Gem::Specification.new do |gem|
   gem.add_dependency "winrm",              "~> 2.0"
   gem.add_dependency "winrm-elevated",     "~> 1.0"
   gem.add_dependency "winrm-fs",           "~> 1.1"
-  gem.add_dependency "license-acceptance", "~> 0.2"
+  # Required to run the Chef provisioner local license check for remote systems
+  # TK is not under Chef EULA
+  gem.add_dependency "license-acceptance", ">= 0.2.16", "< 2.0"
 
   gem.add_development_dependency "rb-readline"
   gem.add_development_dependency "bundler"


### PR DESCRIPTION
The provisioner itself is not protected under the Chef Software EULA. But the product it installs on provisioned machines (Chef Client, ChefDK, etc.) is. So we perform a workstation-side early check to ensure the current user has accepted the license. The acceptance flow is the same as it is for the clients. Acceptance is automatically passed to provisioned instances.

To accept the license the user can:
* Set the CHEF_LICENSE environment variable
* Set the 'chef_license' attribute in the kitchen.yml under the provisioner
* If these are not set and the license has not been previously accepted an interactive prompt will occur asking the user to accept.

Possible values for acceptance are "accept" or "accept-no-persist".

License acceptance is stored on the workstation (unless the user sets "accept-no-persist"). Once stored the license acceptance does not need to be accepted as a flag.

Depends on https://github.com/chef/license-acceptance/pull/36