### PR TITLE
Moving Chef license acceptance to Chef config instead of command line argument

### DIFF
--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -355,7 +355,7 @@ module Kitchen
       def default_config_rb # rubocop:disable Metrics/MethodLength
         root = config[:root_path].gsub("$env:TEMP", "\#{ENV['TEMP']\}")
 
-        {
+        config_rb = {
           node_name: instance.name,
           checksum_path: remote_path_join(root, "checksums"),
           file_cache_path: remote_path_join(root, "cache"),
@@ -378,6 +378,8 @@ module Kitchen
           ),
           treat_deprecation_warnings_as_errors: config[:deprecations_as_errors],
         }
+        config_rb[:chef_license] = config[:chef_license] unless config[:chef_license].nil?
+        config_rb
       end
 
       # Generates a rendered client.rb/solo.rb/knife.rb formatted file as a

--- a/lib/kitchen/provisioner/chef_solo.rb
+++ b/lib/kitchen/provisioner/chef_solo.rb
@@ -72,7 +72,6 @@ module Kitchen
         args << "--logfile #{config[:log_file]}" if config[:log_file]
         args << "--profile-ruby" if config[:profile_ruby]
         args << "--legacy-mode" if config[:legacy_mode]
-        args << "--chef-license #{config[:chef_license]}" if config[:chef_license]
         args
       end
     end

--- a/lib/kitchen/provisioner/chef_zero.rb
+++ b/lib/kitchen/provisioner/chef_zero.rb
@@ -82,9 +82,6 @@ module Kitchen
           args << "--chef-zero-port #{config[:chef_zero_port]}"
         end
         args << "--profile-ruby" if config[:profile_ruby]
-        if config[:chef_license]
-          args << "--chef-license #{config[:chef_license]}"
-        end
       end
       # rubocop:enable Metrics/CyclomaticComplexity
 

--- a/spec/kitchen/provisioner/chef_base_spec.rb
+++ b/spec/kitchen/provisioner/chef_base_spec.rb
@@ -1433,6 +1433,10 @@ describe Kitchen::Provisioner::ChefBase do
             file.must_include %{node_name "#{instance.name}"}
           end
 
+          it "does not contain chef_license" do
+            file.wont_include %{chef_license}
+          end
+
           it "sets checksum_path" do
             file.must_include %{checksum_path "/tmp/kitchen/checksums"}
           end
@@ -1512,6 +1516,13 @@ describe Kitchen::Provisioner::ChefBase do
           provisioner.create_sandbox
 
           file.must_include %{dark_secret "golang"}
+        end
+
+        it "supports accepting the chef_license" do
+          config[:chef_license] = "accept-no-persist"
+          provisioner.create_sandbox
+
+          file.must_include %{chef_license "accept-no-persist"}
         end
       end
 

--- a/spec/kitchen/provisioner/chef_solo_spec.rb
+++ b/spec/kitchen/provisioner/chef_solo_spec.rb
@@ -311,12 +311,6 @@ describe Kitchen::Provisioner::ChefSolo do
 
         cmd.wont_match(/\Amy_prefix /)
       end
-
-      it "accepts the chef license" do
-        config[:chef_license] = "accept-no-persist"
-
-        cmd.must_match regexify(" --chef-license accept-no-persist", :partial_line)
-      end
     end
 
     describe "for bourne shells" do

--- a/spec/kitchen/provisioner/chef_zero_spec.rb
+++ b/spec/kitchen/provisioner/chef_zero_spec.rb
@@ -415,12 +415,6 @@ describe Kitchen::Provisioner::ChefZero do
 
         cmd.wont_match(/\Amy_prefix /)
       end
-
-      it "accepts the chef license" do
-        config[:chef_license] = "accept-no-persist"
-
-        cmd.must_match regexify(" --chef-license accept-no-persist", :partial_line)
-      end
     end
     # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 


### PR DESCRIPTION
This is less conflicting with consumer libraries. It is also backwards
compatible with previous Chef versions (even though we check that).

Signed-off-by: tyler-ball <tball@chef.io>