### PR TITLE
Add Azure Pipelines CI support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
 # Managing line ending conversions
 # See http://git-scm.com/docs/gitattributes#_end-of-line_conversion
-* text=auto
+* text=auto eol=lf

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,9 +41,9 @@ matrix:
         - sudo apt-get update
         - sudo apt-get -y install squid3 git curl
       env:
-        - machine_user=travis
-        - machine_pass=travis
-        - machine_port=22
+        - MACHINE_USER=travis
+        - MACHINE_PASS=travis
+        - MACHINE_PORT=22
         - PROXY_TESTS_DIR=proxy_tests/files/default/scripts
         - PROXY_TESTS_REPO=$PROXY_TESTS_DIR/repo
         - KITCHEN_YAML=/home/travis/build/test-kitchen/test-kitchen/kitchen.proxy.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,115 @@
+---
+trigger:
+  batch: true
+  branches:
+    include:
+    - master
+    - 1-stable
+pr:
+  autoCancel: true
+  branches:
+    include: 
+      - master
+      - 1-stable
+
+variables:
+  CHEF_LICENSE: accept-no-persist
+
+stages:
+  - stage: Build
+    jobs:
+      - job: Validate
+        strategy:
+          matrix:
+            Windows_Ruby25:
+              version: 2.5.3
+              imageName: 'windows-2019'
+              task: windows_ci.bat
+            Windows_Ruby26:
+              version: 2.6.1
+              imageName: 'windows-2019'
+              task: windows_ci.bat
+            Linux_Ruby25:
+              version: 2.5.5
+              imageName: 'ubuntu-16.04'
+              task: linux_ci.sh
+              KITCHEN_YAML: kitchen.dokken.yml
+            Linux_Ruby26:
+              version: 2.6.2
+              imageName: 'ubuntu-16.04'
+              task: linux_ci.sh
+              KITCHEN_YAML: kitchen.dokken.yml
+            Mac_Ruby25:
+              version: 2.5.5
+              imageName: 'macOS-10.13'
+              task: mac_ci.sh
+            Mac_Ruby26:
+              version: 2.6.2
+              imageName: 'macOS-10.13'
+              task: mac_ci.sh
+            Windows_Integration:
+              version: 2.6.1
+              imageName: 'windows-2019'
+              task: windows_integration.bat
+              machine_user: test_user
+              machine_pass: Pass@word1
+              machine_port: 5985
+              KITCHEN_YAML: kitchen.appveyor.yml
+            Proxy_Integration:
+              version: 2.5.5
+              imageName: 'ubuntu-16.04'
+              task: proxy_ci.sh
+              MACHINE_USER: kitchen
+              MACHINE_PASS: K1tch3nY@ml!
+              MACHINE_PORT: 22
+              KITCHEN_YAML: ../../../../../../../kitchen.proxy.yml
+              PROXY_TESTS_DIR: proxy_tests/files/default/scripts
+              PROXY_TESTS_REPO: proxy_tests/files/default/scripts/repo
+        pool:
+          vmImage: $(imageName)
+        steps:
+          - task: UseRubyVersion@0
+            inputs:
+              versionSpec: $(version)
+              addToPath: true
+          - script: |
+              echo "ruby version:"
+              ruby --version
+              echo "gem version:"
+              gem --version
+            displayName: Show Ruby Version
+          - script: |
+              gem install bundler --quiet
+              echo "bundler version:"
+              bundler --version
+            displayName: Install Bundler
+          - script: |
+              bundle install || bundle install || bundle install
+            displayName: Bundle Install Dependencies
+            condition: ne(variables['task'], 'proxy_ci.sh')
+          - script: |
+              ./support/ci/$(task)
+            displayName: Run Tests
+            env:
+              SPEC_OPTS: --format progress
+      - job: Package
+        dependsOn: Validate
+        condition: and(succeeded(), eq(variables['build.sourceBranch'], 'refs/heads/master'), notIn(variables['Build.Reason'], 'PullRequest'))
+        pool:
+          imageName: 'ubuntu-16.04'
+        steps:
+          - task: UseRubyVersion@0
+            inputs:
+              versionSpec: 2.6.2
+              addToPath: true
+          - script: |
+              gem install bundler --quiet
+              bundle install || bundle install || bundle install
+              bundle exec rake build
+            displayName: Package Gem
+          - task: PublishBuildArtifacts@1
+            displayName: "Publish Artifact: Release Build"
+            inputs:
+              PathtoPublish: ./pkg
+              ArtifactName: gem
+              ArtifactType: Container

--- a/kitchen.proxy.yml
+++ b/kitchen.proxy.yml
@@ -3,9 +3,9 @@ driver:
   name: proxy
   host: localhost
   reset_command: "echo hello"
-  port: <%= ENV["machine_port"] %>
-  username: <%= ENV["machine_user"] %>
-  password: <%= ENV["machine_pass"] %>
+  port: <%= ENV["MACHINE_PORT"] %>
+  username: <%= ENV["MACHINE_USER"] %>
+  password: <%= ENV["MACHINE_PASS"] %>
 
 provisioner:
   name: chef_zero

