### PR TITLE
Remove redundant encoding comments

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 ignore %r{^\.gem/}
 
 def rubocop_opts

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 require "bundler/gem_tasks"
 
 require "rake/testtask"

--- a/bin/kitchen
+++ b/bin/kitchen
@@ -1,6 +1,4 @@
 #!/usr/bin/env ruby
-# -*- encoding: utf-8 -*-
-
 # Trap interrupts to quit cleanly. See
 # https://twitter.com/mitchellh/status/283014103189053442
 Signal.trap("INT") { exit 1 }

--- a/features/step_definitions/gem_steps.rb
+++ b/features/step_definitions/gem_steps.rb
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 require "tmpdir"
 require "pathname"
 

--- a/features/step_definitions/git_steps.rb
+++ b/features/step_definitions/git_steps.rb
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 Given(/I have a git repository/) do
   create_directory(".git")
 end

--- a/features/step_definitions/output_steps.rb
+++ b/features/step_definitions/output_steps.rb
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 Then(%r{^the stdout should match /([^/]*)/$}) do |expected|
   expect(last_command_started).to have_output_on_stdout(Regexp.new(expected))
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 # Set up the environment for testing
 require "aruba/cucumber"
 require "aruba/in_process"

--- a/lib/kitchen.rb
+++ b/lib/kitchen.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/lib/kitchen/base64_stream.rb
+++ b/lib/kitchen/base64_stream.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/lib/kitchen/cli.rb
+++ b/lib/kitchen/cli.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/lib/kitchen/collection.rb
+++ b/lib/kitchen/collection.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/lib/kitchen/color.rb
+++ b/lib/kitchen/color.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/lib/kitchen/command.rb
+++ b/lib/kitchen/command.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/lib/kitchen/command/action.rb
+++ b/lib/kitchen/command/action.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/lib/kitchen/command/console.rb
+++ b/lib/kitchen/command/console.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/lib/kitchen/command/diagnose.rb
+++ b/lib/kitchen/command/diagnose.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/lib/kitchen/command/doctor.rb
+++ b/lib/kitchen/command/doctor.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/kitchen/command/exec.rb
+++ b/lib/kitchen/command/exec.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: SAWANOBORI Yukihiko (<sawanoboriyu@higanworks.com>)
 #

--- a/lib/kitchen/command/list.rb
+++ b/lib/kitchen/command/list.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/lib/kitchen/command/login.rb
+++ b/lib/kitchen/command/login.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/lib/kitchen/command/package.rb
+++ b/lib/kitchen/command/package.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/kitchen/command/sink.rb
+++ b/lib/kitchen/command/sink.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/lib/kitchen/command/test.rb
+++ b/lib/kitchen/command/test.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/lib/kitchen/config.rb
+++ b/lib/kitchen/config.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/lib/kitchen/configurable.rb
+++ b/lib/kitchen/configurable.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/lib/kitchen/data_munger.rb
+++ b/lib/kitchen/data_munger.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/lib/kitchen/diagnostic.rb
+++ b/lib/kitchen/diagnostic.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/lib/kitchen/driver.rb
+++ b/lib/kitchen/driver.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/lib/kitchen/driver/base.rb
+++ b/lib/kitchen/driver/base.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/lib/kitchen/driver/dummy.rb
+++ b/lib/kitchen/driver/dummy.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/lib/kitchen/driver/exec.rb
+++ b/lib/kitchen/driver/exec.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/kitchen/driver/proxy.rb
+++ b/lib/kitchen/driver/proxy.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Seth Chisamore <schisamo@opscode.com>
 #

--- a/lib/kitchen/driver/ssh_base.rb
+++ b/lib/kitchen/driver/ssh_base.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/lib/kitchen/errors.rb
+++ b/lib/kitchen/errors.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/lib/kitchen/generator/init.rb
+++ b/lib/kitchen/generator/init.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/lib/kitchen/instance.rb
+++ b/lib/kitchen/instance.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/lib/kitchen/lazy_hash.rb
+++ b/lib/kitchen/lazy_hash.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/lib/kitchen/lifecycle_hooks.rb
+++ b/lib/kitchen/lifecycle_hooks.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Noah Kantrowitz <noah@coderanger.net>
 #

