### PR TITLE
Require Ruby 2.5 or later

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 ---
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
 Naming/FileName:
   Exclude:
     - 'support/**/*'

--- a/lib/kitchen/transport/ssh.rb
+++ b/lib/kitchen/transport/ssh.rb
@@ -195,18 +195,16 @@ module Kitchen
           FileUtils.mkdir_p(File.dirname(local))
 
           Array(remotes).each do |file|
+            logger.debug("Attempting to download '#{file}' as file")
+            session.scp.download!(file, local)
+          rescue Net::SCP::Error
             begin
-              logger.debug("Attempting to download '#{file}' as file")
-              session.scp.download!(file, local)
+              logger.debug("Attempting to download '#{file}' as directory")
+              session.scp.download!(file, local, recursive: true)
             rescue Net::SCP::Error
-              begin
-                logger.debug("Attempting to download '#{file}' as directory")
-                session.scp.download!(file, local, recursive: true)
-              rescue Net::SCP::Error
-                logger.warn(
-                  "SCP download failed for file or directory '#{file}', perhaps it does not exist?"
-                )
-              end
+              logger.warn(
+                "SCP download failed for file or directory '#{file}', perhaps it does not exist?"
+              )
             end
           end
         rescue Net::SSH::Exception => ex

--- a/spec/kitchen/errors_spec.rb
+++ b/spec/kitchen/errors_spec.rb
@@ -50,30 +50,26 @@ describe Kitchen::Error do
     end
 
     it "returns an array containing the exception's backtrace" do
-      begin
-        raise Kitchen::StandardError, "shoot"
-      rescue => e
-        Kitchen::Error.formatted_trace(e)[5...-1].must_equal e.backtrace
-      end
+      raise Kitchen::StandardError, "shoot"
+    rescue => e
+      Kitchen::Error.formatted_trace(e)[5...-1].must_equal e.backtrace
     end
 
     it "returns an array containing a nested exception, if given" do
-      begin
-        raise IOError, "no disk, yo"
-      rescue
-        e = Kitchen::StandardError.new("shoot")
+      raise IOError, "no disk, yo"
+    rescue
+      e = Kitchen::StandardError.new("shoot")
 
-        Kitchen::Error.formatted_trace(e).must_equal([
-                                                       "------Exception-------",
-                                                       "Class: Kitchen::StandardError",
-                                                       "Message: shoot",
-                                                       "----------------------",
-                                                       "---Nested Exception---",
-                                                       "Class: IOError",
-                                                       "Message: no disk, yo",
-                                                       "----------------------",
-                                                     ])
-      end
+      Kitchen::Error.formatted_trace(e).must_equal([
+                                                     "------Exception-------",
+                                                     "Class: Kitchen::StandardError",
+                                                     "Message: shoot",
+                                                     "----------------------",
+                                                     "---Nested Exception---",
+                                                     "Class: IOError",
+                                                     "Message: no disk, yo",
+                                                     "----------------------",
+                                                   ])
     end
 
     it "returns an array when an error has more than one error in original" do
@@ -105,13 +101,12 @@ describe Kitchen::StandardError do
   end
 
   it "by default, sets original exception to the last raised exception" do
-    begin
-      raise IOError, "crap"
-    rescue
-      original = Kitchen::StandardError.new("oops").original
-      original.must_be_kind_of IOError
-      original.message.must_equal "crap"
-    end
+    raise IOError, "crap"
+  rescue
+    original = Kitchen::StandardError.new("oops").original
+    original.must_be_kind_of IOError
+    original.message.must_equal "crap"
+
   end
 
   it "can embed an exception when constructing" do
@@ -162,20 +157,16 @@ describe Kitchen do
     describe "for instance failures" do
       def go_boom
         Kitchen.with_friendly_errors do
-          begin
-            raise IOError, "no stuff"
-          rescue
-            raise Kitchen::InstanceFailure, "cannot do that"
-          end
+          raise IOError, "no stuff"
+        rescue
+          raise Kitchen::InstanceFailure, "cannot do that"
         end
       end
 
       it "exits with 10" do
-        begin
-          go_boom
-        rescue SystemExit => e
-          e.status.must_equal 10
-        end
+        go_boom
+      rescue SystemExit => e
+        e.status.must_equal 10
       end
 
       it "prints a message on STDERR" do
@@ -212,11 +203,11 @@ describe Kitchen do
       end
 
       it "logs the exception message on the common logger's error severity" do
-        begin
-          go_boom
-        rescue SystemExit
-          logger_io.string.must_match(/ERROR -- Kitchen: cannot do that$/)
-        end
+
+        go_boom
+      rescue SystemExit
+        logger_io.string.must_match(/ERROR -- Kitchen: cannot do that$/)
+
       end
 
       it "logs the exception message on debug, if set" do
@@ -233,20 +224,16 @@ describe Kitchen do
     describe "for unexpected failures" do
       def go_boom
         Kitchen.with_friendly_errors do
-          begin
-            raise IOError, "wtf?"
-          rescue
-            raise Kitchen::StandardError, "ah crap"
-          end
+          raise IOError, "wtf?"
+        rescue
+          raise Kitchen::StandardError, "ah crap"
         end
       end
 
       it "exits with 20" do
