### PR TITLE
Add keepalive_maxcount config to ssh connections

### DIFF
--- a/lib/kitchen/transport/ssh.rb
+++ b/lib/kitchen/transport/ssh.rb
@@ -46,6 +46,7 @@ module Kitchen
       default_config :username, "root"
       default_config :keepalive, true
       default_config :keepalive_interval, 60
+      default_config :keepalive_maxcount, 3
       # needs to be one less than the configured sshd_config MaxSessions
       default_config :max_ssh_sessions, 9
       default_config :connection_timeout, 15
@@ -468,6 +469,7 @@ module Kitchen
           compression_level: data[:compression_level],
           keepalive: data[:keepalive],
           keepalive_interval: data[:keepalive_interval],
+          keepalive_maxcount: data[:keepalive_maxcount],
           timeout: data[:connection_timeout],
           connection_retries: data[:connection_retries],
           connection_retry_sleep: data[:connection_retry_sleep],

--- a/spec/kitchen/transport/ssh_spec.rb
+++ b/spec/kitchen/transport/ssh_spec.rb
@@ -86,6 +86,10 @@ describe Kitchen::Transport::Ssh do
       transport[:keepalive_interval].must_equal 60
     end
 
+    it "sets :keepalive_maxcount to 3 by default" do
+      transport[:keepalive_maxcount].must_equal 3
+    end
+
     it "sets :connection_timeout to 15 by default" do
       transport[:connection_timeout].must_equal 15
     end


### PR DESCRIPTION
Adds keepalive_maxcount setting for better control of ssh connection timeouts. This setting defaults to 3 which is the same as the current default [from net-ssh](https://github.com/net-ssh/net-ssh/blob/v5.0.0/lib/net/ssh.rb#L140)