### PR TITLE
allow mixlib-shellout 3.x

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,7 +28,7 @@ stages:
               machine_port: 5985
               KITCHEN_YAML: kitchen.appveyor.yml
             Windows_Ruby26:
-              version: 2.6.3
+              version: 2.6.1
               machine_user: test_user
               machine_pass: Pass@word1
               machine_port: 5985

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,7 +28,7 @@ stages:
               machine_port: 5985
               KITCHEN_YAML: kitchen.appveyor.yml
             Windows_Ruby26:
-              version: 2.6.1
+              version: 2.6.3
               machine_user: test_user
               machine_pass: Pass@word1
               machine_port: 5985
@@ -72,7 +72,7 @@ stages:
             Mac_Ruby25:
               version: 2.5.5
             Mac_Ruby26:
-              version: 2.6.2
+              version: 2.6.3
         pool:
           vmImage: 'macOS-10.13'
         steps:
@@ -105,7 +105,7 @@ stages:
             Linux_Ruby25:
               version: 2.5.5
             Linux_Ruby26:
-              version: 2.6.2
+              version: 2.6.3
         pool:
           vmImage: 'ubuntu-16.04'
         steps:
@@ -207,7 +207,7 @@ stages:
         steps:
           - task: UseRubyVersion@0
             inputs:
-              versionSpec: 2.6.2
+              versionSpec: 2.6.3
               addToPath: true
           - script: |
               gem install bundler --quiet

--- a/test-kitchen.gemspec
+++ b/test-kitchen.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.3"
 
-  gem.add_dependency "mixlib-shellout",    ">= 1.2", "< 3.0"
+  gem.add_dependency "mixlib-shellout",    ">= 1.2", "< 4.0"
   gem.add_dependency "net-scp",            ">= 1.1", "< 3.0" # pinning until we can confirm 3+ works
   gem.add_dependency "net-ssh",            ">= 2.9", "< 6.0" # pinning until we can confirm 6+ works
   gem.add_dependency "net-ssh-gateway",    ">= 1.2", "< 3.0" # pinning until we can confirm 3+ works


### PR DESCRIPTION
required in a very roundabout manner for chef/chef#8861 to pass tests.