### PR TITLE
Allow all plugins to toggle concurrency

### DIFF
--- a/lib/kitchen/driver/base.rb
+++ b/lib/kitchen/driver/base.rb
@@ -19,6 +19,7 @@ require_relative "../configurable"
 require_relative "../errors"
 require_relative "../lazy_hash"
 require_relative "../logging"
+require_relative "../plugin_base"
 require_relative "../shell_out"
 
 module Kitchen
@@ -26,7 +27,7 @@ module Kitchen
     # Base class for a driver.
     #
     # @author Fletcher Nichol <fnichol@nichol.ca>
-    class Base
+    class Base < Kitchen::Plugin::Base
       include Configurable
       include Logging
       include ShellOut
@@ -67,43 +68,6 @@ module Kitchen
       # @returns [Boolean] Return true if a problem is found.
       def doctor(state)
         false
-      end
-
-      class << self
-        # @return [Array<Symbol>] an array of action method names that cannot
-        #   be run concurrently and must be run in serial via a shared mutex
-        attr_reader :serial_actions
-      end
-
-      # Registers certain driver actions that cannot be safely run concurrently
-      # in threads across multiple instances. Typically this might be used
-      # for create or destroy actions that use an underlying resource that
-      # cannot be used at the same time.
-      #
-      # A shared mutex for this driver object will be used to synchronize all
-      # registered methods.
-      #
-      # @example a single action method that cannot be run concurrently
-      #
-      #   no_parallel_for :create
-      #
-      # @example multiple action methods that cannot be run concurrently
-      #
-      #   no_parallel_for :create, :destroy
-      #
-      # @param methods [Array<Symbol>] one or more actions as symbols
-      # @raise [ClientError] if any method is not a valid action method name
-      def self.no_parallel_for(*methods)
-        action_methods = %i{create setup converge verify destroy}
-
-        Array(methods).each do |meth|
-          next if action_methods.include?(meth)
-
-          raise ClientError, "##{meth} is not a valid no_parallel_for method"
-        end
-
-        @serial_actions ||= []
-        @serial_actions += methods
       end
 
       # Sets the API version for this driver. If the driver does not set this

--- a/lib/kitchen/driver/ssh_base.rb
+++ b/lib/kitchen/driver/ssh_base.rb
@@ -18,6 +18,7 @@
 require "thor/util"
 
 require_relative "../lazy_hash"
+require_relative "../plugin_base"
 require "benchmark" unless defined?(Benchmark)
 
 module Kitchen
@@ -42,7 +43,7 @@ module Kitchen
     #   Transport, and Verifier subsystems may not be picked up in these
     #   Drivers. When legacy Driver::SSHBase support is removed, this class
     #   will no longer be available.
-    class SSHBase
+    class SSHBase < Kitchen::Plugin::Base
       include ShellOut
       include Configurable
       include Logging
@@ -178,43 +179,6 @@ module Kitchen
       # @raise [UserError] if the driver will not be able to perform or if a
       #   documented dependency is missing from the system
       def verify_dependencies; end
-
-      class << self
-        # @return [Array<Symbol>] an array of action method names that cannot
-        #   be run concurrently and must be run in serial via a shared mutex
-        attr_reader :serial_actions
-      end
-
-      # Registers certain driver actions that cannot be safely run concurrently
-      # in threads across multiple instances. Typically this might be used
-      # for create or destroy actions that use an underlying resource that
-      # cannot be used at the same time.
-      #
-      # A shared mutex for this driver object will be used to synchronize all
-      # registered methods.
-      #
-      # @example a single action method that cannot be run concurrently
-      #
-      #   no_parallel_for :create
-      #
-      # @example multiple action methods that cannot be run concurrently
-      #
-      #   no_parallel_for :create, :destroy
-      #
-      # @param methods [Array<Symbol>] one or more actions as symbols
-      # @raise [ClientError] if any method is not a valid action method name
-      def self.no_parallel_for(*methods)
-        action_methods = %i{create converge setup verify destroy}
-
-        Array(methods).each do |meth|
-          next if action_methods.include?(meth)
-
-          raise ClientError, "##{meth} is not a valid no_parallel_for method"
-        end
-
-        @serial_actions ||= []
-        @serial_actions += methods
-      end
 
       # Cache directory that a driver could implement to inform the provisioner
       # that it can leverage it internally

