### PR TITLE
Allow includes/excludes filters for hooks

### DIFF
--- a/docs/content/docs/reference/lifecycle-hooks.md
+++ b/docs/content/docs/reference/lifecycle-hooks.md
@@ -12,7 +12,7 @@ run either locally on your workstation (the default) or remotely on the test ins
 
 These hooks are configured under a new `lifecycle:` section in `kitchen.yml`:
 
-```
+```yaml
 lifecycle:
   pre_create: echo before
   post_create:
@@ -23,7 +23,7 @@ lifecycle:
 
 You can also configure hooks on a single platform or suite:
 
-```
+```yaml
 platforms:
 - name: ubuntu-20.04
   lifecycle:
@@ -47,7 +47,7 @@ about which instance the hook is evaluating against:
 
 You can also pass additional configuration for local commands:
 
-```
+```yaml
 lifecycle:
   pre_converge:
   - local: ./setup.sh
@@ -69,7 +69,7 @@ lifecycle:
 
 This is a complete example of using a post_create hook to wait for cloud-init to complete for an AWS EC2 instance:
 
-```
+```yaml
 lifecycle:
   post_create:
   - local: echo 'Awaiting cloud-init completion'
@@ -87,4 +87,22 @@ lifecycle:
         sleep ${wait};
         let i+=${wait};
       done;
