### PR TITLE
Revert "Respect root_path when product_name is specified" due to regression

### DIFF
--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -556,12 +556,8 @@ module Kitchen
 
       def install_from_file(command)
         install_file = "#{config[:root_path]}/chef-installer.sh"
-        script = []
-        script << "mkdir -p #{config[:root_path]}"
-
-        script << "cat > #{install_file} <<\"EOL\""
-        script << command
-        script << "EOL"
+        script = ["mkdir -p #{config[:root_path]}"]
+        script << "echo #{command} | tee #{install_file}"
         script << "chmod +x #{install_file}"
         script << sudo(install_file)
         script.join("\n")

--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -329,7 +329,7 @@ module Kitchen
         return unless config[:require_chef_omnibus] || config[:product_name]
         return if config[:product_name] && config[:install_strategy] == "skip"
 
-        prefix_command(install_script_contents)
+        prefix_command(sudo(install_script_contents))
       end
 
       private
@@ -559,8 +559,8 @@ module Kitchen
         script = ["mkdir -p #{config[:root_path]}"]
         script << "echo #{command} | tee #{install_file}"
         script << "chmod +x #{install_file}"
-        script << sudo(install_file)
-        script.join("\n")
+        script << install_file
+        script.map{ |cmd| sudo(cmd) }.join(";\n")
       end
 
       # @return [String] contents of version based install script
@@ -570,7 +570,7 @@ module Kitchen
           config[:require_chef_omnibus], powershell_shell?, install_options
         )
         config[:chef_omnibus_root] = installer.root
-        sudo(installer.install_command)
+        installer.install_command
       end
 
       # Hook used in subclasses to indicate support for policyfiles.

--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -558,10 +558,7 @@ module Kitchen
         install_file = "#{config[:root_path]}/chef-installer.sh"
         script = []
         script << "mkdir -p #{config[:root_path]}"
-        script << "if [ $? -ne 0 ]; then"
-        script << "  echo Kitchen config setting root_path: '#{config[:root_path]}' not creatable by regular user "
-        script << "  exit 1"
-        script << "fi"
+
         script << "cat > #{install_file} <<\"EOL\""
         script << command
         script << "EOL"

--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -510,8 +510,6 @@ module Kitchen
           channel: config[:channel].to_sym,
           install_command_options: {
             install_strategy: config[:install_strategy],
-            tmp_dir: config[:root_path],
-            "TMPDIR" => config[:root_path],
           },
         }.tap do |opts|
           opts[:shell_type] = :ps1 if powershell_shell?
@@ -537,6 +535,7 @@ module Kitchen
             # install.ps1 only supports http_proxy
             prox.delete_if { |p| %i{https_proxy ftp_proxy no_proxy}.include?(p) } if powershell_shell?
           end
+
           opts[:install_command_options].merge!(proxies)
         end)
         config[:chef_omnibus_root] = installer.root
@@ -555,12 +554,13 @@ module Kitchen
       end
 
       def install_from_file(command)
-        install_file = "#{config[:root_path]}/chef-installer.sh"
-        script = ["mkdir -p #{config[:root_path]}"]
-        script << "echo #{command} | tee #{install_file}"
+        install_file = "/tmp/chef-installer.sh"
+        script = ["cat > #{install_file} <<\"EOL\""]
+        script << command
+        script << "EOL"
         script << "chmod +x #{install_file}"
-        script << install_file
-        script.map{ |cmd| sudo(cmd) }.join(";\n")
+        script << sudo(install_file)
+        script.join("\n")
       end
 
       # @return [String] contents of version based install script


### PR DESCRIPTION
The change in https://github.com/test-kitchen/test-kitchen/pull/1662 is causing failures on windows hosts. Reverting until we can come up with a fix for that.