--- a/lib/kitchen/plugin_base.rb
+++ b/lib/kitchen/plugin_base.rb
@@ -1,0 +1,60 @@
+#
+# Author:: Fletcher Nichol (<fnichol@nichol.ca>)
+#
+# Copyright (C) 2014, Fletcher Nichol
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Kitchen
+  module Plugin
+    class Base
+      class << self
+        # @return [Array<Symbol>] an array of action method names that cannot
+        #   be run concurrently and must be run in serial via a shared mutex
+        attr_reader :serial_actions
+      end
+
+      # Registers certain driver actions that cannot be safely run concurrently
+      # in threads across multiple instances. Typically this might be used
+      # for create or destroy actions that use an underlying resource that
+      # cannot be used at the same time.
+      #
+      # A shared mutex for this driver object will be used to synchronize all
+      # registered methods.
+      #
+      # @example a single action method that cannot be run concurrently
+      #
+      #   no_parallel_for :create
+      #
+      # @example multiple action methods that cannot be run concurrently
+      #
+      #   no_parallel_for :create, :destroy
+      #
+      # @param methods [Array<Symbol>] one or more actions as symbols
+      # @raise [ClientError] if any method is not a valid action method name
+      def self.no_parallel_for(*methods)
+        action_methods = %i{create setup converge verify destroy}
+
+        Array(methods).each do |meth|
+          next if action_methods.include?(meth)
+
+          raise ClientError, "##{meth} is not a valid no_parallel_for method"
+        end
+
+        @serial_actions ||= []
+        @serial_actions += methods
+      end
+
+    end
+  end
+end

--- a/lib/kitchen/provisioner/base.rb
+++ b/lib/kitchen/provisioner/base.rb
@@ -18,13 +18,14 @@
 require_relative "../configurable"
 require_relative "../errors"
 require_relative "../logging"
+require_relative "../plugin_base"
 
 module Kitchen
   module Provisioner
     # Base class for a provisioner.
     #
     # @author Fletcher Nichol <fnichol@nichol.ca>
-    class Base
+    class Base < Kitchen::Plugin::Base
       include Configurable
       include Logging
 

--- a/lib/kitchen/transport/base.rb
+++ b/lib/kitchen/transport/base.rb
@@ -21,6 +21,7 @@ require_relative "../errors"
 require_relative "../lazy_hash"
 require_relative "../logging"
 require_relative "../login_command"
+require_relative "../plugin_base"
 
 module Kitchen
   module Transport
@@ -40,7 +41,7 @@ module Kitchen
     #
     # @author Salim Afiune <salim@afiunemaya.com.mx>
     # @author Fletcher Nichol <fnichol@nichol.ca>
-    class Base
+    class Base < Kitchen::Plugin::Base
       include Configurable
       include Logging
 

--- a/lib/kitchen/verifier/base.rb
+++ b/lib/kitchen/verifier/base.rb
@@ -18,13 +18,14 @@
 require_relative "../errors"
 require_relative "../configurable"
 require_relative "../logging"
+require_relative "../plugin_base"
 
 module Kitchen
   module Verifier
     # Base class for a verifier.
     #
     # @author Fletcher Nichol <fnichol@nichol.ca>
-    class Base
+    class Base < Kitchen::Plugin::Base
       include Configurable
       include Logging
 

--- a/spec/kitchen/provisioner/base_spec.rb
+++ b/spec/kitchen/provisioner/base_spec.rb
@@ -54,6 +54,10 @@ module Kitchen
         "/tmp/sandbox"
       end
     end
