### PR TITLE
Use "Test Kitchen" not "Kitchen" when running the command

### DIFF
--- a/docs/content/docs/getting-started/05-instances.md
+++ b/docs/content/docs/getting-started/05-instances.md
@@ -15,7 +15,7 @@ Let's spin this **Instance** up to see what happens. We're going to be painfully
 
 ~~~
 $ kitchen create default-ubuntu-1604
------> Starting Kitchen (v1.23.2)
+-----> Starting Test Kitchen (v1.23.2)
 -----> Creating <default-ubuntu-1604>...
        Bringing machine 'default' up with 'virtualbox' provider...
        ==> default: Box 'bento/ubuntu-16.04' could not be found. Attempting to find and install...
@@ -56,7 +56,7 @@ $ kitchen create default-ubuntu-1604
        [SSH] Established
        Vagrant instance <default-ubuntu-1604> created.
        Finished creating <default-ubuntu-1604> (1m16.59s).
------> Kitchen is finished. (1m17.05s)
+-----> Test Kitchen is finished. (1m17.05s)
 ~~~
 
 Kitchen calls this the **Create Action** and several subcommands that we'll learn about later map directly to other **actions**. If you are a Vagrant user then the line containing `vagrant up --no-provision` will look familiar. This may take several minutes depending on

--- a/docs/content/docs/getting-started/07-running-converge.md
+++ b/docs/content/docs/getting-started/07-running-converge.md
@@ -10,7 +10,7 @@ menu:
 Now that we have a recipe, let's use `kitchen converge` to see if it works:
 
 ~~~
------> Starting Kitchen (v1.23.2)
+-----> Starting Test Kitchen (v1.23.2)
 -----> Creating <default-ubuntu-1604>...
        Bringing machine 'default' up with 'virtualbox' provider...
        ==> default: Importing base box 'bento/ubuntu-16.04'...
@@ -104,7 +104,7 @@ Now that we have a recipe, let's use `kitchen converge` to see if it works:
        Chef Client finished, 0/1 resources updated in 01 seconds
        Downloading files from <default-ubuntu-1604>
        Finished converging <default-ubuntu-1604> (0m22.49s).
------> Kitchen is finished. (1m2.47s)
+-----> Test Kitchen is finished. (1m2.47s)
 ~~~
 
 If you are a Chef user then part of the output above should look familiar to you. Here's what happened at a high level:

--- a/docs/content/docs/getting-started/10-running-verify.md
+++ b/docs/content/docs/getting-started/10-running-verify.md
@@ -11,7 +11,7 @@ In order to execute our test, we use the command `kitchen verify`:
 
 ~~~
 $ kitchen verify default-ubuntu-1604
------> Starting Kitchen (v1.23.2)
+-----> Starting Test Kitchen (v1.23.2)
 -----> Setting up <default-ubuntu-1604>...
        Finished setting up <default-ubuntu-1604> (0m0.00s).
 -----> Verifying <default-ubuntu-1604>...
@@ -26,7 +26,7 @@ Target:  ssh://vagrant@127.0.0.1:2222
 
 Test Summary: 1 successful, 0 failures, 0 skipped
        Finished verifying <default-ubuntu-1604> (0m0.28s).
------> Kitchen is finished. (0m3.33s)
+-----> Test Kitchen is finished. (0m3.33s)
 ~~~
 
 A few things of note from the output above:
@@ -60,7 +60,7 @@ And re-run the **verify** subcommand:
 
 ~~~
 $ kitchen verify default-ubuntu-1604
------> Starting Kitchen (v1.23.2)
+-----> Starting Test Kitchen (v1.23.2)
 -----> Verifying <default-ubuntu-1604>...
        Loaded tests from {:path=>".Users.cheeseplus.focus.git_cookbook.test.integration.default"}
 
@@ -96,7 +96,7 @@ Then verify our revert:
 
 ~~~
 $ kitchen verify default-ubuntu-1604
------> Starting Kitchen (v1.23.2)
+-----> Starting Test Kitchen (v1.23.2)
 -----> Verifying <default-ubuntu-1604>...
        Loaded tests from {:path=>".Users.cheeseplus.focus.git_cookbook.test.integration.default"}
 
