### PR TITLE
Add a new `slow_resource_report` config for Chef Infra Client 17.2

### DIFF
--- a/lib/kitchen/provisioner/chef_zero.rb
+++ b/lib/kitchen/provisioner/chef_zero.rb
@@ -70,6 +70,7 @@ module Kitchen
           json = remote_path_join(config[:root_path], "dna.json")
           args << "--json-attributes #{json}"
         end
+
         args << "--logfile #{config[:log_file]}" if config[:log_file]
 
         # these flags are chef-client local mode only and will not work
@@ -77,10 +78,20 @@ module Kitchen
         if config[:chef_zero_host]
           args << "--chef-zero-host #{config[:chef_zero_host]}"
         end
+
         if config[:chef_zero_port]
           args << "--chef-zero-port #{config[:chef_zero_port]}"
         end
+
         args << "--profile-ruby" if config[:profile_ruby]
+
+        if config[:slow_resource_report]
+          if config[:slow_resource_report].is_a?(Integer)
+            args << "--slow-report #{config[:slow_resource_report]}"
+          else
+            args << "--slow-report"
+          end
+        end
       end
       # rubocop:enable Metrics/CyclomaticComplexity
 

--- a/spec/kitchen/provisioner/chef_zero_spec.rb
+++ b/spec/kitchen/provisioner/chef_zero_spec.rb
@@ -472,6 +472,22 @@ describe Kitchen::Provisioner::ChefZero do
 
           cmd.wont_match regexify(" --profile-ruby", :partial_line)
         end
+
+        it "sets slow_resource_report flag when config element is set" do
+          config[:slow_resource_report] = true
+
+          cmd.must_match regexify(
+            " --slow-report", :partial_line
+          )
+        end
+
+        it "sets slow_resource_report flag when config element is set with an integer value" do
+          config[:slow_resource_report] = 1
+
+          cmd.must_match regexify(
+            " --slow-report 1", :partial_line
+          )
+        end
       end
       # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 


### PR DESCRIPTION
This allows you to test for the slowest resources in your cookbooks with
Chef Infra Client 17.2 or later

Signed-off-by: Tim Smith <tsmith@chef.io>