### PR TITLE
Minor performance optimizations from rubocop-performance

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -6,7 +6,7 @@ end
 
 def cucumber_opts
   cucumber_cli = "--no-profile --color --format progress --strict"
-  cucumber_cli += " --tags ~@spawn" if RUBY_PLATFORM =~ /mswin|mingw|windows/
+  cucumber_cli += " --tags ~@spawn" if RUBY_PLATFORM.match?(/mswin|mingw|windows/)
 
   { all_on_start: false, cli: cucumber_cli }
 end

--- a/lib/kitchen.rb
+++ b/lib/kitchen.rb
@@ -16,8 +16,6 @@
 # limitations under the License.
 
 require "pathname" unless defined?(Pathname)
-require "thread"
-
 require_relative "kitchen/errors"
 require_relative "kitchen/logger"
 require_relative "kitchen/logging"
@@ -67,7 +65,7 @@ module Kitchen
     #
     # @return [Pathname] root path of gem
     def source_root
-      @source_root ||= Pathname.new(File.expand_path("../../", __FILE__))
+      @source_root ||= Pathname.new(File.expand_path("..", __dir__))
     end
 
     # Returns a default logger which emits on standard output.

--- a/lib/kitchen/command.rb
+++ b/lib/kitchen/command.rb
@@ -15,8 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "thread"
-
 module Kitchen
   module Command
     # Base class for CLI commands.

--- a/lib/kitchen/config.rb
+++ b/lib/kitchen/config.rb
@@ -213,7 +213,7 @@ module Kitchen
           provisioner: Provisioner::DEFAULT_PLUGIN,
           verifier: Verifier::DEFAULT_PLUGIN,
           transport: lambda do |_suite, platform|
-            platform =~ /^win/i ? "winrm" : Transport::DEFAULT_PLUGIN
+            /^win/i.match?(platform) ? "winrm" : Transport::DEFAULT_PLUGIN
           end,
         },
         kitchen_root: kitchen_root,

--- a/lib/kitchen/provisioner/chef/policyfile.rb
+++ b/lib/kitchen/provisioner/chef/policyfile.rb
@@ -110,13 +110,13 @@ module Kitchen
         # @return [String]
         # @api private
         def escape_path(path)
-          if RbConfig::CONFIG["host_os"] =~ /mswin|mingw/
+          if /mswin|mingw/.match?(RbConfig::CONFIG["host_os"])
             # I know what you're thinking: "just use Shellwords.escape". That
             # method produces incorrect results on Windows with certain input
             # which would be a metacharacter in Sh but is not for one or more of
             # Windows command line parsing libraries. This covers the 99% case of
             # spaces in the path without breaking other stuff.
