### PR TITLE
Dup the strings before concatting them in the logger

### DIFF
--- a/lib/kitchen/logger.rb
+++ b/lib/kitchen/logger.rb
@@ -293,11 +293,11 @@ module Kitchen
       logger = StdoutLogger.new(stdout)
       if colorize
         logger.formatter = proc do |_severity, _datetime, _progname, msg|
-          Color.colorize(msg.to_s, color).concat("\n")
+          Color.colorize(msg.dup.to_s, color).concat("\n")
         end
       else
         logger.formatter = proc do |_severity, _datetime, _progname, msg|
-          msg.concat("\n")
+          msg.dup.concat("\n")
         end
       end
       logger


### PR DESCRIPTION
Avoid frozen string errors here

```
irb(main):002:0> "some string".freeze.concat("\n")
Traceback (most recent call last):
        5: from /usr/local/opt/ruby@2.7/bin/irb:23:in `<main>'
        4: from /usr/local/opt/ruby@2.7/bin/irb:23:in `load'
        3: from /usr/local/Cellar/ruby@2.7/2.7.2/lib/ruby/gems/2.7.0/gems/irb-1.2.6/exe/irb:11:in `<top (required)>'
        2: from (irb):2
        1: from (irb):2:in `concat'
FrozenError (can't modify frozen String: "some string")
irb(main):003:0> "some string".freeze.dup.concat("\n")
=> "some string\n"
```

Signed-off-by: Tim Smith <tsmith@chef.io>