### PR TITLE
Make sure Policyfile.lock.json exists before calling chef update

### DIFF
--- a/lib/kitchen/provisioner/chef/policyfile.rb
+++ b/lib/kitchen/provisioner/chef/policyfile.rb
@@ -65,10 +65,6 @@ module Kitchen
         # Runs `chef install` to determine the correct cookbook set and
         # generate the policyfile lock.
         def compile
-          if always_update
-            info("Updating policy lock using `chef update`")
-            run_command("chef update #{escape_path(policyfile)}")
-          end
           if File.exist?(lockfile)
             info("Installing cookbooks for Policyfile #{policyfile} using `chef install`")
           else
@@ -76,6 +72,11 @@ module Kitchen
                  "Policyfile #{policyfile}...")
           end
           run_command("chef install #{escape_path(policyfile)}")
+
+          if always_update
+            info("Updating policy lock using `chef update`")
+            run_command("chef update #{escape_path(policyfile)}")
+          end
         end
 
         # Return the path to the lockfile corresponding to this policyfile.


### PR DESCRIPTION
Make sure that `Policyfile.lock.json` exists before we try to call `chef
update`.  

Otherwise when `always_update_cookbooks: true` is set in `kitchen.yml`
the following error is thrown.

```
Error: Failed to update Policyfile lock
Reason: (ChefCLI::LockfileNotFound) Policyfile lock not found at path <PATH>/Policyfile.lock.json
```