### PR TITLE
Update the front page kitchen.ci content

### DIFF
--- a/docs/themes/kitchen/layouts/index.html
+++ b/docs/themes/kitchen/layouts/index.html
@@ -2,13 +2,13 @@
 or more platforms in isolation.</p><p>A driver plugin architecture is used to run code on various cloud
 providers and virtualization technologies such as Vagrant, Amazon
 EC2, and Docker. <a href="/docs/drivers">Read more</a></p><p>Many testing frameworks are supported out of the box including
-<a href="https://www.inspec.io/">InSpec</a>,
-<a href="//serverspec.org/">Serverspec</a>, and
-<a href="https://github.com/sstephenson/bats">Bats</a></p><p>For Chef workflows, cookbook dependency resolution via
-<a href="https://docs.chef.io/berkshelf.html">Berkshelf</a> or
-<a href="https://docs.chef.io/config_rb_policyfile.html">Policyfiles</a>
+<a href="https://www.inspec.io/">Chef InSpec</a>,
+<a href="https://serverspec.org/">Serverspec</a>, and
+<a href="https://github.com/sstephenson/bats">Bats</a></p><p>For Chef Infra workflows, cookbook dependency resolution via
+<a href="https://docs.chef.io/workstation/berkshelf/">Berkshelf</a> or
+<a href="https://docs.chef.io/policyfile/">Policyfiles</a>
 is supported or include a <code>cookbooks/</code> directory and
-Kitchen will know what to do.</p><p>Kitchen is used by all
+Kitchen will know what to do.</p><p>Test Kitchen is used by all
 <a href="https://github.com/chef-cookbooks/">Chef-managed community
 cookbooks</a> and is the integration testing tool of choice for
 cookbooks.</p></div></div><div class="columns large-8"><div class="row home--image-row"><div class="columns medium-6 medium-text-right"><div class="home--markdown"><div class="highlight"><pre class="highlight yaml"><code><span style="color: #f4bf75">---</span>
@@ -19,8 +19,8 @@ cookbooks.</p></div></div><div class="columns large-8"><div class="row home--ima
   <span style="color: #66d9ef">name</span><span style="color: #f8f8f2">:</span> <span style="color: #a6e22e">chef_zero</span>
 
 <span style="color: #66d9ef">platforms</span><span style="color: #f8f8f2">:</span>
-  <span style="color: #f8f8f2">-</span> <span style="color: #66d9ef">name</span><span style="color: #f8f8f2">:</span> <span style="color: #a6e22e">ubuntu-14.04</span>
-  <span style="color: #f8f8f2">-</span> <span style="color: #66d9ef">name</span><span style="color: #f8f8f2">:</span> <span style="color: #a6e22e">windows-2012r2</span>
+  <span style="color: #f8f8f2">-</span> <span style="color: #66d9ef">name</span><span style="color: #f8f8f2">:</span> <span style="color: #a6e22e">ubuntu-20.04</span>
+  <span style="color: #f8f8f2">-</span> <span style="color: #66d9ef">name</span><span style="color: #f8f8f2">:</span> <span style="color: #a6e22e">windows-2019</span>
 
 <span style="color: #66d9ef">suites</span><span style="color: #f8f8f2">:</span>
   <span style="color: #f8f8f2">-</span> <span style="color: #66d9ef">name</span><span style="color: #f8f8f2">:</span> <span style="color: #a6e22e">client</span>
@@ -47,13 +47,13 @@ infrastructure code.</p></div></div></div><div class="row home--image-row"><div 
 
 Finished verifying
 
-&lt;default-ubuntu-1404&gt; <span style="color: #f8f8f2">(</span>0m0.98s<span style="color: #f8f8f2">)</span><span style="color: #f8f8f2;background-color: #272822">.</span>
+&lt;default-ubuntu-2004&gt; <span style="color: #f8f8f2">(</span>0m0.98s<span style="color: #f8f8f2">)</span><span style="color: #f8f8f2;background-color: #272822">.</span>
 
 <span style="color: #f4bf75">--</span><span style="color: #f8f8f2">&gt;</span> Destroying
 
 <span style="color: #f4bf75">--</span><span style="color: #f8f8f2">&gt;</span> Test Kitchen is finished.
 <span style="color: #f8f8f2">(</span>1m44.11s<span style="color: #f8f8f2">)</span>
-</code></pre></div></div></div><div class="columns medium-6"><div class="home--text--rightcol"><h2 class="body-heading">How do I get started?</h2><p>Install the <a href="https://downloads.chef.io/chefdk/">Chef
-Development Kit (ChefDK)</a> to get started.  Alternatively,
+</code></pre></div></div></div><div class="columns medium-6"><div class="home--text--rightcol"><h2 class="body-heading">How do I get started?</h2><p>Install the <a href="https://downloads.chef.io/chef-workstation/">Chef
+Workstation</a> to get started. Alternatively,
 install the gem directly with <code>gem install
-test-kitchen</code>.</p><a href="/docs/getting-started/introduction" class="button secondary-cta">Get Started</a></div></div></div></div></div><footer class="main-footer"><div class="row"><div class="columns medium-12 text-center"><a href="https://www.chef.io/"><img alt="Chef Logo" class="main-footer--logo" onerror="this.src='/images/chef-logo.png'" src="/images/chef-logo.svg" /></a><p class="main-footer--logo-text">Maintained by Chef.</p></div></div><div class="row content"><div class="columns medium-12 text-center medium-text-left"><p class="main-footer--copyright">&copy; 2018, Chef Software, Inc. All Rights Reserved.</p><ul class="main-footer--links"><li><a href="/" class="main-footer--link">Home</a></li><li><a href="/docs/getting-started/introduction" class="main-footer--link">Docs</a></li><li><a href="https://github.com/test-kitchen/test-kitchen" class="main-footer--link">Github</a></li></ul></div></div></footer><script src="/javascripts/all.js"></script><script>$(document).foundation();</script></body></html>
+test-kitchen</code>.</p><a href="/docs/getting-started/introduction" class="button secondary-cta">Get Started</a></div></div></div></div></div><footer class="main-footer"><div class="row"><div class="columns medium-12 text-center"><a href="https://www.chef.io/"><img alt="Chef Logo" class="main-footer--logo" onerror="this.src='/images/chef-logo.png'" src="/images/chef-logo.svg" /></a><p class="main-footer--logo-text">Maintained by Chef.</p></div></div><div class="row content"><div class="columns medium-12 text-center medium-text-left"><p class="main-footer--copyright">&copy; Chef Software, Inc. All Rights Reserved.</p><ul class="main-footer--links"><li><a href="/" class="main-footer--link">Home</a></li><li><a href="/docs/getting-started/introduction" class="main-footer--link">Docs</a></li><li><a href="https://github.com/test-kitchen/test-kitchen" class="main-footer--link">Github</a></li></ul></div></div></footer><script src="/javascripts/all.js"></script><script>$(document).foundation();</script></body></html>


### PR DESCRIPTION
Remove the date as we've been doing with our other projects
Update docs site links
Fix the serverspec.org link
Inspec -> Chef InSpec
Chef -> Chef Infra
Kitchen -> Kitchen CI
Update to modern platform versions
DK -> Workstation

Signed-off-by: Tim Smith <tsmith@chef.io>