### PR TITLE
use autoload to improve perf of kitchen --version

### DIFF
--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -24,9 +24,9 @@ require_relative "chef/policyfile"
 require_relative "chef/berkshelf"
 require_relative "chef/common_sandbox"
 require_relative "../util"
-require "mixlib/install"
-require "mixlib/install/script_generator"
-require "license_acceptance/acceptor"
+module LicenseAcceptance
+  autoload :Acceptor, "license_acceptance/acceptor"
+end
 
 begin
   require "chef-config/config"
@@ -503,6 +503,7 @@ module Kitchen
       # @return [String] contents of product based install script
       # @api private
       def script_for_product
+        require "mixlib/install"
         installer = Mixlib::Install.new({
           product_name: config[:product_name],
           product_version: config[:product_version],
@@ -576,6 +577,7 @@ module Kitchen
       # @return [String] contents of version based install script
       # @api private
       def script_for_omnibus_version
+        require "mixlib/install/script_generator"
         installer = Mixlib::Install::ScriptGenerator.new(
           config[:require_chef_omnibus], powershell_shell?, install_options
         )

--- a/lib/kitchen/ssh.rb
+++ b/lib/kitchen/ssh.rb
@@ -16,8 +16,9 @@
 # limitations under the License.
 
 require "logger"
-require "net/ssh" unless defined?(Net::SSH)
-require "net/scp"
+module Net
+  autoload :SSH, "net/ssh"
+end
 require "socket" unless defined?(Socket)
 
 require_relative "errors"
@@ -90,6 +91,7 @@ module Kitchen
     #   `Net::SCP.upload`
     # @see http://net-ssh.github.io/net-scp/classes/Net/SCP.html#method-i-upload
     def upload!(local, remote, options = {}, &progress)
+      require "net/scp" unless defined?(Net::SCP)
       if progress.nil?
         progress = lambda do |_ch, name, sent, total|
           logger.debug("Uploaded #{name} (#{total} bytes)") if sent == total
@@ -100,6 +102,7 @@ module Kitchen
     end
 
     def upload(local, remote, options = {}, &progress)
+      require "net/scp" unless defined?(Net::SCP)
       if progress.nil?
         progress = lambda do |_ch, name, sent, total|
           if sent == total

--- a/lib/kitchen/state_file.rb
+++ b/lib/kitchen/state_file.rb
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "yaml" unless defined?(YAML)
+autoload :YAML, "yaml"
 
 module Kitchen
   # Exception class for any exceptions raised when reading and parsing a state

--- a/spec/kitchen/provisioner/chef_base_spec.rb
+++ b/spec/kitchen/provisioner/chef_base_spec.rb
@@ -20,6 +20,8 @@ require_relative "../../spec_helper"
 require "kitchen"
 require "kitchen/provisioner/chef_base"
 require "fileutils"
+require "mixlib/install"
+require "mixlib/install/script_generator"
 
 describe Kitchen::Provisioner::ChefBase do
   let(:logged_output)   { StringIO.new }


### PR DESCRIPTION
This shaves about 1 second off a `kitchen --version`. Unfortunately it does not improve other commands too much. The way the transports load deps could be refactored so that the underlying (and large) deps are not loaded at plugin load time. And of course you need `YAML` to do just about anything.

Signed-off-by: mwrock <matt@mattwrock.com>