-        begin
-          go_boom
-        rescue SystemExit => e
-          e.status.must_equal 20
-        end
+        go_boom
+      rescue SystemExit => e
+        e.status.must_equal 20
       end
 
       it "prints a message on STDERR" do
@@ -285,16 +272,14 @@ describe Kitchen do
       end
 
       it "logs the exception message on the common logger's error severity" do
-        begin
-          go_boom
-        rescue SystemExit
-          logger_io.string
-            .must_match(/ERROR -- Kitchen: ------Exception-------$/)
-          logger_io.string
-            .must_match(/ERROR -- Kitchen: Class: Kitchen::StandardError$/)
-          logger_io.string
-            .must_match(/ERROR -- Kitchen: ------Backtrace-------$/)
-        end
+        go_boom
+      rescue SystemExit
+        logger_io.string
+          .must_match(/ERROR -- Kitchen: ------Exception-------$/)
+        logger_io.string
+          .must_match(/ERROR -- Kitchen: Class: Kitchen::StandardError$/)
+        logger_io.string
+          .must_match(/ERROR -- Kitchen: ------Backtrace-------$/)
       end
 
       it "logs the exception message on debug, if set" do

--- a/spec/kitchen/instance_spec.rb
+++ b/spec/kitchen/instance_spec.rb
@@ -973,13 +973,11 @@ describe Kitchen::Instance do
         end
 
         it "populates the InstanceFailure message" do
-          begin
-            instance.public_send(action)
-          rescue Kitchen::Error => e
-            e.message.must_match regex_for(
-              "Create failed on instance #{instance.to_str}"
-            )
-          end
+          instance.public_send(action)
+        rescue Kitchen::Error => e
+          e.message.must_match regex_for(
+            "Create failed on instance #{instance.to_str}"
+          )
         end
 
         it "logs the failure" do
@@ -1016,13 +1014,11 @@ describe Kitchen::Instance do
         end
 
         it "populates the ActionFailed message" do
-          begin
-            instance.public_send(action)
-          rescue Kitchen::Error => e
-            e.message.must_match regex_for(
-              "Failed to complete #create action: [watwat]"
-            )
-          end
+          instance.public_send(action)
+        rescue Kitchen::Error => e
+          e.message.must_match regex_for(
+            "Failed to complete #create action: [watwat]"
+          )
         end
 
         it "logs the failure" do

--- a/spec/kitchen/provisioner/base_spec.rb
+++ b/spec/kitchen/provisioner/base_spec.rb
@@ -261,10 +261,8 @@ describe Kitchen::Provisioner::Base do
 
   describe "sandbox" do
     after do
-      begin
-        provisioner.cleanup_sandbox
-      rescue # rubocop:disable Lint/HandleExceptions
-      end
+      provisioner.cleanup_sandbox
+    rescue # rubocop:disable Lint/HandleExceptions
     end
 
     it "raises ClientError if #sandbox_path is called before #create_sandbox" do

--- a/spec/kitchen/transport/ssh_spec.rb
+++ b/spec/kitchen/transport/ssh_spec.rb
@@ -920,11 +920,9 @@ describe Kitchen::Transport::Ssh::Connection do
       end
 
       it "returns the exit code with an SshFailed exception" do
-        begin
-          assert_scripted { connection.execute("doit") }
-        rescue Kitchen::Transport::SshFailed => e
-          e.exit_code.must_equal 42
-        end
+        assert_scripted { connection.execute("doit") }
+      rescue Kitchen::Transport::SshFailed => e
+        e.exit_code.must_equal 42
       end
     end
 

--- a/spec/kitchen/transport/winrm_spec.rb
+++ b/spec/kitchen/transport/winrm_spec.rb
@@ -944,11 +944,9 @@ describe Kitchen::Transport::Winrm::Connection do
         end
 
         it "raises WinrmFailed exception with the exit code of the failure" do
-          begin
-            connection.execute("doit")
-          rescue Kitchen::Transport::WinrmFailed => e
-            e.exit_code.must_equal 1
-          end
+          connection.execute("doit")
+        rescue Kitchen::Transport::WinrmFailed => e
+          e.exit_code.must_equal 1
         end
       end
     end

--- a/spec/kitchen/verifier/base_spec.rb
+++ b/spec/kitchen/verifier/base_spec.rb
@@ -269,10 +269,8 @@ describe Kitchen::Verifier::Base do
 
   describe "sandbox" do
     after do
-      begin
-        verifier.cleanup_sandbox
-      rescue # rubocop:disable Lint/HandleExceptions
-      end
+      verifier.cleanup_sandbox
+    rescue # rubocop:disable Lint/HandleExceptions
     end
 
     it "raises ClientError if #sandbox_path is called before #create_sandbox" do

--- a/test-kitchen.gemspec
+++ b/test-kitchen.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.executables   = %w{kitchen}
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.4"
+  gem.required_ruby_version = ">= 2.5"
 
   gem.add_dependency "mixlib-shellout",    ">= 1.2", "< 4.0"
   gem.add_dependency "net-scp",            ">= 1.1", "< 4.0" # pinning until we can confirm 4+ works


### PR DESCRIPTION
Drop support for EOL Ruby 2.4.

Signed-off-by: Tim Smith <tsmith@chef.io>