### PR TITLE
Backport additional Chef license fixes to 1-stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ bundler_args: --with integration --without changelog debug docs
 script:
   - bundle exec rake
   - export KITCHEN_YAML=kitchen.dokken.yml
+  - export CHEF_LICENSE=accept-no-persist
   - bundle exec kitchen test
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,13 @@ before_install:
 
 bundler_args: --with integration --without changelog debug docs
 
+env:
+  - global:
+    - CHEF_LICENSE=accept-no-persist
+
 script:
   - bundle exec rake
   - export KITCHEN_YAML=kitchen.dokken.yml
-  - export CHEF_LICENSE=accept-no-persist
   - bundle exec kitchen test
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,13 +41,12 @@ matrix:
         - sudo apt-get update
         - sudo apt-get -y install squid3 git curl
       env:
-        global:
-          - machine_user=travis
-          - machine_pass=travis
-          - machine_port=22
-          - PROXY_TESTS_DIR=proxy_tests/files/default/scripts
-          - PROXY_TESTS_REPO=$PROXY_TESTS_DIR/repo
-          - KITCHEN_YAML=/home/travis/build/test-kitchen/test-kitchen/kitchen.proxy.yml
+        - machine_user=travis
+        - machine_pass=travis
+        - machine_port=22
+        - PROXY_TESTS_DIR=proxy_tests/files/default/scripts
+        - PROXY_TESTS_REPO=$PROXY_TESTS_DIR/repo
+        - KITCHEN_YAML=/home/travis/build/test-kitchen/test-kitchen/kitchen.proxy.yml
 
       script:
         - bundle exec kitchen --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
 bundler_args: --with integration --without changelog debug docs
 
 env:
-  - global:
+  global:
     - CHEF_LICENSE=accept-no-persist
 
 script:
@@ -41,7 +41,7 @@ matrix:
         - sudo apt-get update
         - sudo apt-get -y install squid3 git curl
       env:
-        - global:
+        global:
           - machine_user=travis
           - machine_pass=travis
           - machine_port=22

--- a/kitchen.proxy.yml
+++ b/kitchen.proxy.yml
@@ -9,6 +9,7 @@ driver:
 
 provisioner:
   name: chef_zero
+  chef_license: accept-no-persist
 
 platforms:
   - name: ubuntu-16.04

--- a/lib/kitchen/instance.rb
+++ b/lib/kitchen/instance.rb
@@ -405,6 +405,7 @@ module Kitchen
         if legacy_ssh_base_driver?
           legacy_ssh_base_converge(state)
         else
+          provisioner.check_license
           provisioner.call(state)
         end
       end

--- a/lib/kitchen/provisioner/base.rb
+++ b/lib/kitchen/provisioner/base.rb
@@ -68,7 +68,6 @@ module Kitchen
       # @raise [ActionFailed] if the action could not be completed
       # rubocop:disable Metrics/AbcSize
       def call(state)
-        check_license
         create_sandbox
         sandbox_dirs = Util.list_directory(sandbox_path)
 

--- a/lib/kitchen/provisioner/base.rb
+++ b/lib/kitchen/provisioner/base.rb
@@ -68,9 +68,9 @@ module Kitchen
       # @raise [ActionFailed] if the action could not be completed
       # rubocop:disable Metrics/AbcSize
       def call(state)
+        check_license
         create_sandbox
         sandbox_dirs = Util.list_directory(sandbox_path)
-        check_license
 
         instance.transport.connection(state) do |conn|
           conn.execute(install_command)

--- a/lib/kitchen/provisioner/chef/common_sandbox.rb
+++ b/lib/kitchen/provisioner/chef/common_sandbox.rb
@@ -179,8 +179,8 @@ module Kitchen
         #
         # @api private
         def make_fake_cookbook
-          info("Berksfile, Cheffile, cookbooks/, or metadata.rb not found " \
-            "so Chef will run with effectively no cookbooks. Is this intended?")
+          info("Policyfile, Cheffile, Berksfile, cookbooks/, or metadata.rb not found " \
+            "so Chef Infra Client will run, but do nothing. Is this intended?")
           name = File.basename(config[:kitchen_root])
           fake_cb = File.join(tmpbooks_dir, name)
           FileUtils.mkdir_p(fake_cb)
@@ -292,7 +292,7 @@ module Kitchen
 
         def update_dna_for_policyfile
           if !config[:run_list].nil? && !config[:run_list].empty?
