### PR TITLE
Let license errors raise without trying to cleanup sandbox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ matrix:
 
       script:
         - bundle exec kitchen --version
-        - git clone https://github.com/chef/proxy_tests.git
+        - git clone --branch license_acceptance https://github.com/chef/proxy_tests.git
         - rvmsudo -E bundle exec bash $PROXY_TESTS_DIR/run_tests.sh kitchen \* \* /tmp/out.txt
       after_script:
         - cat /tmp/out.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ bundler_args: --with integration --without changelog debug docs
 script:
   - bundle exec rake
   - export KITCHEN_YAML=kitchen.dokken.yml
+  - export CHEF_LICENSE=accept-no-persist
   - bundle exec kitchen test
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,13 @@ before_install:
 
 bundler_args: --with integration --without changelog debug docs
 
+env:
+  - global:
+    - CHEF_LICENSE=accept-no-persist
+
 script:
   - bundle exec rake
   - export KITCHEN_YAML=kitchen.dokken.yml
-  - export CHEF_LICENSE=accept-no-persist
   - bundle exec kitchen test
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ matrix:
 
       script:
         - bundle exec kitchen --version
-        - git clone --branch license_acceptance https://github.com/chef/proxy_tests.git
+        - git clone https://github.com/chef/proxy_tests.git
         - rvmsudo -E bundle exec bash $PROXY_TESTS_DIR/run_tests.sh kitchen \* \* /tmp/out.txt
       after_script:
         - cat /tmp/out.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ cache: bundler
 language: ruby
 
 rvm:
+  - 2.3.8
   - 2.4.5
   - 2.5.5
   - 2.6.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,13 +41,12 @@ matrix:
         - sudo apt-get update
         - sudo apt-get -y install squid3 git curl
       env:
-        global:
-          - machine_user=travis
-          - machine_pass=travis
-          - machine_port=22
-          - PROXY_TESTS_DIR=proxy_tests/files/default/scripts
-          - PROXY_TESTS_REPO=$PROXY_TESTS_DIR/repo
-          - KITCHEN_YAML=/home/travis/build/test-kitchen/test-kitchen/kitchen.proxy.yml
+        - machine_user=travis
+        - machine_pass=travis
+        - machine_port=22
+        - PROXY_TESTS_DIR=proxy_tests/files/default/scripts
+        - PROXY_TESTS_REPO=$PROXY_TESTS_DIR/repo
+        - KITCHEN_YAML=/home/travis/build/test-kitchen/test-kitchen/kitchen.proxy.yml
 
       script:
         - bundle exec kitchen --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ cache: bundler
 language: ruby
 
 rvm:
-  - 2.3.8
   - 2.4.5
   - 2.5.5
   - 2.6.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
 bundler_args: --with integration --without changelog debug docs
 
 env:
-  - global:
+  global:
     - CHEF_LICENSE=accept-no-persist
 
 script:
@@ -41,7 +41,7 @@ matrix:
         - sudo apt-get update
         - sudo apt-get -y install squid3 git curl
       env:
-        - global:
+        global:
           - machine_user=travis
           - machine_pass=travis
           - machine_port=22

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@
 source "https://rubygems.org"
 gemspec
 
+gem "license-acceptance", git: "https://github.com/chef/license-acceptance.git", branch: "windows2012", glob: "components/ruby/*.gemspec"
+
 group :integration do
   gem "berkshelf"
   gem "kitchen-inspec"

--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,6 @@
 source "https://rubygems.org"
 gemspec
 
-gem "license-acceptance", git: "https://github.com/chef/license-acceptance.git", branch: "windows2012", glob: "components/ruby/*.gemspec"
-
 group :integration do
   gem "berkshelf"
   gem "kitchen-inspec"

--- a/kitchen.proxy.yml
+++ b/kitchen.proxy.yml
@@ -9,6 +9,7 @@ driver:
 
 provisioner:
   name: chef_zero
+  chef_license: accept-no-persist
 
 platforms:
   - name: ubuntu-16.04

--- a/lib/kitchen/instance.rb
+++ b/lib/kitchen/instance.rb
@@ -405,6 +405,7 @@ module Kitchen
         if legacy_ssh_base_driver?
           legacy_ssh_base_converge(state)
         else
