### PR TITLE
Remove the ohai symbol check

### DIFF
--- a/lib/kitchen/which.rb
+++ b/lib/kitchen/which.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 require "chef-utils/dsl/which" unless defined?(ChefUtils::DSL::Which)
-require_relative "chef_utils_wiring" unless defined?(Ohai::Mixin::ChefUtilsWiring)
+require_relative "chef_utils_wiring" unless defined?(Kitchen::ChefUtilsWiring)
 
 module Kitchen
   module Which


### PR DESCRIPTION
This was a bit of a mistake.  Chef-cli testing was useful and
found it.