-            warn("You must set your run_list in your policyfile instead of "\
+            warn("You must set your run_list in your Policyfile instead of "\
                  "kitchen config. The run_list in your config will be ignored.")
             warn("Ignored run_list: #{config[:run_list].inspect}")
           end

--- a/lib/kitchen/provisioner/chef/policyfile.rb
+++ b/lib/kitchen/provisioner/chef/policyfile.rb
@@ -87,7 +87,7 @@ module Kitchen
 
         private
 
-        # @return [String] path to a Berksfile
+        # @return [String] path to a Policyfile
         # @api private
         attr_reader :policyfile
 
@@ -139,8 +139,8 @@ module Kitchen
               File.exist?(File.join(p, "chef"))
             end
               logger.fatal("The `chef` executable cannot be found in your " \
-                          "PATH. Ensure you have installed ChefDK from " \
-                          "https://downloads.chef.io and that your PATH " \
+                          "PATH. Ensure you have installed ChefDK or Chef Workstation " \
+                          "from https://downloads.chef.io and that your PATH " \
                           "setting includes the path to the `chef` comand.")
               raise UserError,
                     "Could not find the chef executable in your PATH."

--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -272,11 +272,11 @@ module Kitchen
         acceptor = LicenseAcceptance::Acceptor.new(logger: Kitchen.logger, provided: config[:chef_license])
         if acceptor.license_required?(name, version)
           debug("License acceptance required for #{name} version: #{version}. Prompting")
-          license_name = acceptor.name_from_mixlib(name)
+          license_id = acceptor.id_from_mixlib(name)
           begin
-            acceptor.check_and_persist(license_name, version.to_s)
-          rescue LicenseAcceptance::LicenseNotAcceptedError
-            error("Cannot converge without accepting the Chef License. Set it in your kitchen.yml or using the CHEF_LICENSE environment variable")
+            acceptor.check_and_persist(license_id, version.to_s)
+          rescue LicenseAcceptance::LicenseNotAcceptedError => e
+            error("Cannot converge without accepting the #{e.product.pretty_name} License. Set it in your kitchen.yml or using the CHEF_LICENSE environment variable")
             raise
           end
           config[:chef_license] ||= acceptor.acceptance_value

--- a/spec/kitchen/instance_spec.rb
+++ b/spec/kitchen/instance_spec.rb
@@ -509,6 +509,7 @@ describe Kitchen::Instance do
       describe "with no state" do
         it "calls Driver#create and Provisioner#call with empty state hash" do
           driver.expects(:create).with({})
+          provisioner.expects(:check_license)
           provisioner.expects(:call)
                      .with { |state| state[:last_action] == "create" }
 

--- a/spec/kitchen/provisioner/base_spec.rb
+++ b/spec/kitchen/provisioner/base_spec.rb
@@ -163,12 +163,6 @@ describe Kitchen::Provisioner::Base do
       FakeFS::FileSystem.clear
     end
 
-    it "checks the license" do
-      provisioner.expects(:check_license)
-
-      cmd
-    end
-
     it "creates the sandbox" do
       provisioner.expects(:create_sandbox)
 

--- a/spec/kitchen/provisioner/chef_base_spec.rb
+++ b/spec/kitchen/provisioner/chef_base_spec.rb
@@ -834,7 +834,7 @@ describe Kitchen::Provisioner::ChefBase do
 
     describe "when the license is required" do
       let(:acceptor) do
-        stub(license_required?: true, name_from_mixlib: "chef-client", check_and_persist: true, acceptance_value: "foo")
+        stub(license_required?: true, id_from_mixlib: "chef", check_and_persist: true, acceptance_value: "foo")
       end
       it "does not call the license-acceptance flow" do
         provisioner.check_license
@@ -843,14 +843,14 @@ describe Kitchen::Provisioner::ChefBase do
 
       describe "when there is an error accepting the license" do
         let(:product) do
-          stub(name: "chef-client")
+          stub(id: "chef-client", pretty_name: "Chef Infra Client")
         end
         let(:acceptor) do
-          stub(license_required?: true, name_from_mixlib: "chef-client")
+          stub(license_required?: true, id_from_mixlib: "chef")
         end
         it "raises the error" do
           acceptor.stubs(:check_and_persist).with do
-            raise LicenseAcceptance::LicenseNotAcceptedError.new([product])
+            raise LicenseAcceptance::LicenseNotAcceptedError.new(product, [product])
           end
           assert_raises(LicenseAcceptance::LicenseNotAcceptedError) { provisioner.check_license }
           config[:chef_license].must_be_nil

--- a/test-kitchen.gemspec
+++ b/test-kitchen.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |gem|
 
   # Required to run the Chef provisioner local license check for remote systems
   # TK is not under Chef EULA
-  gem.add_dependency "license-acceptance", "~> 1.0", ">= 1.0.8"
+  gem.add_dependency "license-acceptance", "~> 1.0", ">= 1.0.11"
 
   gem.add_development_dependency "rb-readline"
   gem.add_development_dependency "bundler"

--- a/test-kitchen.gemspec
+++ b/test-kitchen.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |gem|
 
   # Required to run the Chef provisioner local license check for remote systems
   # TK is not under Chef EULA
-  gem.add_dependency "license-acceptance", ">= 0.2.16", "< 2.0"
+  gem.add_dependency "license-acceptance", "~> 1.0", ">= 1.0.5"
 
   gem.add_development_dependency "rb-readline"
   gem.add_development_dependency "bundler"

--- a/test-kitchen.gemspec
+++ b/test-kitchen.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |gem|
 
   # Required to run the Chef provisioner local license check for remote systems
   # TK is not under Chef EULA
-  gem.add_dependency "license-acceptance", "~> 1.0", ">= 1.0.5"
+  gem.add_dependency "license-acceptance", "~> 1.0", ">= 1.0.8"
 
   gem.add_development_dependency "rb-readline"
   gem.add_development_dependency "bundler"


### PR DESCRIPTION
Make it so we can ship a TK 1.x that supports the latest Chef Infra Client.