@@ -109,7 +109,7 @@ Target:  ssh://vagrant@127.0.0.1:2222
 
 Test Summary: 1 successful, 0 failures, 0 skipped
        Finished verifying <default-ubuntu-1604> (0m0.32s).
------> Kitchen is finished. (0m3.06s)
+-----> Test Kitchen is finished. (0m3.06s)
 ~~~
 
 One of the advantages of `kitchen-inspec` is that the InSpec tests are executed from the host over the transport (SSH or WinRM) to the instance. No tests need to be uploaded to the instance itself.

--- a/docs/content/docs/getting-started/11-running-test.md
+++ b/docs/content/docs/getting-started/11-running-test.md
@@ -10,7 +10,7 @@ menu:
 Now it's time to introduce to the **test** meta-action which helps you automate all the previous actions so far into one command. Checking `kitchen list`, the "Last Action" of our instance should be "Verified". With this in mind, let's run `kitchen test`:
 
 ~~~
------> Starting Kitchen (v1.23.2)
+-----> Starting Test Kitchen (v1.23.2)
 -----> Cleaning up any prior instances of <default-ubuntu-1604>
 -----> Destroying <default-ubuntu-1604>...
        ==> default: Forcing shutdown of VM...
@@ -135,7 +135,7 @@ Test Summary: 1 successful, 0 failures, 0 skipped
        Vagrant instance <default-ubuntu-1604> destroyed.
        Finished destroying <default-ubuntu-1604> (0m5.61s).
        Finished testing <default-ubuntu-1604> (1m10.75s).
------> Kitchen is finished. (1m13.21s)
+-----> Test Kitchen is finished. (1m13.21s)
 ~~~
 
 There's only one remaining action left that needs a mention: the **Destroy Action** which as one might expect, destroys the instance. With this in mind, here's what kitchen is doing in the **Test Action**:

--- a/docs/content/docs/getting-started/12-adding-platform.md
+++ b/docs/content/docs/getting-started/12-adding-platform.md
@@ -54,7 +54,7 @@ Let's see how CentOS runs our cookbook:
 
 ~~~
 $ kitchen verify 7
------> Starting Kitchen (v1.23.2)
+-----> Starting Test Kitchen (v1.23.2)
 -----> Creating <default-centos-7>...
        Bringing machine 'default' up with 'virtualbox' provider...
        ==> default: Box 'bento/centos-7' could not be found. Attempting to find and install...
@@ -169,14 +169,14 @@ Target:  ssh://vagrant@127.0.0.1:2222
 
 Test Summary: 1 successful, 0 failures, 0 skipped
        Finished verifying <default-centos-7> (0m0.65s).
------> Kitchen is finished. (2m12.04s)
+-----> Test Kitchen is finished. (2m12.04s)
 ~~~
 
 Nice! We've verified that our cookbook works on Ubuntu 16.04 and CentOS 7. Since the CentOS instance is no longer needed, let's destroy it for now:
 
 ~~~
 $ kitchen destroy
------> Starting Kitchen (v1.23.2)
+-----> Starting Test Kitchen (v1.23.2)
 -----> Destroying <default-ubuntu-1604>...
        Finished destroying <default-ubuntu-1604> (0m0.00s).
 -----> Destroying <default-centos-7>...
@@ -184,7 +184,7 @@ $ kitchen destroy
        ==> default: Destroying VM and associated drives...
        Vagrant instance <default-centos-7> destroyed.
        Finished destroying <default-centos-7> (0m5.89s).
------> Kitchen is finished. (0m8.62s)
+-----> Test Kitchen is finished. (0m8.62s)
 ~~~
 
 Interesting. Kitchen tried to destroy both instances, one that was created and the other that was not. Which brings us to another tip with the `kitchen` command:

--- a/docs/content/docs/getting-started/17-excluding-platforms.md
+++ b/docs/content/docs/getting-started/17-excluding-platforms.md
@@ -73,7 +73,7 @@ Finally let's destroy our running instances:
 
 ~~~
 $ kitchen destroy
------> Starting Kitchen (v1.23.2)
+-----> Starting Test Kitchen (v1.23.2)
 -----> Destroying <default-ubuntu-1604>...
        Finished destroying <default-ubuntu-1604> (0m0.00s).
 -----> Destroying <default-centos-7>...
