### PR TITLE
Respect root_path when product_name is specified

### DIFF
--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -558,7 +558,10 @@ module Kitchen
         install_file = "#{config[:root_path]}/chef-installer.sh"
         script = []
         script << "mkdir -p #{config[:root_path]}"
-
+        script << "if [ $? -ne 0 ]; then"
+        script << "  echo Kitchen config setting root_path: '#{config[:root_path]}' not creatable by regular user "
+        script << "  exit 1"
+        script << "fi"
         script << "cat > #{install_file} <<\"EOL\""
         script << command
         script << "EOL"

--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -556,8 +556,12 @@ module Kitchen
 
       def install_from_file(command)
         install_file = "#{config[:root_path]}/chef-installer.sh"
-        script = ["mkdir -p #{config[:root_path]}"]
-        script << "echo #{command} | tee #{install_file}"
+        script = []
+        script << "mkdir -p #{config[:root_path]}"
+
+        script << "cat > #{install_file} <<\"EOL\""
+        script << command
+        script << "EOL"
         script << "chmod +x #{install_file}"
         script << sudo(install_file)
         script.join("\n")

--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -329,7 +329,7 @@ module Kitchen
         return unless config[:require_chef_omnibus] || config[:product_name]
         return if config[:product_name] && config[:install_strategy] == "skip"
 
-        prefix_command(sudo(install_script_contents))
+        prefix_command(install_script_contents)
       end
 
       private
@@ -559,8 +559,8 @@ module Kitchen
         script = ["mkdir -p #{config[:root_path]}"]
         script << "echo #{command} | tee #{install_file}"
         script << "chmod +x #{install_file}"
-        script << install_file
-        script.map{ |cmd| sudo(cmd) }.join(";\n")
+        script << sudo(install_file)
+        script.join("\n")
       end
 
       # @return [String] contents of version based install script
@@ -570,7 +570,7 @@ module Kitchen
           config[:require_chef_omnibus], powershell_shell?, install_options
         )
         config[:chef_omnibus_root] = installer.root
-        installer.install_command
+        sudo(installer.install_command)
       end
 
       # Hook used in subclasses to indicate support for policyfiles.


### PR DESCRIPTION
# Description

Fixes the `root_path` config option so it is respected when the user specifies `product_name`. The specified directory path will be created without sudo, the install script created without privileges, and then executed with sudo. 

Tested with kitchen-vagrant and kitchen-ec2; kitchen-dokken was also verified not to break, though it does not use this code path. kitchen-openstack would also be good to test.

## Issues Resolved

Fixes #1364

This is an adoption of #1626.

Related PRs and Issues:
#1369 was a prior attempt to fix this, reverted in #1403. Reverted because a sudo command caused the folder to be created with root perms, then the download would occur as an unprivileged user, causing it to fail.
#1626 is a WIP PR to solve this, which this PR adopts. This PR uses the mixlib-install API changes, but keep the original script inject method using a heredoc, finding the sudo issue was located elsewhere. This PR also adds an error message.

Closes chef/chef-workstation#1319, an effort-tracking ticket.

## Check List

- [x] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
