### PR TITLE
include ohai directory in cookbooks

### DIFF
--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -69,6 +69,7 @@ module Kitchen
         README.* VERSION metadata.{json,rb} attributes.rb recipe.rb
         attributes/**/* definitions/**/* files/**/* libraries/**/*
         providers/**/* recipes/**/* resources/**/* templates/**/*
+        ohai/**/*
       ).join(",")
       # to ease upgrades, allow the user to turn deprecation warnings into errors
       default_config :deprecations_as_errors, false


### PR DESCRIPTION
This changes allows test-kitchen to work with the documented placement of ohai plugins: https://docs.chef.io/cookbooks/#components