### PR TITLE
Fix builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ tmp
 .rvmrc
 .rbenv-version
 .ruby-version
+.envrc
+.direnv/
 .project
 .DS_Store
 .kitchen/

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,7 +23,7 @@ stages:
         strategy:
           matrix:
             Windows_Ruby25:
-              version: 2.5.7
+              version: 2.5
               machine_user: test_user
               machine_pass: Pass@word1
               machine_port: 5985
@@ -35,7 +35,7 @@ stages:
               machine_port: 5985
               KITCHEN_YAML: kitchen.appveyor.yml
         pool:
-          vmImage: windows-2019
+          vmImage: windows-latest
         steps:
           - task: Cache@2
             inputs:
@@ -80,7 +80,7 @@ stages:
             Mac_Ruby26:
               version: 2.6
         pool:
-          vmImage: "macOS-10.13"
+          vmImage: "macOS-latest"
         steps:
           - task: Cache@2
             inputs:
@@ -119,7 +119,7 @@ stages:
             Linux_Ruby26:
               version: 2.6
         pool:
-          vmImage: "ubuntu-16.04"
+          vmImage: "ubuntu-latest"
         steps:
           - task: Cache@2
             inputs:
@@ -165,11 +165,11 @@ stages:
           PROXY_TESTS_DIR: proxy_tests/files/default/scripts
           PROXY_TESTS_REPO: proxy_tests/files/default/scripts/repo
         pool:
-          vmImage: "ubuntu-16.04"
+          vmImage: "ubuntu-latest"
         steps:
           - task: UseRubyVersion@0
             inputs:
-              versionSpec: 2.5.7
+              versionSpec: 2.5
               addToPath: true
           - script: |
               echo "ruby version:"
@@ -225,7 +225,7 @@ stages:
         steps:
           - task: UseRubyVersion@0
             inputs:
-              versionSpec: 2.6.5
+              versionSpec: 2.6
               addToPath: true
           - script: |
               gem install bundler --quiet

--- a/test-kitchen.gemspec
+++ b/test-kitchen.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "bundler"
   gem.add_development_dependency "rake"
 
-  gem.add_development_dependency "aruba",     "~> 0.11"
+  gem.add_development_dependency "aruba",     "~> 0.11", "< 1.0"
   gem.add_development_dependency "fakefs",    "~> 1.0"
   gem.add_development_dependency "minitest",  "~> 5.3", "< 5.12"
   gem.add_development_dependency "mocha",     "~> 1.1"


### PR DESCRIPTION
Currently builds are failing due to a ruby version patch, this will make azure pipelines use the latest ruby version available

The macos runner we were using also has been removed by Microsoft Azure, so transitioned to use `latest` images instead 

Signed-off-by: Jason Field <jason@avon-lea.co.uk>