### PR TITLE
Pass in all local env vars to the instance

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -225,7 +225,7 @@ stages:
         steps:
           - task: UseRubyVersion@0
             inputs:
-              versionSpec: 2.6.3
+              versionSpec: 2.6.5
               addToPath: true
           - script: |
               gem install bundler --quiet

--- a/lib/kitchen/configurable.rb
+++ b/lib/kitchen/configurable.rb
@@ -349,8 +349,8 @@ module Kitchen
       code_parts = resolve_proxy_settings_from_config
       code_parts << shell_env_var("TEST_KITCHEN", 1)
       code_parts << shell_env_var("CI", ENV["CI"]) if ENV["CI"]
-      ENV.select { |key, value| key.start_with?("KITCHEN_") }.each do |key, value|
-        env_var_name = "#{key}".sub!("KITCHEN_", "")
+      ENV.select { |key, value| key.start_with?("TKENV_") }.each do |key, value|
+        env_var_name = "#{key}".sub!("TKENV_", "")
         code_parts << shell_env_var(env_var_name, value)
       end
 

--- a/lib/kitchen/configurable.rb
+++ b/lib/kitchen/configurable.rb
@@ -350,7 +350,7 @@ module Kitchen
       code_parts << shell_env_var("TEST_KITCHEN", 1)
       code_parts << shell_env_var("CI", ENV["CI"]) if ENV["CI"]
       ENV.select{|key, value| key.start_with?('KITCHEN_') }.each do |key, value|
-        env_var_name = key.sub!('KITCHEN_', '')
+        env_var_name = "#{key}".sub!('KITCHEN_', '')
         code_parts << shell_env_var(env_var_name, value)
       end
 

--- a/lib/kitchen/configurable.rb
+++ b/lib/kitchen/configurable.rb
@@ -349,6 +349,11 @@ module Kitchen
       code_parts = resolve_proxy_settings_from_config
       code_parts << shell_env_var("TEST_KITCHEN", 1)
       code_parts << shell_env_var("CI", ENV["CI"]) if ENV["CI"]
+      ENV.select{|key, value| key.start_with?('KITCHEN_') }.each do |key, value|
+        env_var_name = key.sub!('KITCHEN_', '')
+        code_parts << shell_env_var(env_var_name, value)
+      end
+
       code_parts << code
       code_parts.join("\n")
     end

--- a/lib/kitchen/configurable.rb
+++ b/lib/kitchen/configurable.rb
@@ -349,8 +349,8 @@ module Kitchen
       code_parts = resolve_proxy_settings_from_config
       code_parts << shell_env_var("TEST_KITCHEN", 1)
       code_parts << shell_env_var("CI", ENV["CI"]) if ENV["CI"]
-      ENV.select{|key, value| key.start_with?('KITCHEN_') }.each do |key, value|
-        env_var_name = "#{key}".sub!('KITCHEN_', '')
+      ENV.select { |key, value| key.start_with?("KITCHEN_") }.each do |key, value|
+        env_var_name = "#{key}".sub!("KITCHEN_", "")
         code_parts << shell_env_var(env_var_name, value)
       end
 

--- a/spec/kitchen/configurable_spec.rb
+++ b/spec/kitchen/configurable_spec.rb
@@ -930,8 +930,8 @@ describe Kitchen::Configurable do
         CODE
       end
 
-      it "exports FOO when KITCHEN_FOO is set" do
-        ENV["KITCHEN_FOO"] = "BAR"
+      it "exports FOO when TKENV_FOO is set" do
+        ENV["TKENV_FOO"] = "BAR"
 
         cmd.must_equal(outdent!(<<-CODE.chomp))
           sh -c '
@@ -1094,8 +1094,8 @@ describe Kitchen::Configurable do
         CODE
       end
 
-      it "exports FOO when KITCHEN_FOO is set" do
-        ENV["KITCHEN_FOO"] = "BAR"
+      it "exports FOO when TKENV_FOO is set" do
+        ENV["TKENV_FOO"] = "BAR"
 
         cmd.must_equal(outdent!(<<-CODE.chomp))
           $env:TEST_KITCHEN = "1"

--- a/spec/kitchen/configurable_spec.rb
+++ b/spec/kitchen/configurable_spec.rb
@@ -929,6 +929,18 @@ describe Kitchen::Configurable do
           '
         CODE
       end
+
+      it "exports FOO when KITCHEN_FOO is set" do
+        ENV["KITCHEN_FOO"] = "BAR"
+
+        cmd.must_equal(outdent!(<<-CODE.chomp))
+          sh -c '
+          TEST_KITCHEN="1"; export TEST_KITCHEN
+          FOO="BAR"; export FOO
+          mkdir foo
+          '
+        CODE
+      end
     end
 
     describe "for powershell shells" do
@@ -1081,6 +1093,17 @@ describe Kitchen::Configurable do
           mkdir foo
         CODE
       end
+
+      it "exports FOO when KITCHEN_FOO is set" do
+        ENV["KITCHEN_FOO"] = "BAR"
+
+        cmd.must_equal(outdent!(<<-CODE.chomp))
+          $env:TEST_KITCHEN = "1"
+          $env:FOO = "BAR"
+          mkdir foo
+        CODE
+      end
+
     end
   end
 


### PR DESCRIPTION
## Description

This commit will add the ability to push in additional env vars from the host to the client, it will push all env vars which start KITCHEN_ to the machine

Signed-off-by: Jason Field <jason@avon-lea.co.uk>

## Issues fixed

#1622 
