### PR TITLE
Use xfreerdp instead of rdesktop on Linux with WinRM

### DIFF
--- a/lib/kitchen/cli.rb
+++ b/lib/kitchen/cli.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 # CI tests fail without an explicit unconditional require of Thor
-require "thor" # rubocop:disable ChefRuby/UnlessDefinedRequire
+require "thor" # rubocop:disable Chef/Ruby/UnlessDefinedRequire
 
 require_relative "../kitchen"
 require_relative "generator/init"

--- a/lib/kitchen/transport/winrm.rb
+++ b/lib/kitchen/transport/winrm.rb
@@ -315,6 +315,7 @@ module Kitchen
           unless xfreerdp
             raise WinrmFailed, "xfreerdp binary not found. Please install freerdp2-x11 on Debian-based systems or freerdp on Redhat-based systems."
           end
+
           args  = %W{/u:#{options[:user]}}
           args += %W{/p:#{options[:password]}} if options.key?(:password)
           args += %W{/v:#{URI.parse(options[:endpoint]).host}:#{rdp_port}}

--- a/lib/kitchen/transport/winrm.rb
+++ b/lib/kitchen/transport/winrm.rb
@@ -308,16 +308,19 @@ module Kitchen
 
         # Builds a `LoginCommand` for use by Linux-based platforms.
         #
-        # TODO: determine whether or not `desktop` exists
-        #
         # @return [LoginCommand] a login command
         # @api private
         def login_command_for_linux
-          args  = %W{-u #{options[:user]}}
-          args += %W{-p #{options[:password]}} if options.key?(:password)
-          args += %W{#{URI.parse(options[:endpoint]).host}:#{rdp_port}}
+          xfreerdp = Util.command_exists? "xfreerdp"
+          unless xfreerdp
+            raise WinrmFailed, "xfreerdp binary not found. Please install freerdp2-x11 on Debian-based systems or freerdp on Redhat-based systems."
+          end
+          args  = %W{/u:#{options[:user]}}
+          args += %W{/p:#{options[:password]}} if options.key?(:password)
+          args += %W{/v:#{URI.parse(options[:endpoint]).host}:#{rdp_port}}
+          args += %W{/cert-tofu} # always accept certificate
 
-          LoginCommand.new("rdesktop", args)
+          LoginCommand.new(xfreerdp, args)
         end
 
         # Builds a `LoginCommand` for use by Mac-based platforms.

--- a/lib/kitchen/util.rb
+++ b/lib/kitchen/util.rb
@@ -215,5 +215,15 @@ module Kitchen
     def self.snake_case(a_string)
       Thor::Util.snake_case(a_string)
     end
+
+    # Check if a cmd exists on the PATH
+    def self.command_exists?(cmd)
+      paths = ENV["PATH"].split(File::PATH_SEPARATOR) + [ "/bin", "/usr/bin", "/sbin", "/usr/sbin" ]
+      paths.each do |path|
+        filename = File.join(path, cmd)
+        return filename if File.executable?(filename)
+      end
+      false
+    end
   end
 end

--- a/spec/kitchen/transport/base_spec.rb
+++ b/spec/kitchen/transport/base_spec.rb
@@ -22,6 +22,7 @@ require "kitchen"
 module Kitchen
   module Transport
     class TestingDummy < Kitchen::Transport::Base; end
+
     class Dodgy < Kitchen::Transport::Base
       no_parallel_for :setup
     end


### PR DESCRIPTION
This works around the following problem with rdesktop:

```
ERROR: CredSSP: Initialize failed, do you have correct kerberos tgt initialized ?
Failed to connect, CredSSP required by server.
```

It seems to be related to this issue [1]. As a workaround, xfreerdp works out of the box and seems to be a better option.

[1] https://github.com/rdesktop/rdesktop/issues/28

Signed-off-by: Lance Albertson <lance@osuosl.org>
