### PR TITLE
WinRM exec driver file limit

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,7 +23,7 @@ stages:
         strategy:
           matrix:
             Windows_Ruby25:
-              version: 2.5.7
+              version: 2.5.8
               machine_user: test_user
               machine_pass: Pass@word1
               machine_port: 5985
@@ -169,7 +169,7 @@ stages:
         steps:
           - task: UseRubyVersion@0
             inputs:
-              versionSpec: 2.5.7
+              versionSpec: 2.5.8
               addToPath: true
           - script: |
               echo "ruby version:"
@@ -225,7 +225,7 @@ stages:
         steps:
           - task: UseRubyVersion@0
             inputs:
-              versionSpec: 2.6.5
+              versionSpec: 2.6.6
               addToPath: true
           - script: |
               gem install bundler --quiet

--- a/spec/kitchen/transport/winrm_spec.rb
+++ b/spec/kitchen/transport/winrm_spec.rb
@@ -963,6 +963,40 @@ describe Kitchen::Transport::Winrm::Connection do
       end
     end
 
+
+    describe "long command" do
+      let(:command) { %{Write-Host "#{"a" * 4000}"} }
+
+      let(:connection) do
+        Kitchen::Transport::WinRMConnectionDummy.new(options)
+      end
+
+      let(:response) do
+        o = WinRM::Output.new
+        o[:exitcode] = 0
+        o[:data].concat([
+          { :stdout => "ok\r\n" },
+          { :stderr => "congrats\r\n" }
+        ])
+        o
+      end
+
+      before do
+        executor.expects(:open).returns("shell-123")
+        executor.expects(:run_powershell_script).
+          with(%{& "$env:TEMP/kitchen/coolbeans-long_script.ps1"}).
+          yields("ok\n", nil).returns(response)
+      end
+
+      it "uploads the long command" do
+        with_fake_fs do
+          connection.execute(command)
+
+          connection.saved_command.must_equal command
+        end
+      end
+    end
+
     [
       Errno::EACCES, Errno::EADDRINUSE, Errno::ECONNREFUSED,
       Errno::ECONNRESET, Errno::ENETUNREACH, Errno::EHOSTUNREACH,


### PR DESCRIPTION
This commit will put files on disk via winrm when they are greater than 3000 characters, if this is not done the exec driver will blow up as the cli commands will be greater than the 8k character limit in windows cli (base64 doubles character count)
This was orginally done in #878 and then appears to have been removed in #1061

Without the exec driver working it is not possible to use github actions without supplying your own build runner

Relates to #1630

Signed-off-by: Jason Field <jason@avon-lea.co.uk>