### PR TITLE
Add instance name to download path when downloading files

### DIFF
--- a/lib/kitchen/verifier/base.rb
+++ b/lib/kitchen/verifier/base.rb
@@ -78,7 +78,7 @@ module Kitchen
 
           info("Downloading files from #{instance.to_str}")
           config[:downloads].to_h.each do |remotes, local|
-            safe_instance_name = instance.name.gsub(/[^0-9A-Z-]/i, '_')
+            safe_instance_name = instance.name.gsub(/[^0-9A-Z-]/i, "_")
             local_path = File.join(local, safe_instance_name)
 
             debug("Downloading #{Array(remotes).join(", ")} to #{local_path}")

--- a/lib/kitchen/verifier/base.rb
+++ b/lib/kitchen/verifier/base.rb
@@ -78,8 +78,11 @@ module Kitchen
 
           info("Downloading files from #{instance.to_str}")
           config[:downloads].to_h.each do |remotes, local|
-            debug("Downloading #{Array(remotes).join(", ")} to #{local}")
-            conn.download(remotes, local)
+            safe_instance_name = instance.name.gsub(/[^0-9A-Z-]/i, '_')
+            local_path = File.join(local, safe_instance_name)
+
+            debug("Downloading #{Array(remotes).join(", ")} to #{local_path}")
+            conn.download(remotes, local_path)
           end
           debug("Download complete")
         end

--- a/spec/kitchen/verifier/base_spec.rb
+++ b/spec/kitchen/verifier/base_spec.rb
@@ -224,10 +224,10 @@ describe Kitchen::Verifier::Base do
 
       logged_output.string.must_match(/DEBUG -- : Transfer complete$/)
       logged_output.string.must_match(
-        %r{DEBUG -- : Downloading /tmp/kitchen/nodes, /tmp/kitchen/data_bags to ./test/fixtures$}
+        %r{DEBUG -- : Downloading /tmp/kitchen/nodes, /tmp/kitchen/data_bags to ./test/fixtures/coolbeans$}
       )
       logged_output.string.must_match(
-        %r{DEBUG -- : Downloading /remote to /local$}
+        %r{DEBUG -- : Downloading /remote to /local/coolbeans$}
       )
       logged_output.string.must_match(/DEBUG -- : Download complete$/)
     end
@@ -235,10 +235,10 @@ describe Kitchen::Verifier::Base do
     it "downloads files" do
       connection.expects(:download).with(
         ["/tmp/kitchen/nodes", "/tmp/kitchen/data_bags"],
-        "./test/fixtures"
+        "./test/fixtures/coolbeans"
       )
 
-      connection.expects(:download).with("/remote", "/local")
+      connection.expects(:download).with("/remote", "/local/coolbeans")
 
       cmd
     end


### PR DESCRIPTION
If the same download path is used for all instances, it may prove problematic, especially if it is configured to download specific files; the file would be overwritten and the data lost.

Adding the instance name to the path allows the feature to be used by multiple instances in succession without potentially overwriting files.

/cc @tas50 @smurawski @gep13 