### PR TITLE
Windows Shell fixes

### DIFF
--- a/lib/kitchen/provisioner/shell.rb
+++ b/lib/kitchen/provisioner/shell.rb
@@ -106,13 +106,17 @@ module Kitchen
 
         if config[:arguments] && !config[:arguments].empty?
           if config[:arguments].is_a?(Array)
-            script = Shellwords.join([script] + config[:arguments])
+            if powershell_shell?
+              script = ([script] + config[:arguments]).join(" ")
+            else
+              script = Shellwords.join([script] + config[:arguments])
+            end
           else
             script.concat(" ").concat(config[:arguments].to_s)
           end
         end
 
-        code = powershell_shell? ? %{& "#{script}"} : sudo(script)
+        code = powershell_shell? ? %{& #{script}} : sudo(script)
 
         prefix_command(wrap_shell_code(code))
       end

--- a/spec/kitchen/provisioner/shell_spec.rb
+++ b/spec/kitchen/provisioner/shell_spec.rb
@@ -447,7 +447,7 @@ describe Kitchen::Provisioner::Shell do
       it "invokes the bootstrap.ps1 script" do
         config[:root_path] = '\\r'
 
-        cmd.must_match regexify(%{& "\\r\\bootstrap.ps1"})
+        cmd.must_match regexify(%{& \\r\\bootstrap.ps1})
       end
     end
   end


### PR DESCRIPTION
Currently, it's effectively impossible to run powershell scripts with the provisioner, or to pass arguments to powershell provisioners, which this PR fixes.

- Remove quotes from powershell commands, which was grouping
  the script name with the arguments, causing failures.
  e.g: `somescript.ps1 myarg1 myarg2` => `"somescript.ps1 myarg1 myarg2"`
  Powershell would complain that the executable doesn't exist.

- Don't use `Shellwords.join()` for powershell. This was generating
  `\$env:TEMP/somescript.ps1` (escaping the dollar sign) which
  powershell evaluated to `\C:\Users\someuser\...etc` leaving the
  backslash before `C:` which caused it not find the file.

- Update affected tests