### PR TITLE
[WIP] consider root_path given under provisioner option

### DIFF
--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -509,6 +509,8 @@ module Kitchen
           channel: config[:channel].to_sym,
           install_command_options: {
             install_strategy: config[:install_strategy],
+            tmp_dir: config[:root_path],
+            "TMPDIR" => config[:root_path],
           },
         }.tap do |opts|
           opts[:shell_type] = :ps1 if powershell_shell?
@@ -534,7 +536,6 @@ module Kitchen
             # install.ps1 only supports http_proxy
             prox.delete_if { |p| %i{https_proxy ftp_proxy no_proxy}.include?(p) } if powershell_shell?
           end
-
           opts[:install_command_options].merge!(proxies)
         end)
         config[:chef_omnibus_root] = installer.root
@@ -553,13 +554,12 @@ module Kitchen
       end
 
       def install_from_file(command)
-        install_file = "/tmp/chef-installer.sh"
-        script = ["cat > #{install_file} <<\"EOL\""]
-        script << command
-        script << "EOL"
+        install_file = "#{config[:root_path]}/chef-installer.sh"
+        script = ["mkdir -p #{config[:root_path]}"]
+        script << "echo #{command} | tee #{install_file}"
         script << "chmod +x #{install_file}"
-        script << sudo(install_file)
-        script.join("\n")
+        script << install_file
+        script.map{ |cmd| sudo(cmd) }.join(";\n")
       end
 
       # @return [String] contents of version based install script


### PR DESCRIPTION
This is an in-progress PR and some fixes are needed.

Changes done so far:
- Passing tmp_dir and TMPDIR options to mixlib-install [WIP]
- The option would then reflect under [helpers.sh](https://github.com/chef/mixlib-install/blob/master/lib/mixlib/install/generator/bourne/scripts/helpers.sh.erb#L324) script.
- Other changes includes fixes done in addition to a previous [PR#1369](https://github.com/test-kitchen/test-kitchen/pull/1369) which was reverted due to some issue.
- Possible issue could be:  "sudo cat with redirect" creates an ambiguity for shell and so it raises permission denied error. An alternative is to use tee with pipe (|).
- There is a related discussion for the [reference](https://stackoverflow.com/questions/10134901/why-sudo-cat-gives-a-permission-denied-but-sudo-vim-works-fine).
- Stucked at passing params to mixlib-install's helper.sh
- Testing under progress.

Signed-off-by: Nimesh-Msys <nimesh.patni@msystechnologies.com>

Issues Resolved:
#1364 
[#customer-bugs#4](https://github.com/chef/customer-bugs/issues/4)