### PR TITLE
Optimize our requires

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -42,7 +42,7 @@ desc "Run all quality tasks"
 task quality: %i{style stats}
 
 begin
-  require "yard"
+  require "yard" unless defined?(YARD)
   YARD::Rake::YardocTask.new
 rescue LoadError
   puts "yard is not available. (sudo) gem install yard to generate yard documentation."

--- a/bin/kitchen
+++ b/bin/kitchen
@@ -4,7 +4,7 @@
 Signal.trap("INT") { exit 1 }
 
 $LOAD_PATH.unshift File.join(File.dirname(__FILE__), %w{.. lib})
-require "rubygems"
+require "rubygems" unless defined?(Gem)
 require "kitchen/cli"
 require "kitchen/errors"
 

--- a/features/step_definitions/gem_steps.rb
+++ b/features/step_definitions/gem_steps.rb
@@ -1,5 +1,5 @@
-require "tmpdir"
-require "pathname"
+require "tmpdir" unless defined?(Dir.mktmpdir)
+require "pathname" unless defined?(Pathname)
 
 Then(/^a gem named "(.*?)" is installed with version "(.*?)"$/) do |name, version|
   unbundlerize do

--- a/lib/kitchen.rb
+++ b/lib/kitchen.rb
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "pathname"
+require "pathname" unless defined?(Pathname)
 require "thread"
 
 require_relative "kitchen/errors"

--- a/lib/kitchen/cli.rb
+++ b/lib/kitchen/cli.rb
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "thor" unless defined?(Thor)
+require "thor"
 
 require_relative "../kitchen"
 require_relative "generator/init"

--- a/lib/kitchen/cli.rb
+++ b/lib/kitchen/cli.rb
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "thor"
+require "thor" unless defined?(Thor)
 
 require_relative "../kitchen"
 require_relative "generator/init"

--- a/lib/kitchen/command/action.rb
+++ b/lib/kitchen/command/action.rb
@@ -17,7 +17,7 @@
 
 require_relative "../command"
 
-require "benchmark"
+require "benchmark" unless defined?(Benchmark)
 
 module Kitchen
   module Command

--- a/lib/kitchen/command/diagnose.rb
+++ b/lib/kitchen/command/diagnose.rb
@@ -18,7 +18,7 @@
 require_relative "../command"
 require_relative "../diagnostic"
 
-require "yaml"
+require "yaml" unless defined?(YAML)
 
 module Kitchen
   module Command

--- a/lib/kitchen/command/list.rb
+++ b/lib/kitchen/command/list.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 require_relative "../command"
-require "json"
+require "json" unless defined?(JSON)
 
 module Kitchen
   module Command

--- a/lib/kitchen/command/test.rb
+++ b/lib/kitchen/command/test.rb
@@ -17,7 +17,7 @@
 
 require_relative "../command"
 
-require "benchmark"
+require "benchmark" unless defined?(Benchmark)
 
 module Kitchen
   module Command

--- a/lib/kitchen/driver/ssh_base.rb
+++ b/lib/kitchen/driver/ssh_base.rb
@@ -18,7 +18,7 @@
 require "thor/util"
 
 require_relative "../lazy_hash"
-require "benchmark"
+require "benchmark" unless defined?(Benchmark)
 
 module Kitchen
   module Driver

--- a/lib/kitchen/instance.rb
+++ b/lib/kitchen/instance.rb
@@ -15,8 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "benchmark"
-require "fileutils"
+require "benchmark" unless defined?(Benchmark)
+require "fileutils" unless defined?(FileUtils)
 
 module Kitchen
   # An instance of a suite running on a platform. A created instance may be a

--- a/lib/kitchen/loader/yaml.rb
+++ b/lib/kitchen/loader/yaml.rb
@@ -15,9 +15,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "erb"
+require "erb" unless defined?(Erb)
 require_relative "../../vendor/hash_recursive_merge"
-require "yaml"
+require "yaml" unless defined?(YAML)
 
 module Kitchen
   module Loader

--- a/lib/kitchen/logger.rb
+++ b/lib/kitchen/logger.rb
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "fileutils"
+require "fileutils" unless defined?(FileUtils)
 require "logger"
 
 module Kitchen

--- a/lib/kitchen/provisioner/chef/common_sandbox.rb
+++ b/lib/kitchen/provisioner/chef/common_sandbox.rb
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "json"
+require "json" unless defined?(JSON)
 
 module Kitchen
   module Provisioner

