### PR TITLE
Follow renaming of pry library's history array that applies from version 0.12 onwards

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ group :integration do
 end
 
 group :debug do
-  gem "pry"
+  gem "pry", "~>0.12"
   gem "pry-byebug"
   gem "pry-stack_explorer"
 end

--- a/lib/kitchen/command/console.rb
+++ b/lib/kitchen/command/console.rb
@@ -43,7 +43,7 @@ module Kitchen
       def prompt(char)
         proc do |target_self, nest_level, pry|
           [
-            "[#{pry.input_array.size}] ",
+            "[#{pry.input_ring.size}] ",
             "kc(#{Pry.view_clip(target_self.class)})",
             "#{":#{nest_level}" unless nest_level == 0}#{char} ",
           ].join


### PR DESCRIPTION
# Description

This change follows a breaking change in `pry` version 0.12 that renamed a history array variable.

## Issues Resolved

Resolves #1737.

## Check List

- [x] All tests pass. See TESTING.md for details.
- [ ] ~~New functionality includes testing.~~
- [ ] ~~New functionality has been documented in the README if applicable.~~