+```
+
+You can include or exclude platforms from specific lifecycle hooks with the `include` or `exclude`
+keys, e.g.
+
+```yaml
+lifecycle:
+  post_create:
+  - local: echo 'Awaiting cloud-init completion'
+  - remote: |
+      echo "This is my *nix"
+    exclude:
+      - windows-2012r2
+      - windows-2016
+  - remote: |
+      Write-Host "This is my windows"
+    exclude:
+      - redhat-7
 ```

--- a/lib/kitchen/config.rb
+++ b/lib/kitchen/config.rb
@@ -244,16 +244,18 @@ module Kitchen
     # @return [Instance] a new Instance object
     # @api private
     def new_instance(suite, platform, index)
+      sf = new_state_file(suite, platform)
+
       Instance.new(
         driver: new_driver(suite, platform),
-        lifecycle_hooks: new_lifecycle_hooks(suite, platform),
+        lifecycle_hooks: new_lifecycle_hooks(suite, platform, sf),
         logger: new_instance_logger(suite, platform, index),
         suite: suite,
         platform: platform,
         provisioner: new_provisioner(suite, platform),
         transport: new_transport(suite, platform),
         verifier: new_verifier(suite, platform),
-        state_file: new_state_file(suite, platform)
+        state_file: sf
       )
     end
 
@@ -284,11 +286,12 @@ module Kitchen
     #
     # @param suite [Suite,#name] a Suite
     # @param platform [Platform,#name] a Platform
+    # @param state_file [Kitchen::StateFile] a SateFile
     # @return [LifecycleHooks] a new LifecycleHooks object
     # @api private
-    def new_lifecycle_hooks(suite, platform)
+    def new_lifecycle_hooks(suite, platform, state_file)
       lhdata = data.lifecycle_hooks_data_for(suite.name, platform.name)
-      LifecycleHooks.new(lhdata)
+      LifecycleHooks.new(lhdata, state_file)
     end
 
     # Builds a newly configured Provisioner object, for a given Suite and

--- a/lib/kitchen/lifecycle_hook/base.rb
+++ b/lib/kitchen/lifecycle_hook/base.rb
@@ -56,7 +56,7 @@ module Kitchen
 
       # @return [Kitchen::StateFile]
       def state_file
-        instance.state_file
+        lifecycle_hooks.state_file
       end
 
       # @return [Array<String>] names of excluded platforms

--- a/lib/kitchen/lifecycle_hook/base.rb
+++ b/lib/kitchen/lifecycle_hook/base.rb
@@ -1,0 +1,78 @@
+module Kitchen
+  class LifecycleHook
+    class Base
+      # @return [Kitchen::LifecycleHooks]
+      attr_reader :lifecycle_hooks
+
+      # return [String]
+      attr_reader :phase
+
+      # return [Hash]
+      attr_reader :hook
+
+      # @param lifecycle_hooks [Kitchen::LifecycleHooks]
+      # @param phase [String]
+      # @param hook [Hash]
+      def initialize(lifecycle_hooks, phase, hook)
+        @lifecycle_hooks = lifecycle_hooks
+        @phase = phase
+        @hook = hook
+      end
+
+      # return [void]
+      def run
+        raise NotImplementedError
+      end
+
+      # @return [TrueClass, FalseClass]
+      def should_run?
+        if !includes.empty?
+          includes.include?(platform_name)
+        elsif !excludes.empty?
+          !excludes.include?(platform_name)
+        else
+          true
+        end
+      end
+
+      # @return [Logger] the lifecycle hooks's logger
+      #   otherwise
+      # @api private
+      def logger
+        lifecycle_hooks.send(:logger)
+      end
+
+      private
+
+      # @return [Kitchen::Instance]
+      def instance
+        lifecycle_hooks.instance
+      end
+
+      # @return [Hash]
+      def config
+        lifecycle_hooks.send(:config)
+      end
+
+      # @return [Kitchen::StateFile]
+      def state_file
+        instance.state_file
+      end
+
+      # @return [Array<String>] names of excluded platforms
+      def excludes
+        @excludes ||= hook.fetch(:excludes, [])
+      end
+
+      # @return [Array<String>] names of only included platforms
+      def includes
+        @includes ||= hook.fetch(:includes, [])
+      end
+
+      # @return [String]
+      def platform_name
+        instance.platform.name
+      end
+    end
+  end
+end

--- a/lib/kitchen/lifecycle_hook/local.rb
+++ b/lib/kitchen/lifecycle_hook/local.rb
@@ -1,0 +1,53 @@
+require_relative "base"
+require_relative "../shell_out"
+require_relative "../logging"
+
+module Kitchen
+  class LifecycleHook
+    class Local < Base
+      include ShellOut
+      include Logging
+
+      # Execute a specific local command hook.
+      #
+      # @return [void]
+      def run
+        state = state_file.read
+        # set up empty user variable
+        user = {}
+        # Set up some environment variables with instance info.
+        environment = {
+          "KITCHEN_INSTANCE_NAME" => instance.name,
+          "KITCHEN_SUITE_NAME" => instance.suite.name,
+          "KITCHEN_PLATFORM_NAME" => instance.platform.name,
+          "KITCHEN_INSTANCE_HOSTNAME" => state[:hostname].to_s,
+        }
+        # If the user specified env vars too, fix them up because symbol keys
+        # make mixlib-shellout sad.
+        hook[:environment]&.each do |k, v|
+          environment[k.to_s] = v.to_s
+        end
+
+        # add user to user hash for later merging
+        user[:user] = hook[:user] if hook[:user]
+
+        # Default the cwd to the kitchen root and resolve a relative input cwd against that.
+        cwd = if hook[:cwd]
+                File.expand_path(hook[:cwd], config[:kitchen_root])
+              else
+                config[:kitchen_root]
+              end
+        # Build the options for mixlib-shellout.
+        opts = {}.merge(user).merge(cwd: cwd, environment: environment)
+        run_command(command, opts)
+      end
+
+      private
+
+      # @return [String]
+      def command
+        hook.fetch(:local)
+      end
+    end
+  end
+end

--- a/lib/kitchen/lifecycle_hook/remote.rb
+++ b/lib/kitchen/lifecycle_hook/remote.rb
@@ -1,0 +1,33 @@
+require_relative "base"
+require_relative "../errors"
+
+module Kitchen
+  class LifecycleHook
+    class Remote < Base
+      # Execute a specific remote command hook.
+      #
+      # @return [void]
+      def run
+        # Check if we're in a state that makes sense to even try.
+        unless instance.last_action
+          if hook[:skippable]
+            # Just not even trying.
+            return
+          else
+            raise UserError, "Cannot use remote lifecycle hooks during phases when the instance is not available"
+          end
+        end
+
+        conn = instance.transport.connection(state_file.read)
+        conn.execute(command)
+      end
+
+      private
+
+      # return [String]
+      def command
+        hook.fetch(:remote)
+      end
+    end
+  end
+end

--- a/lib/kitchen/lifecycle_hooks.rb
+++ b/lib/kitchen/lifecycle_hooks.rb
@@ -15,8 +15,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require_relative "configurable"
 require_relative "errors"
-require_relative "shell_out"
+require_relative "lifecycle_hook/local"
+require_relative "lifecycle_hook/remote"
+require_relative "logging"
 
 module Kitchen
   # A helper object used by {Instance} to coordinate lifecycle hook calls from
@@ -27,7 +30,6 @@ module Kitchen
   class LifecycleHooks
     include Configurable
     include Logging
-    include ShellOut
 
     def initialize(config)
       init_config(config)
@@ -40,21 +42,19 @@ module Kitchen
     # @param block [Proc] Block of code implementing the lifecycle phase.
     # @return [void]
     def run_with_hooks(phase, state_file, &block)
-      run(instance, phase, state_file, :pre)
+      run(phase, :pre)
       yield
-      run(instance, phase, state_file, :post)
+      run(phase, :post)
     end
 
     private
 
     # Execute a specific lifecycle hook.
     #
-    # @param instance [Instance] The instance object to run against.
     # @param phase [String] Lifecycle phase which is being executed.
-    # @param state_file [StateFile] Instance state file object.
     # @param hook_timing [Symbol] `:pre` or `:post` to indicate which hook to run.
     # @return [void]
-    def run(instance, phase, state_file, hook_timing)
+    def run(phase, hook_timing)
       # Yes this has to be a symbol because of how data munger works.
       hook_key = :"#{hook_timing}_#{phase}"
       # No hooks? We're outta here.
@@ -65,80 +65,24 @@ module Kitchen
         # Coerce the common case of a bare string to be a local command. This
         # is to match the behavior of the old `pre_create_command` semi-hook.
         hook = { local: hook } if hook.is_a?(String)
-        if hook.include?(:local)
-          # Local command execution on the workstation.
-          run_local_hook(instance, state_file, hook)
-        elsif hook.include?(:remote)
-          # Remote command execution on the test instance.
-          run_remote_hook(instance, state_file, hook)
-        else
-          raise UserError, "Unknown lifecycle hook target #{hook.inspect}"
-        end
+        hook = generate_hook(phase, hook)
+        hook.run if hook.should_run?
       end
     end
 
-    # Execute a specific local command hook.
-    #
-    # @param instance [Instance] The instance object to run against.
-    # @param state_file [StateFile] Instance state file object.
-    # @param hook [Hash] Hook configration to use.
-    # @return [void]
-    def run_local_hook(instance, state_file, hook)
-      cmd = hook.fetch(:local)
-      state = state_file.read
-      # set up empty user variable
-      user = {}
-      # Set up some environment variables with instance info.
-      environment = {
-        "KITCHEN_INSTANCE_NAME" => instance.name,
-        "KITCHEN_SUITE_NAME" => instance.suite.name,
-        "KITCHEN_PLATFORM_NAME" => instance.platform.name,
-        "KITCHEN_INSTANCE_HOSTNAME" => state[:hostname].to_s,
-      }
-      # If the user specified env vars too, fix them up because symbol keys
-      # make mixlib-shellout sad.
-      if hook[:environment]
-        hook[:environment].each do |k, v|
-          environment[k.to_s] = v.to_s
-        end
+    # @param phase [String]
+    # @param hook [Hash]
+    # @return [Kitchen::LifecycleHook::Local, Kitchen::LifecycleHook::Remote]
+    def generate_hook(phase, hook)
+      if hook.include?(:local)
+        # Local command execution on the workstation.
+        Kitchen::LifecycleHook::Local.new(self, phase, hook)
+      elsif hook.include?(:remote)
+        # Remote command execution on the test instance.
+        Kitchen::LifecycleHook::Remote.new(self, phase, hook)
+      else
+        raise UserError, "Unknown lifecycle hook target #{hook.inspect}"
       end
-
-      # add user to user hash for later merging
-      if hook[:user]
-        user[:user] = hook[:user]
-      end
-
-      # Default the cwd to the kitchen root and resolve a relative input cwd against that.
-      cwd = if hook[:cwd]
-              File.expand_path(hook[:cwd], config[:kitchen_root])
-            else
-              config[:kitchen_root]
-            end
-      # Build the options for mixlib-shellout.
-      opts = {}.merge(user).merge(cwd: cwd, environment: environment)
-      run_command(cmd, opts)
-    end
-
-    # Execute a specific remote command hook.
-    #
-    # @param instance [Instance] The instance object to run against.
-    # @param state_file [StateFile] Instance state file object.
-    # @param hook [Hash] Hook configration to use.
-    # @return [void]
-    def run_remote_hook(instance, state_file, hook)
-      # Check if we're in a state that makes sense to even try.
-      unless instance.last_action
-        if hook[:skippable]
-          # Just not even trying.
-          return
-        else
-          raise UserError, "Cannot use remote lifecycle hooks during phases when the instance is not available"
-        end
-      end
-
-      cmd = hook.fetch(:remote)
-      conn = instance.transport.connection(state_file.read)
-      conn.execute(cmd)
     end
   end
 end

--- a/lib/kitchen/lifecycle_hooks.rb
+++ b/lib/kitchen/lifecycle_hooks.rb
@@ -31,8 +31,9 @@ module Kitchen
     include Configurable
     include Logging
 
-    def initialize(config)
+    def initialize(config, state_file)
       init_config(config)
+      @state_file = state_file
     end
 
     # Run a lifecycle phase with the pre and post hooks.
@@ -46,6 +47,9 @@ module Kitchen
       yield
       run(phase, :post)
     end
+
+    # @return [Kitchen::StateFile]
+    attr_reader :state_file
 
     private
 

--- a/spec/kitchen/instance_spec.rb
+++ b/spec/kitchen/instance_spec.rb
@@ -119,7 +119,7 @@ describe Kitchen::Instance do
   let(:logger_io)       { StringIO.new }
   let(:logger)          { Kitchen::Logger.new(logdev: logger_io) }
   let(:instance)        { Kitchen::Instance.new(opts) }
-  let(:lifecycle_hooks) { Kitchen::LifecycleHooks.new({}) }
+  let(:lifecycle_hooks) { Kitchen::LifecycleHooks.new({}, state_file) }
   let(:provisioner)     { Kitchen::Provisioner::Dummy.new({}) }
   let(:state_file)      { DummyStateFile.new }
   let(:transport)       { Kitchen::Transport::Dummy.new({}) }

--- a/spec/kitchen/instance_spec.rb
+++ b/spec/kitchen/instance_spec.rb
@@ -500,8 +500,8 @@ describe Kitchen::Instance do
         end
 
         it "calls lifecycle hooks" do
-          lifecycle_hooks.expects(:run).with(instance, :create, state_file, :pre)
-          lifecycle_hooks.expects(:run).with(instance, :create, state_file, :post)
+          lifecycle_hooks.expects(:run).with(:create, :pre)
+          lifecycle_hooks.expects(:run).with(:create, :post)
 
           instance.create
         end
@@ -556,10 +556,10 @@ describe Kitchen::Instance do
         end
 
         it "calls lifecycle hooks" do
-          lifecycle_hooks.expects(:run).with(instance, :create, state_file, :pre)
-          lifecycle_hooks.expects(:run).with(instance, :create, state_file, :post)
-          lifecycle_hooks.expects(:run).with(instance, :converge, state_file, :pre)
-          lifecycle_hooks.expects(:run).with(instance, :converge, state_file, :post)
+          lifecycle_hooks.expects(:run).with(:create, :pre)
+          lifecycle_hooks.expects(:run).with(:create, :post)
+          lifecycle_hooks.expects(:run).with(:converge, :pre)
+          lifecycle_hooks.expects(:run).with(:converge, :post)
 
           instance.converge
         end
@@ -582,8 +582,8 @@ describe Kitchen::Instance do
         end
 
         it "calls lifecycle hooks" do
-          lifecycle_hooks.expects(:run).with(instance, :converge, state_file, :pre)
-          lifecycle_hooks.expects(:run).with(instance, :converge, state_file, :post)
+          lifecycle_hooks.expects(:run).with(:converge, :pre)
+          lifecycle_hooks.expects(:run).with(:converge, :post)
 
           instance.converge
         end

--- a/spec/kitchen/lifecycle_hooks_spec.rb
+++ b/spec/kitchen/lifecycle_hooks_spec.rb
@@ -36,7 +36,7 @@ describe Kitchen::LifecycleHooks do
     end
   end
   let(:config) { { kitchen_root: kitchen_root } }
-  let(:lifecycle_hooks) { Kitchen::LifecycleHooks.new(config).tap { |lh| lh.finalize_config!(instance) } }
+  let(:lifecycle_hooks) { Kitchen::LifecycleHooks.new(config, state_file).tap { |lh| lh.finalize_config!(instance) } }
   let(:standard_local_options) do
     {
       cwd: kitchen_root,

--- a/spec/kitchen/lifecycle_hooks_spec.rb
+++ b/spec/kitchen/lifecycle_hooks_spec.rb
@@ -27,130 +27,136 @@ describe Kitchen::LifecycleHooks do
   let(:connection) { mock("connection") }
   let(:transport) { mock("transport").tap { |t| t.stubs(:connection).with({ hostname: "localhost" }).returns(connection) } }
   let(:last_action) { :create }
-  let(:instance) { mock("instance").tap { |i| i.stubs(name: "default-toaster-10", transport: transport, last_action: last_action, suite: suite, platform: platform) } }
-  let(:config) { { kitchen_root: "/kitchen" } }
+  let(:instance) { mock("instance").tap { |i| i.stubs(name: "default-toaster-10", transport: transport, last_action: last_action, suite: suite, platform: platform, state_file: state_file) } }
+  let(:kitchen_root) do
+    if RUBY_PLATFORM =~ /mswin|mingw|windows/
+      "#{ENV["SYSTEMDRIVE"]}/kitchen"
+    else
+      "/kitchen"
+    end
+  end
+  let(:config) { { kitchen_root: kitchen_root } }
   let(:lifecycle_hooks) { Kitchen::LifecycleHooks.new(config).tap { |lh| lh.finalize_config!(instance) } }
+  let(:standard_local_options) do
+    {
+      cwd: kitchen_root,
+      environment: {
+        "KITCHEN_INSTANCE_NAME" => "default-toaster-10",
+        "KITCHEN_SUITE_NAME" => "default",
+        "KITCHEN_PLATFORM_NAME" => "toaster-1.0",
+        "KITCHEN_INSTANCE_HOSTNAME" => "localhost",
+      },
+    }
+  end
 
   def run_lifecycle_hooks
     lifecycle_hooks.run_with_hooks(:create, state_file) {}
   end
 
-  # Pull this out because it's used in a bunch of tests.
-  STANDARD_LOCAL_OPTIONS = {
-    cwd: "/kitchen",
-    environment: {
-      "KITCHEN_INSTANCE_NAME" => "default-toaster-10",
-      "KITCHEN_SUITE_NAME" => "default",
-      "KITCHEN_PLATFORM_NAME" => "toaster-1.0",
-      "KITCHEN_INSTANCE_HOSTNAME" => "localhost",
-    },
-  }.freeze
+  def expect_local_hook_generated_and_run(phase, hook, non_standard_local_opts: {})
+    local_hook = Kitchen::LifecycleHook::Local.new(lifecycle_hooks, phase, hook)
+    lifecycle_hooks.expects(:generate_hook).with(:create, hook).returns(local_hook)
+    expected_options = standard_local_options.merge(non_standard_local_opts)
+    local_hook.expects(:run_command).with(hook[:local], expected_options)
+    local_hook
+  end
+
+  def expect_remote_hook_generated_and_run(phase, hook)
+    remote_hook = Kitchen::LifecycleHook::Remote.new(lifecycle_hooks, phase, hook)
+    lifecycle_hooks.expects(:generate_hook).with(:create, hook).returns(remote_hook)
+    remote_hook.expects(:run_command).never
+    connection.expects(:execute).with(hook[:remote])
+    remote_hook
+  end
 
   it "runs a single local command" do
-    config.update(post_create: ["echo foo"])
-    lifecycle_hooks.expects(:run_command).with("echo foo", STANDARD_LOCAL_OPTIONS)
+    local_command = "echo foo"
+    config.update(post_create: [local_command])
+    expect_local_hook_generated_and_run(:post, { local: local_command })
     run_lifecycle_hooks
   end
 
   it "runs multiple local commands" do
-    config.update(post_create: ["echo foo", { local: "echo bar" }])
-    lifecycle_hooks.expects(:run_command).with("echo foo", STANDARD_LOCAL_OPTIONS)
-    lifecycle_hooks.expects(:run_command).with("echo bar", STANDARD_LOCAL_OPTIONS)
+    local_command = "echo foo"
+    local_hook = { local: "echo bar" }
+    config.update(post_create: [local_command, local_hook])
+    expect_local_hook_generated_and_run(:post, { local: local_command })
+    expect_local_hook_generated_and_run(:post, local_hook)
     run_lifecycle_hooks
   end
 
   it "runs multiple local hooks" do
     config.update(pre_create: ["echo foo"], post_create: ["echo bar"])
-    lifecycle_hooks.expects(:run_command).with("echo foo", STANDARD_LOCAL_OPTIONS)
-    lifecycle_hooks.expects(:run_command).with("echo bar", STANDARD_LOCAL_OPTIONS)
+    expect_local_hook_generated_and_run(:create, { local: "echo foo" })
+    expect_local_hook_generated_and_run(:create, { local: "echo bar" })
     run_lifecycle_hooks
   end
 
   it "runs a local command with a user option" do
-    config.update(post_create: [{ local: "echo foo", user: "bar" }])
-    lifecycle_hooks.expects(:run_command).with("echo foo", {
-      cwd: "/kitchen",
-      user: "bar",
-      environment: {
-        "KITCHEN_INSTANCE_NAME" => "default-toaster-10",
-        "KITCHEN_SUITE_NAME" => "default",
-        "KITCHEN_PLATFORM_NAME" => "toaster-1.0",
-        "KITCHEN_INSTANCE_HOSTNAME" => "localhost",
-      },
-    })
+    hook = { local: "echo foo", user: "bar" }
+    config.update(post_create: [hook])
+    expect_local_hook_generated_and_run(:create, hook, non_standard_local_opts: { user: "bar" })
     run_lifecycle_hooks
   end
 
   it "runs a local command with environment options" do
-    config.update(post_create: [{ local: "echo foo", environment: { FOO: "one", BAR: "two" } }])
-    lifecycle_hooks.expects(:run_command).with("echo foo", {
-      cwd: "/kitchen",
-      environment: {
-        "FOO" => "one",
-        "BAR" => "two",
-        "KITCHEN_INSTANCE_NAME" => "default-toaster-10",
-        "KITCHEN_SUITE_NAME" => "default",
-        "KITCHEN_PLATFORM_NAME" => "toaster-1.0",
-        "KITCHEN_INSTANCE_HOSTNAME" => "localhost",
-      },
-    })
+    hook = { local: "echo foo", environment: { FOO: "one", BAR: "two" } }
+    config.update(post_create: [hook])
+    command_opts = standard_local_options.dup
+    command_opts[:environment]["FOO"] = "one"
+    command_opts[:environment]["BAR"] = "two"
+    expect_local_hook_generated_and_run(:create, hook, non_standard_local_opts: command_opts)
     run_lifecycle_hooks
   end
 
   it "runs a local command with a relative cwd option" do
-    config.update(post_create: [{ local: "echo foo", cwd: "test" }])
-    lifecycle_hooks.expects(:run_command).with("echo foo", {
-      cwd: os_safe_root_path("/kitchen/test"),
-      environment: {
-        "KITCHEN_INSTANCE_NAME" => "default-toaster-10",
-        "KITCHEN_SUITE_NAME" => "default",
-        "KITCHEN_PLATFORM_NAME" => "toaster-1.0",
-        "KITCHEN_INSTANCE_HOSTNAME" => "localhost",
-      },
-    })
+    hook = { local: "echo foo", cwd: "test" }
+    config.update(post_create: [hook])
+    expect_local_hook_generated_and_run(:create, hook, non_standard_local_opts: { cwd: "#{kitchen_root}/test" })
     run_lifecycle_hooks
   end
 
   it "runs a local command with an absolute cwd option" do
-    config.update(post_create: [{ local: "echo foo", cwd: "/test" }])
-    lifecycle_hooks.expects(:run_command).with("echo foo", {
-      cwd: os_safe_root_path("/test"),
-      environment: {
-        "KITCHEN_INSTANCE_NAME" => "default-toaster-10",
-        "KITCHEN_SUITE_NAME" => "default",
-        "KITCHEN_PLATFORM_NAME" => "toaster-1.0",
-        "KITCHEN_INSTANCE_HOSTNAME" => "localhost",
-      },
-    })
+    cwd = if RUBY_PLATFORM =~ /mswin|mingw|windows/
+            "#{ENV["SYSTEMDRIVE"]}/test"
+          else
+            "/test"
+          end
+    hook = { local: "echo foo", cwd: cwd }
+    config.update(post_create: [hook])
+    expect_local_hook_generated_and_run(:create, hook, non_standard_local_opts: { cwd: cwd })
     run_lifecycle_hooks
   end
 
   it "runs a single remote command" do
-    config.update(post_create: [{ remote: "echo foo" }])
-    lifecycle_hooks.expects(:run_command).never
-    connection.expects(:execute).with("echo foo")
+    hook = { remote: "echo foo" }
+    config.update(post_create: [hook])
+    expect_remote_hook_generated_and_run(:create, hook)
     run_lifecycle_hooks
   end
 
   it "runs a multiple remote command" do
-    config.update(post_create: [{ remote: "echo foo" }, { remote: "echo bar" }])
-    lifecycle_hooks.expects(:run_command).never
-    connection.expects(:execute).with("echo foo")
-    connection.expects(:execute).with("echo bar")
+    hook1 = { remote: "echo foo" }
+    hook2 = { remote: "echo bar" }
+    config.update(post_create: [hook1, hook2])
+    expect_remote_hook_generated_and_run(:create, hook1)
+    expect_remote_hook_generated_and_run(:create, hook2)
     run_lifecycle_hooks
   end
 
   it "rejects unknown hook targets" do
     config.update(post_create: [{ banana: "echo foo" }])
-    lifecycle_hooks.expects(:run_command).never
     proc { run_lifecycle_hooks }.must_raise Kitchen::UserError
   end
 
   it "runs mixed local and remote commands" do
-    config.update(post_create: ["echo foo", { local: "echo bar" }, { remote: "echo baz" }])
-    lifecycle_hooks.expects(:run_command).with("echo foo", STANDARD_LOCAL_OPTIONS)
-    lifecycle_hooks.expects(:run_command).with("echo bar", STANDARD_LOCAL_OPTIONS)
-    connection.expects(:execute).with("echo baz")
+    local_command = "echo foo"
+    local_hook = { local: "echo bar" }
+    remote_hook = { remote: "echo baz" }
+    config.update(post_create: [local_command, local_hook, remote_hook])
+    expect_local_hook_generated_and_run(:create, { local: local_command })
+    expect_local_hook_generated_and_run(:create, local_hook)
+    expect_remote_hook_generated_and_run(:create, remote_hook)
     run_lifecycle_hooks
   end
 
@@ -158,20 +164,25 @@ describe Kitchen::LifecycleHooks do
     let(:last_action) { nil }
 
     it "runs local commands" do
-      config.update(post_create: [{ local: "echo foo" }])
-      lifecycle_hooks.expects(:run_command).with("echo foo", STANDARD_LOCAL_OPTIONS)
+      hook = { local: "echo foo" }
+      config.update(post_create: [hook])
+      expect_local_hook_generated_and_run(:create, hook)
       run_lifecycle_hooks
     end
 
     it "fails on remote commands" do
-      config.update(post_create: [{ remote: "echo foo" }])
-      lifecycle_hooks.expects(:run_command).never
+      hook = { remote: "echo foo" }
+      config.update(post_create: [hook])
+      remote_lifecycle_hook = Kitchen::LifecycleHook::Remote.new(lifecycle_hooks, :create, hook)
+      remote_lifecycle_hook.expects(:run_command).never
       proc { run_lifecycle_hooks }.must_raise Kitchen::UserError
     end
 
     it "ignores skippable remote commands" do
-      config.update(post_create: [{ remote: "echo foo", skippable: true }])
-      lifecycle_hooks.expects(:run_command).never
+      hook = { remote: "echo foo", skippable: true }
+      config.update(post_create: [hook])
+      remote_lifecycle_hook = Kitchen::LifecycleHook::Remote.new(lifecycle_hooks, :create, hook)
+      remote_lifecycle_hook.expects(:run_command).never
       run_lifecycle_hooks
     end
   end


### PR DESCRIPTION
# Description

This extends the same idea used in suites to be used in lifecycle hooks, specifically the ability to include/exclude hooks based on platform name. This also goes into extracting hooks into their own class to help build a foundation for future things like https://github.com/test-kitchen/test-kitchen/issues/1641, potentially.

## This seems odd, what is the point of this and why can't you just define platform specific hooks in the platform definition?

The use case I'm trying to solve is someone who has complex platforms defined globally in a KITCHEN_GLOBAL_YAML and only defines suites in the KITCHEN_YAML file. In this case I have multiple platforms defined in the KITCHEN_GLOBAL_YAML file and I wish to define a unique pre_destroy hook per platform type (i.e. windows versus linux) in the  KITCHEN_YAML for the specific suite. Because of the way the YAML loader works with `#rmerge`, it can only merge hashes, not arrays (which totally makes sense technically). Because platforms are defined as an array it forces me to duplicate the platform content to all of my cookbooks in the mono repo.

With the feature layed out in the PR it would allow someone to do the following:

```yaml
# KITCHEN_GLOBAL_YAML
---
platforms:
  - name: redhat-7
    ...lots of content
  - name: windows-2012r2
    ...lots of content
  - name: windows-2016
    ...lots of content
```

```yaml
# KITCHEN_YAML
---
suites:
  - name: default
    run_list:
      - recipe[cookbook::default]
    pre_destroy:
      - remote: /opt/app/bin/cmd --delete
        includes:
          - redhat-7
      - remote: C:/app/bin/other-cmd --destroy
        excludes:
          - redhat-7
```

## Issues Resolved

N/A

## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
