### PR TITLE
Require Ruby 2.4 or later

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,6 @@
 ---
+AllCops:
+  TargetRubyVersion: 2.4
 Naming/FileName:
   Exclude:
     - 'support/**/*'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1092,7 +1092,7 @@
 - Don't reset locale in Kitchen::Driver::Base run\_command\(\) [\#485](https://github.com/test-kitchen/test-kitchen/issues/485)
 - Intermittent 'kitchen test' failures [\#449](https://github.com/test-kitchen/test-kitchen/issues/449)
 - shell-provisioner: lots of trouble with a noexec /tmp, failing workaround. [\#444](https://github.com/test-kitchen/test-kitchen/issues/444)
-- Support Chef-DK [\#443](https://github.com/test-kitchen/test-kitchen/issues/443)
+- Support ChefDK [\#443](https://github.com/test-kitchen/test-kitchen/issues/443)
 - Message: Failed to complete \#converge action: \[Permission denied [\#441](https://github.com/test-kitchen/test-kitchen/issues/441)
 - Idea: enable chef-zero to run on another server than the converged node. [\#437](https://github.com/test-kitchen/test-kitchen/issues/437)
 - Test Artifact Fetch Feature [\#434](https://github.com/test-kitchen/test-kitchen/issues/434)

--- a/test-kitchen.gemspec
+++ b/test-kitchen.gemspec
@@ -15,12 +15,12 @@ Gem::Specification.new do |gem|
   gem.summary       = gem.description
   gem.homepage      = "https://kitchen.ci/"
 
-  # The gemfile and gemspec are necessary for appbundler in Chef-DK / Workstation
+  # The gemfile and gemspec are necessary for appbundler in ChefDK / Workstation
   gem.files         = %w{LICENSE test-kitchen.gemspec Gemfile Rakefile} + Dir.glob("{bin,lib,templates,support}/**/*")
   gem.executables   = %w{kitchen}
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.3"
+  gem.required_ruby_version = ">= 2.4"
 
   gem.add_dependency "mixlib-shellout",    ">= 1.2", "< 4.0"
   gem.add_dependency "net-scp",            ">= 1.1", "< 4.0" # pinning until we can confirm 4+ works
@@ -35,7 +35,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "winrm-fs",           "~> 1.1"
   # Required to run the Chef provisioner local license check for remote systems
   # TK is not under Chef EULA
-  gem.add_dependency "license-acceptance", "~> 1.0", ">= 1.0.11"
+  gem.add_dependency "license-acceptance", ">= 1.0.11", "< 3.0" # pinning until we can confirm 3+ works
 
   gem.add_development_dependency "rb-readline"
   gem.add_development_dependency "bundler"


### PR DESCRIPTION
Ruby 2.3 is fully EOL and we should not support this release anymore
since we're not testing it.

I plan to bump to 2.6 here since there should not be an expectation of support for long EOL Ruby releases.

Signed-off-by: Tim Smith <tsmith@chef.io>