### PR TITLE
Must read license acceptance before creating config.rb

### DIFF
--- a/lib/kitchen/provisioner/base.rb
+++ b/lib/kitchen/provisioner/base.rb
@@ -68,9 +68,9 @@ module Kitchen
       # @raise [ActionFailed] if the action could not be completed
       # rubocop:disable Metrics/AbcSize
       def call(state)
+        check_license
         create_sandbox
         sandbox_dirs = Util.list_directory(sandbox_path)
-        check_license
 
         instance.transport.connection(state) do |conn|
           conn.execute(install_command)


### PR DESCRIPTION
@tas50 Found this when testing the chef_client_updater cookbook. Because we passthrough the license acceptance as part of the `config.rb` we must read the setting before creating the sandbox.

I have a fuzzy memory that we moved this below the `create_sandbox` method for some reason. Do you have any recollection of that?