+
+    class Dodgy < Kitchen::Provisioner::Base
+      no_parallel_for :converge
+    end
   end
 end
 
@@ -387,6 +391,22 @@ describe Kitchen::Provisioner::Base do
       it "returns an unaltered command" do
         provisioner.send(:prefix_command, "my_command").must_equal("my_command")
       end
+    end
+  end
+
+  describe ".no_parallel_for" do
+    it "registers no serial actions when none are declared" do
+      Kitchen::Provisioner::TestingDummy.serial_actions.must_be_nil
+    end
+
+    it "registers a single serial action method" do
+      Kitchen::Provisioner::Dodgy.serial_actions.must_equal [:converge]
+    end
+
+    it "raises a ClientError if value is not an action method" do
+      proc do
+        Class.new(Kitchen::Provisioner::Base) { no_parallel_for :telling_stories }
+      end.must_raise Kitchen::ClientError
     end
   end
 end

--- a/spec/kitchen/transport/base_spec.rb
+++ b/spec/kitchen/transport/base_spec.rb
@@ -19,6 +19,15 @@ require_relative "../../spec_helper"
 
 require "kitchen"
 
+module Kitchen
+  module Transport
+    class TestingDummy < Kitchen::Transport::Base; end
+    class Dodgy < Kitchen::Transport::Base
+      no_parallel_for :setup
+    end
+  end
+end
+
 describe Kitchen::Transport::Base do
   let(:logged_output)   { StringIO.new }
   let(:logger)          { Logger.new(logged_output) }
@@ -66,6 +75,22 @@ describe Kitchen::Transport::Base do
       it "#exit_code returns the supplied exit code" do
         failure_with_exit_code.exit_code.must_equal 123
       end
+    end
+  end
+
+  describe ".no_parallel_for" do
+    it "registers no serial actions when none are declared" do
+      Kitchen::Transport::TestingDummy.serial_actions.must_be_nil
+    end
+
+    it "registers a single serial action method" do
+      Kitchen::Transport::Dodgy.serial_actions.must_equal [:setup]
+    end
+
+    it "raises a ClientError if value is not an action method" do
+      proc do
+        Class.new(Kitchen::Transport::Base) { no_parallel_for :telling_stories }
+      end.must_raise Kitchen::ClientError
     end
   end
 end

--- a/spec/kitchen/verifier/base_spec.rb
+++ b/spec/kitchen/verifier/base_spec.rb
@@ -57,6 +57,10 @@ module Kitchen
         "/tmp/sandbox"
       end
     end
+
+    class Dodgy < Kitchen::Verifier::Base
+      no_parallel_for :verify
+    end
   end
 end
 
@@ -365,6 +369,22 @@ describe Kitchen::Verifier::Base do
       it "returns an unaltered command" do
         verifier.send(:prefix_command, "my_command").must_equal("my_command")
       end
+    end
+  end
+
+  describe ".no_parallel_for" do
+    it "registers no serial actions when none are declared" do
+      Kitchen::Verifier::TestingDummy.serial_actions.must_be_nil
+    end
+
+    it "registers a single serial action method" do
+      Kitchen::Verifier::Dodgy.serial_actions.must_equal [:verify]
+    end
+
+    it "raises a ClientError if value is not an action method" do
+      proc do
+        Class.new(Kitchen::Verifier::Base) { no_parallel_for :telling_stories }
+      end.must_raise Kitchen::ClientError
     end
   end
 end


### PR DESCRIPTION
# Description

Previously, only Driver plugins were able to declare that they should not be run concurrently using `-c`. In fact, individual plugins of other types may not be thread-safe, but they had no way of expressing this, and were thus run in parallel, sometimes to poor outcomes. This PR:

 * expands the plugin DSL keyword `no_parallel_for` to be available to Transports, Provisioner, and Verifier plugins, as well as Drivers
 * modifies the code that implements serialization checking to now check for the serialization needs of other plugin types besides Drivers

The minor version should be bumped when merging this PR.

## Issues Resolved

Fixes #1677 

## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
