### PR TITLE
Add upload support to provisioner

### DIFF
--- a/docs/content/docs/provisioners/_index.md
+++ b/docs/content/docs/provisioners/_index.md
@@ -22,6 +22,8 @@ provisioner:
   retry_on_exit_code: []
   max_retries: 1
   wait_for_retry: 30
+  uploads: # a Hash of local => remote file mappings to upload at the start of invocation
+    "contrib/some_file.cfg": "/etc"
   downloads: # a Hash of remote => local file mappings to download post-converge
   # if the local value is an existing dir, the file will be copied into it
   # if the local value does not exist, a file with that value as name will be created

--- a/lib/kitchen/provisioner/base.rb
+++ b/lib/kitchen/provisioner/base.rb
@@ -51,6 +51,7 @@ module Kitchen
 
       default_config :command_prefix, nil
 
+      default_config :uploads, {}
       default_config :downloads, {}
 
       expand_path_for :test_base_path
@@ -72,6 +73,10 @@ module Kitchen
         sandbox_dirs = Util.list_directory(sandbox_path)
 
         instance.transport.connection(state) do |conn|
+          config[:uploads].to_h.each do |locals, remote|
+            debug("Uploading #{Array(locals).join(', ')} to #{remote}")
+            conn.upload(locals.to_s, remote)
+          end
           conn.execute(install_command)
           conn.execute(init_command)
           info("Transferring files to #{instance.to_str}")


### PR DESCRIPTION
In case of air-gapped or proxy-enforced environments, sometimes there is the need to upload installers to kitchen instances from the developer's machine. This patch replicates the `downloads` functionality of the base provisioner to include an `uploads` functionality as well.