### PR TITLE
Mark chef_solo provisioner unsafe for concurrency

### DIFF
--- a/lib/kitchen/provisioner/chef_solo.rb
+++ b/lib/kitchen/provisioner/chef_solo.rb
@@ -27,6 +27,10 @@ module Kitchen
 
       plugin_version Kitchen::VERSION
 
+      # ChefSolo is dependent on Berkshelf, which is not thread-safe.
+      # See discussion on https://github.com/test-kitchen/test-kitchen/issues/1307
+      no_parallel_for :converge
+
       default_config :solo_rb, {}
 
       default_config :chef_solo_path do |provisioner|


### PR DESCRIPTION
Uses the `no_parallel_for` plugin DSL keyword introduced to Provisioners in 2.7.0 to mark the `chef_solo` provisioner as being single-threaded. This is to protect Berkshelf, which is not thread-safe, and should make the `-c` option usably stable for the converge action.

I've opened an issue, #1680, with background and discussion, and mentioned the idea in [community Slack](https://chefcommunity.slack.com/archives/C2B6G1WCQ/p1599244742044400). 

This PR is just to make the actual change.

## Issues Resolved

Closes #1680

## Check List

- [x] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