--- a/spec/kitchen/util_spec.rb
+++ b/spec/kitchen/util_spec.rb
@@ -234,13 +234,16 @@ describe Kitchen::Util do
     end
 
     it "globs without parameters" do
-      Kitchen::Util.safe_glob(@root, "**/*").must_equal Dir.glob(File.join(@root, "**/*"))
+      expected = []
+      Dir.glob(File.join(@root, "**/*")) { |f| expected << os_safe_temp_path(f) }
+      Kitchen::Util.safe_glob(@root, "**/*").must_equal expected
     end
 
     it "globs with parameters" do
-      Kitchen::Util.safe_glob(@root, "**/*", File::FNM_DOTMATCH).must_equal(
-        Dir.glob(File.join(@root, "**/*"), File::FNM_DOTMATCH)
-      )
+      expected = []
+      Dir.glob(File.join(@root, "**/*"), File::FNM_DOTMATCH) { |f| expected << os_safe_temp_path(f) }
+      Kitchen::Util.safe_glob(@root, "**/*", File::FNM_DOTMATCH).must_equal expected
+
     end
 
     it "globs a folder that does not exist" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -99,7 +99,8 @@ end
 
 def os_safe_root_path(root_path)
   if running_tests_on_windows?
-    File.join(ENV["SystemDrive"], root_path).to_s
+    File.join(Dir.pwd[0..1], root_path).to_s
+    # File.join(ENV["SystemDrive"], root_path).to_s
   else
     root_path
   end
@@ -107,4 +108,13 @@ end
 
 def padded_octal_string(integer)
   integer.to_s(8).rjust(4, "0")
+end
+
+def os_safe_temp_path(temp_path)
+  if running_tests_on_windows? && ENV["USERNAME"].length > 8
+    short_name = ENV["USERNAME"].upcase[0..5] + "~1"
+    updated_path = temp_path.sub(ENV["USERNAME"], short_name)
+    return updated_path unless updated_path.nil?
+  end
+  temp_path
 end

--- a/support/ci/linux_ci.sh
+++ b/support/ci/linux_ci.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -e
+
+bundle exec rake
+bundle install --with integration
+bundle exec kitchen test

--- a/support/ci/mac_ci.sh
+++ b/support/ci/mac_ci.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -e
+
+bundle exec rake

--- a/support/ci/proxy_ci.sh
+++ b/support/ci/proxy_ci.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Add a local user for kitchen with a password we control.
+sudo -E useradd $MACHINE_USER --shell /bin/bash --create-home
+sudo -E usermod -p `openssl passwd -1 $MACHINE_PASS` $MACHINE_USER
+sudo -E usermod -aG sudo $MACHINE_USER
+
+# Make sure SSH can run on Azure DevOps hosted agent.
+sudo mkdir -p /var/run/sshd
+sudo service ssh restart
+
+# Install squid and git.
+sudo apt-get update
+sudo apt-get -y install squid3 git curl 
+git clone https://github.com/smurawski/proxy_tests.git
+
+# Add the ruby path to the secure path, so we can run the tests elevated (to manage the squid service)
+sudo echo 'Defaults	secure_path="/opt/hostedtoolcache/Ruby/2.5.5/x64/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin"' | sudo tee /etc/sudoers.d/kitchen
+sudo echo "" | sudo tee -a /etc/sudoers.d/kitchen
+sudo echo "kitchen ALL=(ALL) NOPASSWD:ALL" | sudo tee -a /etc/sudoers.d/kitchen
+sudo echo "" | sudo tee -a /etc/sudoers.d/kitchen
+
+
+# Install dependencies and run some tests!
+sudo -E bundle install --gemfile Gemfile.proxy_tests
+sudo -E bundle exec bash $PROXY_TESTS_DIR/run_tests.sh kitchen \* \* /tmp/out.txt
+cat /tmp/out.txt
+
+echo ""
+echo "===================="
+echo "Tests finished."
+echo "===================="
+echo ""
+
+sudo cat /var/log/squid/cache.log
+sudo cat /var/log/squid/access.log

--- a/support/ci/windows_ci.bat
+++ b/support/ci/windows_ci.bat
@@ -1,0 +1,1 @@
+bundle exec rake unit && bundle exec rake quality

--- a/support/ci/windows_integration.bat
+++ b/support/ci/windows_integration.bat
@@ -1,0 +1,5 @@
+  winrm.cmd quickconfig -q
+  net user /add %machine_user% %machine_pass%
+  net localgroup administrators %machine_user% /add
+  bundle install --with integration
+  bundle exec kitchen verify windows


### PR DESCRIPTION
Adds a `azure-pipelines.yml` and tweaks some of the test helpers to get tests running on the hosted build agents.

Sets up builds across Windows, Mac, and Linux and replicates the tests that are happening in Travis and AppVeyor.

Once the PR is merged, we can wire it up to Azure DevOps (along side the other CI environments) to compare behaviors/times.