### PR TITLE
Add kitchen*.yml to the chefignore in kitchen init

### DIFF
--- a/templates/init/chefignore.erb
+++ b/templates/init/chefignore.erb
@@ -1,1 +1,2 @@
 .kitchen
+kitchen*.yml


### PR DESCRIPTION
We should be ignoring the actual kitchen configs as well

Signed-off-by: Tim Smith <tsmith@chef.io>