### PR TITLE
add caching steps

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -86,7 +86,12 @@ stages:
             inputs:
               key: gems | $(Agent.OS) | "$(version)" | test-kitchen.gemspec | Gemfile | Gemfile.proxy_tests
               path: $(BUNDLE_PATH)
+              cacheHitVar: CACHE_RESTORED
             displayName: Cache gems
+          - script: |
+              chmod a+x $(BUNDLE_PATH)/bin/*
+            condition: ne(variables.CACHE_RESTORED, 'false')
+            displayName: Restore Executable Bit For Cached Binstubs
           - task: UseRubyVersion@0
             inputs:
               versionSpec: $(version)
@@ -124,7 +129,12 @@ stages:
             inputs:
               key: gems | $(Agent.OS) | "$(version)" | test-kitchen.gemspec | Gemfile | Gemfile.proxy_tests
               path: $(BUNDLE_PATH)
+              cacheHitVar: CACHE_RESTORED
             displayName: Cache gems
+          - script: |
+              chmod a+x $(BUNDLE_PATH)/bin/*
+            condition: ne(variables.CACHE_RESTORED, 'false')
+            displayName: Restore Executable Bit For Cached Binstubs
           - task: UseRubyVersion@0
             inputs:
               versionSpec: $(version)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,6 +13,7 @@ pr:
       - 1-stable
 
 variables:
+  BUNDLE_PATH: $(Pipeline.Workspace)/.bundle
   CHEF_LICENSE: accept-no-persist
 
 stages:
@@ -36,6 +37,11 @@ stages:
         pool:
           vmImage: windows-2019
         steps:
+          - task: CacheBeta@1
+            inputs:
+              key: gems | $(Agent.OS) | "$(version)" | test-kitchen.gemspec | Gemfile | Gemfile.proxy_tests
+              path: $(BUNDLE_PATH)
+            displayName: Cache gems
           - task: UseRubyVersion@0
             inputs:
               versionSpec: $(version)
@@ -76,6 +82,11 @@ stages:
         pool:
           vmImage: 'macOS-10.13'
         steps:
+          - task: CacheBeta@1
+            inputs:
+              key: gems | $(Agent.OS) | "$(version)" | test-kitchen.gemspec | Gemfile | Gemfile.proxy_tests
+              path: $(BUNDLE_PATH)
+            displayName: Cache gems
           - task: UseRubyVersion@0
             inputs:
               versionSpec: $(version)
@@ -109,6 +120,11 @@ stages:
         pool:
           vmImage: 'ubuntu-16.04'
         steps:
+          - task: CacheBeta@1
+            inputs:
+              key: gems | $(Agent.OS) | "$(version)" | test-kitchen.gemspec | Gemfile | Gemfile.proxy_tests
+              path: $(BUNDLE_PATH)
+            displayName: Cache gems
           - task: UseRubyVersion@0
             inputs:
               versionSpec: $(version)


### PR DESCRIPTION
Added pipeline caching.

Linux and Mac agents required a workaround to restore the executable bit to binstubs created by bundler ( see https://github.com/microsoft/azure-pipelines-tasks/issues/11204 )