### PR TITLE
Accept the license in the appveyor kitchen config

### DIFF
--- a/kitchen.appveyor.yml
+++ b/kitchen.appveyor.yml
@@ -9,6 +9,7 @@ driver:
 
 provisioner:
   name: chef_zero
+  chef_license: accept-no-persist
 
 platforms:
   - name: windows-2012R2


### PR DESCRIPTION
This should get appveyor green again

Signed-off-by: Tim Smith <tsmith@chef.io>