### PR TITLE
Upgrade usage of deprecated minitest global assertions in unit tests that capture stderr output

### DIFF
--- a/spec/kitchen/errors_spec.rb
+++ b/spec/kitchen/errors_spec.rb
@@ -181,7 +181,7 @@ describe Kitchen do
         begin
           go_boom
         rescue SystemExit
-          $stderr.string.must_equal output
+          _($stderr.string).must_equal output
         end
       end
 
@@ -198,7 +198,7 @@ describe Kitchen do
         begin
           go_boom
         rescue SystemExit
-          $stderr.string.must_equal output
+          _($stderr.string).must_equal output
         end
       end
 
@@ -249,7 +249,7 @@ describe Kitchen do
         begin
           go_boom
         rescue SystemExit
-          $stderr.string.must_equal output
+          _($stderr.string).must_equal output
         end
       end
 
@@ -267,7 +267,7 @@ describe Kitchen do
         begin
           go_boom
         rescue SystemExit
-          $stderr.string.must_equal output
+          _($stderr.string).must_equal output
         end
       end
 


### PR DESCRIPTION
# Description

This is a small changeset which applies to a subset of unit tests that both:

- Use `minitest` global asserts
- Have expectations that use the output written to stderr during the test

These are affected by #1733.

## Issues Resolved

Resolves #1733 - albeit perhaps as a minimal / incomplete migration.

## Check List

- [x] All tests pass. See TESTING.md for details.
- [ ] ~~New functionality includes testing.~~
- [ ] ~~New functionality has been documented in the README if applicable.~~