--- a/lib/kitchen/loader/yaml.rb
+++ b/lib/kitchen/loader/yaml.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/lib/kitchen/logger.rb
+++ b/lib/kitchen/logger.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/lib/kitchen/logging.rb
+++ b/lib/kitchen/logging.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/lib/kitchen/login_command.rb
+++ b/lib/kitchen/login_command.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/lib/kitchen/metadata_chopper.rb
+++ b/lib/kitchen/metadata_chopper.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/lib/kitchen/platform.rb
+++ b/lib/kitchen/platform.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/lib/kitchen/plugin.rb
+++ b/lib/kitchen/plugin.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/lib/kitchen/provisioner.rb
+++ b/lib/kitchen/provisioner.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/lib/kitchen/provisioner/base.rb
+++ b/lib/kitchen/provisioner/base.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/lib/kitchen/provisioner/chef/berkshelf.rb
+++ b/lib/kitchen/provisioner/chef/berkshelf.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/lib/kitchen/provisioner/chef/common_sandbox.rb
+++ b/lib/kitchen/provisioner/chef/common_sandbox.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/lib/kitchen/provisioner/chef/policyfile.rb
+++ b/lib/kitchen/provisioner/chef/policyfile.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/lib/kitchen/provisioner/chef_apply.rb
+++ b/lib/kitchen/provisioner/chef_apply.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: SAWANOBORI Yukihiko <sawanoboriyu@higanworks.com>)
 #

--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/lib/kitchen/provisioner/chef_solo.rb
+++ b/lib/kitchen/provisioner/chef_solo.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/lib/kitchen/provisioner/chef_zero.rb
+++ b/lib/kitchen/provisioner/chef_zero.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/lib/kitchen/provisioner/dummy.rb
+++ b/lib/kitchen/provisioner/dummy.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/lib/kitchen/provisioner/shell.rb
+++ b/lib/kitchen/provisioner/shell.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Chris Lundquist (<chris.lundquist@github.com>)
 #

--- a/lib/kitchen/rake_tasks.rb
+++ b/lib/kitchen/rake_tasks.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/lib/kitchen/shell_out.rb
+++ b/lib/kitchen/shell_out.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/lib/kitchen/ssh.rb
+++ b/lib/kitchen/ssh.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/lib/kitchen/state_file.rb
+++ b/lib/kitchen/state_file.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/lib/kitchen/suite.rb
+++ b/lib/kitchen/suite.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/lib/kitchen/thor_tasks.rb
+++ b/lib/kitchen/thor_tasks.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/lib/kitchen/transport.rb
+++ b/lib/kitchen/transport.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Salim Afiune (<salim@afiunemaya.com.mx>)
 #

--- a/lib/kitchen/transport/base.rb
+++ b/lib/kitchen/transport/base.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Salim Afiune (<salim@afiunemaya.com.mx>)
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)

--- a/lib/kitchen/transport/dummy.rb
+++ b/lib/kitchen/transport/dummy.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Salim Afiune (<salim@afiunemaya.com.mx>)
 #

--- a/lib/kitchen/transport/exec.rb
+++ b/lib/kitchen/transport/exec.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/kitchen/transport/ssh.rb
+++ b/lib/kitchen/transport/ssh.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/lib/kitchen/transport/winrm.rb
+++ b/lib/kitchen/transport/winrm.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Salim Afiune (<salim@afiunemaya.com.mx>)
 # Author:: Matt Wrock (<matt@mattwrock.com>)

--- a/lib/kitchen/util.rb
+++ b/lib/kitchen/util.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/lib/kitchen/verifier.rb
+++ b/lib/kitchen/verifier.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/lib/kitchen/verifier/base.rb
+++ b/lib/kitchen/verifier/base.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/lib/kitchen/verifier/busser.rb
+++ b/lib/kitchen/verifier/busser.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/lib/kitchen/verifier/dummy.rb
+++ b/lib/kitchen/verifier/dummy.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/lib/kitchen/verifier/shell.rb
+++ b/lib/kitchen/verifier/shell.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: SAWANOBORI Yukihiko (<sawanoboriyu@higanworks.com>)
 #

--- a/lib/kitchen/version.rb
+++ b/lib/kitchen/version.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/lib/vendor/hash_recursive_merge.rb
+++ b/lib/vendor/hash_recursive_merge.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # = Hash Recursive Merge
 #

--- a/spec/kitchen/base64_stream_spec.rb
+++ b/spec/kitchen/base64_stream_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/spec/kitchen/cli_spec.rb
+++ b/spec/kitchen/cli_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Tyler Ball (<tball@chef.io>)
 #

