### PR TITLE
Disable linting for thor require

### DIFF
--- a/lib/kitchen/cli.rb
+++ b/lib/kitchen/cli.rb
@@ -15,7 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "thor"
+# CI tests fail without an explicit unconditional require of Thor
+require "thor" # rubocop:disable ChefRuby/UnlessDefinedRequire
 
 require_relative "../kitchen"
 require_relative "generator/init"


### PR DESCRIPTION
Make CI on master happy again by disabling the ChefStyle rule for the `thor` require in cli.rb. This one can't be conditionalized because it breaks it the tests.

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
