### PR TITLE
Implement --fail-fast option

### DIFF
--- a/lib/kitchen/cli.rb
+++ b/lib/kitchen/cli.rb
@@ -186,6 +186,11 @@ module Kitchen
                       default: false,
                       desc: "Run the #{action} with debugging enabled."
       end
+      method_option :fail_fast,
+        aliases: "-f",
+        type: :boolean,
+        desc: "Fail immediately when errors occur in concurrency mode"
+
       test_base_path
       log_options
       define_method(action) do |*args|

--- a/lib/kitchen/command.rb
+++ b/lib/kitchen/command.rb
@@ -170,6 +170,7 @@ module Kitchen
             end
           end
         end
+        Thread.abort_on_exception = true if options[:fail_fast]
         threads.map(&:join)
         report_errors
       end


### PR DESCRIPTION
replaces #740

This is simple, but testing will be difficult, we have no existing tests
around concurrency at all that I can see from grepping the
specs/features.