### PR TITLE
Chef license checking should work with legacy require_chef_omnibus config

### DIFF
--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -245,11 +245,25 @@ module Kitchen
         end
       end
 
+      # gives us the product version from either require_chef_omnibus or product_version
+      # If the non-default (true) value of require_chef_omnibus is present use that
+      # otherwise use config[:product_version] which defaults to :latest and is the actual
+      # default for chef provisioners
+      #
+      # @return [String] version
+      def product_version
+        if !config[:require_chef_omnibus].is_a?(TrueClass)
+          config[:require_chef_omnibus]
+        else
+          config[:product_version]
+        end
+      end
+
       # (see Base#check_license)
       def check_license
         name = config[:product_name] || "chef"
-        version = config[:product_version]
-        debug("Checking if we need to prompt for license acceptance on product: #{name} version: #{version}")
+        version = product_version
+        debug("Checking if we need to prompt for license acceptance on product: #{name} version: #{version}.")
 
         acceptor = LicenseAcceptance::Acceptor.new(logger: Kitchen.logger, provided: config[:chef_license])
         if acceptor.license_required?(name, version)

--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -250,12 +250,15 @@ module Kitchen
       # otherwise use config[:product_version] which defaults to :latest and is the actual
       # default for chef provisioners
       #
-      # @return [String] version
+      # @return [String,Symbol,NilClass] version or nil if not applicable
       def product_version
-        if !config[:require_chef_omnibus].is_a?(TrueClass)
-          config[:require_chef_omnibus]
-        else
+        case config[:require_chef_omnibus]
+        when FalseClass
+          nil
+        when TrueClass
           config[:product_version]
+        else
+          config[:require_chef_omnibus]
         end
       end
 

--- a/spec/kitchen/provisioner/chef_base_spec.rb
+++ b/spec/kitchen/provisioner/chef_base_spec.rb
@@ -785,6 +785,37 @@ describe Kitchen::Provisioner::ChefBase do
     end
   end
 
+  describe "#product_version" do
+    describe "when require_chef_omnibus is true and product_version is not set" do
+      it "returns :latest" do
+        config[:require_chef_omnibus] = true
+        provisioner.product_version.must_match :latest
+      end
+    end
+
+    describe "when require_chef_omnibus is false and product_version is nil" do
+      it "returns nil" do
+        config[:product_version] = nil
+        config[:require_chef_omnibus] = false
+        provisioner.product_version.must_be_nil
+      end
+    end
+
+    describe "when require_chef_omnibus is a string" do
+      it "returns the require_chef_omnibus string" do
+        config[:require_chef_omnibus] = "15.0.0"
+        provisioner.product_version.must_match "15.0.0"
+      end
+    end
+
+    describe "when product_version is set" do
+      it "returns the product_version string" do
+        config[:product_version] = "15.0.0"
+        provisioner.product_version.must_match "15.0.0"
+      end
+    end
+  end
+
   describe "#check_license" do
     before do
       LicenseAcceptance::Acceptor.stubs(:new).returns(acceptor)

--- a/spec/kitchen/provisioner/chef_base_spec.rb
+++ b/spec/kitchen/provisioner/chef_base_spec.rb
@@ -789,7 +789,7 @@ describe Kitchen::Provisioner::ChefBase do
     describe "when require_chef_omnibus is true and product_version is not set" do
       it "returns :latest" do
         config[:require_chef_omnibus] = true
-        provisioner.product_version.must_match :latest
+        provisioner.product_version.must_equal :latest
       end
     end
 
@@ -819,7 +819,6 @@ describe Kitchen::Provisioner::ChefBase do
   describe "#check_license" do
     before do
       LicenseAcceptance::Acceptor.stubs(:new).returns(acceptor)
-      config[:product_name] = "chef"
       config[:product_version] = "15.0.0"
     end
 


### PR DESCRIPTION
We'd prefer if people would stop using this old config, but it's used in a lot of places. This adds a new method that determines where a person specified the version of chef they'd like to provision. Without this a person using require_chef_omnibus set to 15 or later will not receive a license prompt since we interpret that as a nil version that doesn't require a license.

Signed-off-by: Tim Smith <tsmith@chef.io>