### PR TITLE
Update policyfile provisioner to find BAT/EXE bins

### DIFF
--- a/lib/kitchen/provisioner/chef/policyfile.rb
+++ b/lib/kitchen/provisioner/chef/policyfile.rb
@@ -136,8 +136,15 @@ module Kitchen
           # @raise [UserError] if the `chef` command is not in the PATH
           # @api private
           def detect_chef_command!(logger)
-            unless ENV["PATH"].split(File::PATH_SEPARATOR).any? do |p|
-              File.exist?(File.join(p, "chef"))
+            unless ENV["PATH"].split(File::PATH_SEPARATOR).any? do |path|
+              if RbConfig::CONFIG["host_os"] =~ /mswin|mingw/
+                # Windows could have differenct extentions: BAT, EXE or NONE
+                %w{chef chef.exe chef.bat}.each do |bin|
+                  File.exist?(File.join(path, bin))
+                end
+              else
+                File.exist?(File.join(path, "chef"))
+              end
             end
               logger.fatal("The `chef` executable cannot be found in your " \
                           "PATH. Ensure you have installed ChefDK or Chef Workstation " \

--- a/lib/kitchen/provisioner/chef/policyfile.rb
+++ b/lib/kitchen/provisioner/chef/policyfile.rb
@@ -138,7 +138,7 @@ module Kitchen
           def detect_chef_command!(logger)
             unless ENV["PATH"].split(File::PATH_SEPARATOR).any? do |path|
               if RbConfig::CONFIG["host_os"] =~ /mswin|mingw/
-                # Windows could have differenct extentions: BAT, EXE or NONE
+                # Windows could have different extentions: BAT, EXE or NONE
                 %w{chef chef.exe chef.bat}.each do |bin|
                   File.exist?(File.join(path, bin))
                 end


### PR DESCRIPTION
The latest release of Chef Workstation implemented a new `chef`
top-level wrapper that doesn't deploy a `chef` binary itself, but
instead a `chef.exe`.

Previous versions used `chef.bat` and `chef` without extension so this
should give backward compatibility.

Issue: https://github.com/chef/chef-workstation/issues/633

Signed-off-by: Salim Afiune <afiune@chef.io>