+          provisioner.check_license
           provisioner.call(state)
         end
       end

--- a/lib/kitchen/provisioner/base.rb
+++ b/lib/kitchen/provisioner/base.rb
@@ -68,7 +68,6 @@ module Kitchen
       # @raise [ActionFailed] if the action could not be completed
       # rubocop:disable Metrics/AbcSize
       def call(state)
-        check_license
         create_sandbox
         sandbox_dirs = Util.list_directory(sandbox_path)
 

--- a/spec/kitchen/instance_spec.rb
+++ b/spec/kitchen/instance_spec.rb
@@ -509,6 +509,7 @@ describe Kitchen::Instance do
       describe "with no state" do
         it "calls Driver#create and Provisioner#call with empty state hash" do
           driver.expects(:create).with({})
+          provisioner.expects(:check_license)
           provisioner.expects(:call)
                      .with { |state| state[:last_action] == "create" }
 

--- a/spec/kitchen/provisioner/base_spec.rb
+++ b/spec/kitchen/provisioner/base_spec.rb
@@ -163,12 +163,6 @@ describe Kitchen::Provisioner::Base do
       FakeFS::FileSystem.clear
     end
 
-    it "checks the license" do
-      provisioner.expects(:check_license)
-
-      cmd
-    end
-
     it "creates the sandbox" do
       provisioner.expects(:create_sandbox)
 

--- a/test-kitchen.gemspec
+++ b/test-kitchen.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "winrm-fs",           "~> 1.1"
   # Required to run the Chef provisioner local license check for remote systems
   # TK is not under Chef EULA
-  gem.add_dependency "license-acceptance", "~> 1.0", ">= 1.0.5"
+  gem.add_dependency "license-acceptance", "~> 1.0", ">= 1.0.6"
 
   gem.add_development_dependency "rb-readline"
   gem.add_development_dependency "bundler"

--- a/test-kitchen.gemspec
+++ b/test-kitchen.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "winrm-fs",           "~> 1.1"
   # Required to run the Chef provisioner local license check for remote systems
   # TK is not under Chef EULA
-  gem.add_dependency "license-acceptance", "~> 1.0", ">= 1.0.8"
+  gem.add_dependency "license-acceptance", "~> 1.0", ">= 1.0.11"
 
   gem.add_development_dependency "rb-readline"
   gem.add_development_dependency "bundler"

--- a/test-kitchen.gemspec
+++ b/test-kitchen.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.executables   = %w{kitchen}
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.3"
+  gem.required_ruby_version = ">= 2.4"
 
   gem.add_dependency "mixlib-shellout",    ">= 1.2", "< 3.0"
   gem.add_dependency "net-scp",            ">= 1.1", "< 3.0" # pinning until we can confirm 3+ works

--- a/test-kitchen.gemspec
+++ b/test-kitchen.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.executables   = %w{kitchen}
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.4"
+  gem.required_ruby_version = ">= 2.3"
 
   gem.add_dependency "mixlib-shellout",    ">= 1.2", "< 3.0"
   gem.add_dependency "net-scp",            ">= 1.1", "< 3.0" # pinning until we can confirm 3+ works
@@ -36,7 +36,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "winrm-fs",           "~> 1.1"
   # Required to run the Chef provisioner local license check for remote systems
   # TK is not under Chef EULA
-  gem.add_dependency "license-acceptance", "~> 1.0", ">= 1.0.6"
+  gem.add_dependency "license-acceptance", "~> 1.0", ">= 1.0.8"
 
   gem.add_development_dependency "rb-readline"
   gem.add_development_dependency "bundler"


### PR DESCRIPTION
Before this change if the license acceptance failed and raised an
exception the 'cleanup_sandbox' was called in an ensure. But the
sandbox would not have been created yet so it would fail with an error
like:

Failed to complete #converge action: [Sandbox directory has not yet been
created. Please run Kitchen::Provisioner::ChefGithub#create_sandox
before trying to access the path.]

Signed-off-by: tyler-ball <tball@chef.io>