--- a/lib/kitchen/provisioner/chef/policyfile.rb
+++ b/lib/kitchen/provisioner/chef/policyfile.rb
@@ -15,8 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "shellwords"
-require "rbconfig"
+require "shellwords" unless defined?(Shellwords)
+require "rbconfig" unless defined?(RbConfig)
 
 require_relative "../../errors"
 require_relative "../../logging"

--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -15,10 +15,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "fileutils"
-require "pathname"
-require "json"
-require "cgi"
+require "fileutils" unless defined?(FileUtils)
+require "pathname" unless defined?(Pathname)
+require "json" unless defined?(JSON)
+require "cgi" unless defined?(CGI)
 
 require_relative "chef/policyfile"
 require_relative "chef/berkshelf"

--- a/lib/kitchen/provisioner/shell.rb
+++ b/lib/kitchen/provisioner/shell.rb
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "shellwords"
+require "shellwords" unless defined?(Shellwords)
 
 require_relative "base"
 require_relative "../version"

--- a/lib/kitchen/shell_out.rb
+++ b/lib/kitchen/shell_out.rb
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "mixlib/shellout"
+require "mixlib/shellout" unless defined?(Mixlib::ShellOut)
 
 module Kitchen
   # Mixin that wraps a command shell out invocation, providing a #run_command

--- a/lib/kitchen/ssh.rb
+++ b/lib/kitchen/ssh.rb
@@ -16,9 +16,9 @@
 # limitations under the License.
 
 require "logger"
-require "net/ssh"
+require "net/ssh" unless defined?(Net::SSH)
 require "net/scp"
-require "socket"
+require "socket" unless defined?(Socket)
 
 require_relative "errors"
 require_relative "login_command"

--- a/lib/kitchen/state_file.rb
+++ b/lib/kitchen/state_file.rb
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "yaml"
+require "yaml" unless defined?(YAML)
 
 module Kitchen
   # Exception class for any exceptions raised when reading and parsing a state

--- a/lib/kitchen/thor_tasks.rb
+++ b/lib/kitchen/thor_tasks.rb
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "thor"
+require "thor" unless defined?(Thor)
 
 require_relative "../kitchen"
 

--- a/lib/kitchen/transport/exec.rb
+++ b/lib/kitchen/transport/exec.rb
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "fileutils"
+require "fileutils" unless defined?(FileUtils)
 
 require_relative "../shell_out"
 require_relative "base"

--- a/lib/kitchen/transport/ssh.rb
+++ b/lib/kitchen/transport/ssh.rb
@@ -17,13 +17,13 @@
 
 require_relative "../../kitchen"
 
-require "fileutils"
-require "net/ssh"
+require "fileutils" unless defined?(FileUtils)
+require "net/ssh" unless defined?(Net::SSH)
 require "net/ssh/gateway"
 require "net/ssh/proxy/http"
 require "net/scp"
-require "timeout"
-require "benchmark"
+require "timeout" unless defined?(Timeout)
+require "benchmark" unless defined?(Benchmark)
 
 module Kitchen
   module Transport

--- a/lib/kitchen/transport/winrm.rb
+++ b/lib/kitchen/transport/winrm.rb
@@ -17,10 +17,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "rbconfig"
-require "uri"
+require "rbconfig" unless defined?(RbConfig)
+require "uri" unless defined?(URI)
 require_relative "../../kitchen"
-require "winrm"
+require "winrm" unless defined?(WinRM::Connection)
 
 module Kitchen
   module Transport

--- a/lib/kitchen/verifier/busser.rb
+++ b/lib/kitchen/verifier/busser.rb
@@ -15,8 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "base64"
-require "digest"
+require "base64" unless defined?(Base64)
+require "digest" unless defined?(Digest)
 
 require_relative "base"
 

--- a/lib/kitchen/verifier/shell.rb
+++ b/lib/kitchen/verifier/shell.rb
@@ -23,7 +23,7 @@ module Kitchen
     #
     # @author SAWANOBORI Yukihiko (<sawanoboriyu@higanworks.com>)
     class Shell < Kitchen::Verifier::Base
-      require "mixlib/shellout"
+      require "mixlib/shellout" unless defined?(Mixlib::ShellOut)
 
       kitchen_verifier_api_version 1
 


### PR DESCRIPTION
Avoid requiring things that are already defined. Rubygems is very slow at traversing the filesystem.

Signed-off-by: Tim Smith <tsmith@chef.io>