--- a/spec/kitchen/collection_spec.rb
+++ b/spec/kitchen/collection_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/spec/kitchen/color_spec.rb
+++ b/spec/kitchen/color_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/spec/kitchen/config_spec.rb
+++ b/spec/kitchen/config_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/spec/kitchen/configurable_spec.rb
+++ b/spec/kitchen/configurable_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/spec/kitchen/data_munger_spec.rb
+++ b/spec/kitchen/data_munger_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/spec/kitchen/diagnostic_spec.rb
+++ b/spec/kitchen/diagnostic_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/spec/kitchen/driver/base_spec.rb
+++ b/spec/kitchen/driver/base_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/spec/kitchen/driver/dummy_spec.rb
+++ b/spec/kitchen/driver/dummy_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/spec/kitchen/driver/proxy_spec.rb
+++ b/spec/kitchen/driver/proxy_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/spec/kitchen/driver/ssh_base_spec.rb
+++ b/spec/kitchen/driver/ssh_base_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/spec/kitchen/driver_spec.rb
+++ b/spec/kitchen/driver_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/spec/kitchen/errors_spec.rb
+++ b/spec/kitchen/errors_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/spec/kitchen/instance_spec.rb
+++ b/spec/kitchen/instance_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/spec/kitchen/lazy_hash_spec.rb
+++ b/spec/kitchen/lazy_hash_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/spec/kitchen/lifecycle_hooks_spec.rb
+++ b/spec/kitchen/lifecycle_hooks_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Noah Kantrowitz <noah@coderanger.net>
 #

--- a/spec/kitchen/loader/yaml_spec.rb
+++ b/spec/kitchen/loader/yaml_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/spec/kitchen/logger_spec.rb
+++ b/spec/kitchen/logger_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/spec/kitchen/logging_spec.rb
+++ b/spec/kitchen/logging_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/spec/kitchen/login_command_spec.rb
+++ b/spec/kitchen/login_command_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/spec/kitchen/metadata_chopper_spec.rb
+++ b/spec/kitchen/metadata_chopper_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/spec/kitchen/platform_spec.rb
+++ b/spec/kitchen/platform_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/spec/kitchen/plugin_spec.rb
+++ b/spec/kitchen/plugin_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/spec/kitchen/provisioner/base_spec.rb
+++ b/spec/kitchen/provisioner/base_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/spec/kitchen/provisioner/chef/policyfile_spec.rb
+++ b/spec/kitchen/provisioner/chef/policyfile_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Noah Kantrowitz
 #

--- a/spec/kitchen/provisioner/chef_apply_spec.rb
+++ b/spec/kitchen/provisioner/chef_apply_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: SAWANOBORI Yukihiko <sawanoboriyu@higanworks.com>)
 #

--- a/spec/kitchen/provisioner/chef_base_spec.rb
+++ b/spec/kitchen/provisioner/chef_base_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/spec/kitchen/provisioner/chef_solo_spec.rb
+++ b/spec/kitchen/provisioner/chef_solo_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/spec/kitchen/provisioner/chef_zero_spec.rb
+++ b/spec/kitchen/provisioner/chef_zero_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/spec/kitchen/provisioner/dummy_spec.rb
+++ b/spec/kitchen/provisioner/dummy_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/spec/kitchen/provisioner/shell_spec.rb
+++ b/spec/kitchen/provisioner/shell_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/spec/kitchen/provisioner_spec.rb
+++ b/spec/kitchen/provisioner_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/spec/kitchen/shell_out_spec.rb
+++ b/spec/kitchen/shell_out_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/spec/kitchen/ssh_spec.rb
+++ b/spec/kitchen/ssh_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/spec/kitchen/state_file_spec.rb
+++ b/spec/kitchen/state_file_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/spec/kitchen/suite_spec.rb
+++ b/spec/kitchen/suite_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/spec/kitchen/transport/base_spec.rb
+++ b/spec/kitchen/transport/base_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/spec/kitchen/transport/ssh_spec.rb
+++ b/spec/kitchen/transport/ssh_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/spec/kitchen/transport/winrm_spec.rb
+++ b/spec/kitchen/transport/winrm_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Matt Wrock (<matt@mattwrock.com>)
 #

--- a/spec/kitchen/transport_spec.rb
+++ b/spec/kitchen/transport_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Matt Wrock (<matt@mattwrock.com>)
 #

--- a/spec/kitchen/util_spec.rb
+++ b/spec/kitchen/util_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/spec/kitchen/verifier/base_spec.rb
+++ b/spec/kitchen/verifier/base_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/spec/kitchen/verifier/busser_spec.rb
+++ b/spec/kitchen/verifier/busser_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/spec/kitchen/verifier/dummy_spec.rb
+++ b/spec/kitchen/verifier/dummy_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/spec/kitchen/verifier/shell_spec.rb
+++ b/spec/kitchen/verifier/shell_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: SAWANOBORI Yukihiko (<sawanoboriyu@higanworks.com>)
 #

--- a/spec/kitchen/verifier_spec.rb
+++ b/spec/kitchen/verifier_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/spec/kitchen_spec.rb
+++ b/spec/kitchen_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/spec/support/powershell_max_size_spec.rb
+++ b/spec/support/powershell_max_size_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #

--- a/test-kitchen.gemspec
+++ b/test-kitchen.gemspec
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "kitchen/version"


### PR DESCRIPTION
In Ruby 2.0 utf-8 became the default so there's no reason to set it anymore.

Signed-off-by: Tim Smith <tsmith@chef.io>