### PR TITLE
CI: loosen ruby version spec 

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -70,9 +70,9 @@ stages:
         strategy:
           matrix:
             Mac_Ruby25:
-              version: 2.5.5
+              version: 2.5
             Mac_Ruby26:
-              version: 2.6.3
+              version: 2.6
         pool:
           vmImage: 'macOS-10.13'
         steps:
@@ -103,9 +103,9 @@ stages:
         strategy:
           matrix:
             Linux_Ruby25:
-              version: 2.5.5
+              version: 2.5
             Linux_Ruby26:
-              version: 2.6.3
+              version: 2.6
         pool:
           vmImage: 'ubuntu-16.04'
         steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,13 +22,13 @@ stages:
         strategy:
           matrix:
             Windows_Ruby25:
-              version: 2.5.3
+              version: 2.5
               machine_user: test_user
               machine_pass: Pass@word1
               machine_port: 5985
               KITCHEN_YAML: kitchen.appveyor.yml
             Windows_Ruby26:
-              version: 2.6.1
+              version: 2.6
               machine_user: test_user
               machine_pass: Pass@word1
               machine_port: 5985


### PR DESCRIPTION
The ruby versions were bumped on the build workers and no longer matched.

I'm loosening the dependency (to just major/minor).

There's still a bit of tight coupling to fix in the proxy test scenario due to an issue with `sudo` and safe paths.  (see https://github.com/microsoft/azure-pipelines-image-generation/issues/1092) but I'll try to come up with something in the near future to make that a bit more resilient as well.

For now, this should fix any point release updates to the build images.