### PR TITLE
Simplify the Gemfile for dependabot

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 source "https://rubygems.org"
 gemspec
 
@@ -26,13 +25,3 @@ end
 group :docs do
   gem "yard"
 end
-
-instance_eval(ENV["GEMFILE_MOD"]) if ENV["GEMFILE_MOD"]
-
-# To avoid bringing in development or test dependencies that are not
-# absolutely needed, if you want to load tools not present in the gemspec
-# or this Gemfile, add those additional dependencies into a Gemfile.local
-# file which is ignored by this repository.
-# rubocop:disable Security/Eval
-eval(IO.read(__FILE__ + ".local"), binding) if File.exist?(__FILE__ + ".local")
-# rubocop:enable Security/Eval


### PR DESCRIPTION
If we remove evals then dependabot can manage the deps, which makes
our life a lot easier

Signed-off-by: Tim Smith <tsmith@chef.io>