### PR TITLE
avoid uninitialized constant

### DIFF
--- a/lib/kitchen/loader/yaml.rb
+++ b/lib/kitchen/loader/yaml.rb
@@ -17,6 +17,7 @@
 
 require "erb" unless defined?(Erb)
 require_relative "../../vendor/hash_recursive_merge"
+require "psych" unless defined?(Psych)
 require "yaml" unless defined?(YAML)
 
 module Kitchen


### PR DESCRIPTION
"uninitialized constant Kitchen::Loader::YAML::Psych" can occur without this line.

# Description

I use a Kitchen::Loader::YAML object in some custom orchestration of my test-kitchen usage. When upgrading from test-kitchen 2.6.0 to 2.9.0, I suddenly started getting an error about the uninitialized constant.

I can resolve the error by either adding `require 'psych'` to my own Rakefile or via this change.

Unfortunately, my efforts to reproduce this with some tiny test case have been frustratingly elusive. Admittedly, I didn't spend much time trying, and I can only hope that the change is sufficiently self-evident.

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