@@ -83,7 +83,7 @@ $ kitchen destroy
        ==> default: Destroying VM and associated drives...
        Vagrant instance <server-ubuntu-1604> destroyed.
        Finished destroying <server-ubuntu-1604> (0m12.55s).
------> Kitchen is finished. (0m17.39s)
+-----> Test Kitchen is finished. (0m17.39s)
 ~~~
 
 Now that we've completed our git daemon feature and made sure we're testing it on only the

--- a/docs/static/index.html
+++ b/docs/static/index.html
@@ -51,7 +51,7 @@ Finished verifying
 
 <span style="color: #f4bf75">--</span><span style="color: #f8f8f2">&gt;</span> Destroying
 
-<span style="color: #f4bf75">--</span><span style="color: #f8f8f2">&gt;</span> Kitchen is finished.
+<span style="color: #f4bf75">--</span><span style="color: #f8f8f2">&gt;</span> Test Kitchen is finished.
 <span style="color: #f8f8f2">(</span>1m44.11s<span style="color: #f8f8f2">)</span>
 </code></pre></div></div></div><div class="columns medium-6"><div class="home--text--rightcol"><h2 class="body-heading">How do I get started?</h2><p>Install the <a href="https://downloads.chef.io/chefdk/">Chef
 Development Kit (ChefDK)</a> to get started.  Alternatively,

--- a/features/kitchen_test_command.feature
+++ b/features/kitchen_test_command.feature
@@ -25,11 +25,11 @@ Feature: Running a full test instance test
   @spawn
   Scenario: Running a single instance
     When I run `kitchen test client-beans`
-    Then the output should contain "Starting Kitchen"
+    Then the output should contain "Starting Test Kitchen"
     Then the output should contain "Cleaning up any prior instances of <client-beans>"
     Then the output should contain "Testing <client-beans>"
     Then the output should contain "Finished testing <client-beans>"
-    Then the output should contain "Kitchen is finished."
+    Then the output should contain "Test Kitchen is finished."
     And the exit status should be 0
 
   @spawn
@@ -74,12 +74,12 @@ Feature: Running a full test instance test
   @spawn
   Scenario: Running all instances
     When I run `kitchen test`
-    Then the output should contain "Starting Kitchen"
+    Then the output should contain "Starting Test Kitchen"
     Then the output should contain "Finished testing <client-cool>"
     Then the output should contain "Finished testing <client-beans>"
     Then the output should contain "Finished testing <server-cool>"
     Then the output should contain "Finished testing <server-beans>"
-    Then the output should contain "Kitchen is finished."
+    Then the output should contain "Test Kitchen is finished."
     And the exit status should be 0
     When I successfully run `kitchen list`
     Then the output should match /^client-cool\s+.+\s+\<Not Created\>\s+\<None\>$/

--- a/lib/kitchen/command/action.rb
+++ b/lib/kitchen/command/action.rb
@@ -30,12 +30,12 @@ module Kitchen
 
       # Invoke the command.
       def call
-        banner "Starting Kitchen (v#{Kitchen::VERSION})"
+        banner "Starting Test Kitchen (v#{Kitchen::VERSION})"
         elapsed = Benchmark.measure do
           results = parse_subcommand(args.first)
           run_action(action, results)
         end
-        banner "Kitchen is finished. #{Util.duration(elapsed.real)}"
+        banner "Test Kitchen is finished. #{Util.duration(elapsed.real)}"
       end
     end
   end

--- a/lib/kitchen/command/test.rb
+++ b/lib/kitchen/command/test.rb
@@ -34,14 +34,14 @@ module Kitchen
           raise ArgumentError, "Destroy mode must be passing, always, or never."
         end
 
-        banner "Starting Kitchen (v#{Kitchen::VERSION})"
+        banner "Starting Test Kitchen (v#{Kitchen::VERSION})"
         elapsed = Benchmark.measure do
           destroy_mode = options[:destroy].to_sym
           results = parse_subcommand(args.join("|"))
 
           run_action(:test, results, destroy_mode)
         end
-        banner "Kitchen is finished. #{Util.duration(elapsed.real)}"
+        banner "Test Kitchen is finished. #{Util.duration(elapsed.real)}"
       end
     end
   end


### PR DESCRIPTION
We've never really been consistent with this. The command is kitche, but
the product we're starting is Test Kitchen. We should refer to it by the
product name.

Signed-off-by: Tim Smith <tsmith@chef.io>