-            if path =~ /[ \t\n\v"]/
+            if /[ \t\n\v"]/.match?(path)
               "\"#{path.gsub(/[ \t\n\v\"\\]/) { |m| '\\' + m[0] }}\""
             else
               path
@@ -136,7 +136,7 @@ module Kitchen
           # @api private
           def detect_chef_command!(logger)
             unless ENV["PATH"].split(File::PATH_SEPARATOR).any? do |path|
-              if RbConfig::CONFIG["host_os"] =~ /mswin|mingw/
+              if /mswin|mingw/.match?(RbConfig::CONFIG["host_os"])
                 # Windows could have different extentions: BAT, EXE or NONE
                 %w{chef chef.exe chef.bat}.each do |bin|
                   File.exist?(File.join(path, bin))

--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -156,7 +156,7 @@ module Kitchen
               product_name: <chef or chef-workstation>
               install_strategy: skip
           MSG
-        when provisioner[:require_chef_omnibus].to_s.match(/\d/)
+        when provisioner[:require_chef_omnibus].to_s.match?(/\d/)
           Util.outdent!(<<-MSG)
             The 'require_chef_omnibus' attribute with version values will change
             to use the new 'product_version' attribute.

--- a/lib/kitchen/util.rb
+++ b/lib/kitchen/util.rb
@@ -110,7 +110,7 @@ module Kitchen
     def self.wrap_command(cmd)
       cmd = "false" if cmd.nil?
       cmd = "true" if cmd.to_s.empty?
-      cmd = cmd.sub(/\n\Z/, "") if cmd =~ /\n\Z/
+      cmd = cmd.sub(/\n\Z/, "") if /\n\Z/.match?(cmd)
 
       "sh -c '\n#{cmd}\n'"
     end

--- a/lib/kitchen/verifier/busser.rb
+++ b/lib/kitchen/verifier/busser.rb
@@ -168,7 +168,7 @@ module Kitchen
       # @api private
       def gem_install_args
         gem, version = config[:version].split("@")
-        if gem =~ /^\d+\.\d+\.\d+/
+        if /^\d+\.\d+\.\d+/.match?(gem)
           version = gem
           gem = "busser"
         end

--- a/spec/kitchen_spec.rb
+++ b/spec/kitchen_spec.rb
@@ -64,7 +64,7 @@ describe "Kitchen" do
 
   it ".source_root returns the root path of the gem" do
     Kitchen.source_root
-      .must_equal Pathname.new(File.expand_path("../..", __FILE__))
+      .must_equal Pathname.new(File.expand_path("..", __dir__))
   end
 
   it ".default_logger is a Kitchen::Logger" do

--- a/test-kitchen.gemspec
+++ b/test-kitchen.gemspec
@@ -1,4 +1,4 @@
-lib = File.expand_path("../lib", __FILE__)
+lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "kitchen/version"
 require "English"


### PR DESCRIPTION
Mostly using .match? to avoid creating the full match object when all we need is a boolean

```
lib/kitchen.rb:19:1: W: [Corrected] Lint/RedundantRequireStatement: Remove unnecessary require statement.
require "thread"
^^^^^^^^^^^^^^^^
lib/kitchen.rb:68:54: C: [Corrected] Style/StringLiterals: Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping.
      @source_root ||= Pathname.new(File.expand_path('..', __dir__))
                                                     ^^^^
lib/kitchen.rb:70:42: C: [Corrected] Style/ExpandPathArguments: Use expand_path('..', __dir__) instead of expand_path('../../', __FILE__).
      @source_root ||= Pathname.new(File.expand_path("../../", __FILE__))
                                         ^^^^^^^^^^^
lib/kitchen/command.rb:18:1: W: [Corrected] Lint/RedundantRequireStatement: Remove unnecessary require statement.
require "thread"
^^^^^^^^^^^^^^^^
spec/kitchen_spec.rb:67:37: C: [Corrected] Style/ExpandPathArguments: Use expand_path('..', __dir__) instead of expand_path('../..', __FILE__).
      .must_equal Pathname.new(File.expand_path("../..", __FILE__))
                                    ^^^^^^^^^^^
spec/kitchen_spec.rb:67:49: C: [Corrected] Style/StringLiterals: Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping.
      .must_equal Pathname.new(File.expand_path('..', __dir__))
                                                ^^^^
test-kitchen.gemspec:1:12: C: [Corrected] Style/ExpandPathArguments: Use expand_path('lib', __dir__) instead of expand_path('../lib', __FILE__).
lib = File.expand_path("../lib", __FILE__)
           ^^^^^^^^^^^
test-kitchen.gemspec:1:24: C: [Corrected] Style/StringLiterals: Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping.
lib = File.expand_path('lib', __dir__)
                       ^^^^^

Guardfile:9:40: C: [Corrected] Performance/RegexpMatch: Use match? instead of =~ when MatchData is not used.
  cucumber_cli += " --tags ~@spawn" if RUBY_PLATFORM =~ /mswin|mingw|windows/
                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/kitchen/config.rb:216:13: C: [Corrected] Performance/RegexpMatch: Use match? instead of =~ when MatchData is not used.
            platform =~ /^win/i ? "winrm" : Transport::DEFAULT_PLUGIN
            ^^^^^^^^^^^^^^^^^^^
lib/kitchen/data_munger.rb:297:9: C: Performance/CollectionLiteralInLoop: Avoid immutable Array literals in loops. It is better to extract it into a local variable or a constant.
        %w{ ...
        ^^^
lib/kitchen/provisioner/chef/common_sandbox.rb:200:48: C: Performance/CollectionLiteralInLoop: Avoid immutable Array literals in loops. It is better to extract it into a local variable or a constant.
            .select { |fn| File.file?(fn) && ! %w{. ..}.include?(fn) }
                                               ^^^^^^^^
lib/kitchen/provisioner/chef/policyfile.rb:113:14: C: [Corrected] Performance/RegexpMatch: Use match? instead of =~ when MatchData is not used.
          if RbConfig::CONFIG["host_os"] =~ /mswin|mingw/
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/kitchen/provisioner/chef/policyfile.rb:119:16: C: [Corrected] Performance/RegexpMatch: Use match? instead of =~ when MatchData is not used.
            if path =~ /[ \t\n\v"]/
               ^^^^^^^^^^^^^^^^^^^^
lib/kitchen/provisioner/chef/policyfile.rb:139:18: C: [Corrected] Performance/RegexpMatch: Use match? instead of =~ when MatchData is not used.
              if RbConfig::CONFIG["host_os"] =~ /mswin|mingw/
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/kitchen/provisioner/chef/policyfile.rb:141:17: C: Performance/CollectionLiteralInLoop: Avoid immutable Array literals in loops. It is better to extract it into a local variable or a constant.
                %w{chef chef.exe chef.bat}.each do |bin|
                ^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/kitchen/provisioner/chef_base.rb:159:14: C: [Corrected] Performance/RegexpMatch: Use match? instead of match when MatchData is not used.
        when provisioner[:require_chef_omnibus].to_s.match(/\d/)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/kitchen/shell_out.rb:85:9: C: Performance/CollectionLiteralInLoop: Avoid immutable Array literals in loops. It is better to extract it into a local variable or a constant.
        %i{use_sudo sudo_command log_subject quiet}.include?(key)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/kitchen/util.rb:113:36: C: [Corrected] Performance/RegexpMatch: Use match? instead of =~ when MatchData is not used.
      cmd = cmd.sub(/\n\Z/, "") if cmd =~ /\n\Z/
                                   ^^^^^^^^^^^^^
lib/kitchen/util.rb:181:27: C: Performance/CollectionLiteralInLoop: Avoid immutable Array literals in loops. It is better to extract it into a local variable or a constant.
            .reject { |f| [".", ".."].include?(f) }
                          ^^^^^^^^^^^
lib/kitchen/verifier/busser.rb:171:12: C: [Corrected] Performance/RegexpMatch: Use match? instead of =~ when MatchData is not used.
        if gem =~ /^\d+\.\d+\.\d+/
           ^^^^^^^^^^^^^^^^^^^^^^^
```

Signed-off-by: Tim Smith <tsmith@chef.io>
