### PR TITLE
add download capability to verifier base

### DIFF
--- a/lib/kitchen/verifier/base.rb
+++ b/lib/kitchen/verifier/base.rb
@@ -75,6 +75,13 @@ module Kitchen
           debug("Transfer complete")
           conn.execute(prepare_command)
           conn.execute(run_command)
+
+          info("Downloading files from #{instance.to_str}")
+          config[:downloads].to_h.each do |remotes, local|
+            debug("Downloading #{Array(remotes).join(", ")} to #{local}")
+            conn.download(remotes, local)
+          end
+          debug("Download complete")
         end
       rescue Kitchen::Transport::TransportFailed => ex
         raise ActionFailed, ex.message


### PR DESCRIPTION
Adds the download support to the verifier to be able to pull back test run results.

Needed to support https://github.com/test-kitchen/kitchen-pester/issues/42 without streaming/scraping the output report back from the console text.