### PR TITLE
Set always_update_cookbooks to true for Policyfiles/Berkshelf

### DIFF
--- a/lib/kitchen/provisioner/chef/policyfile.rb
+++ b/lib/kitchen/provisioner/chef/policyfile.rb
@@ -41,7 +41,7 @@ module Kitchen
         #   cookbooks
         # @param logger [Kitchen::Logger] a logger to use for output, defaults
         #   to `Kitchen.logger`
-        def initialize(policyfile, path, logger: Kitchen.logger, always_update: false)
+        def initialize(policyfile, path, logger: Kitchen.logger, always_update: true)
           @policyfile    = policyfile
           @path          = path
           @logger        = logger

--- a/lib/kitchen/provisioner/chef/policyfile.rb
+++ b/lib/kitchen/provisioner/chef/policyfile.rb
@@ -41,7 +41,7 @@ module Kitchen
         #   cookbooks
         # @param logger [Kitchen::Logger] a logger to use for output, defaults
         #   to `Kitchen.logger`
-        def initialize(policyfile, path, logger: Kitchen.logger, always_update: true)
+        def initialize(policyfile, path, logger: Kitchen.logger, always_update: false)
           @policyfile    = policyfile
           @path          = path
           @logger        = logger

--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -63,7 +63,7 @@ module Kitchen
       default_config :berksfile_path, nil
       # If set to true (which is the default from `chef generate`), try to update
       # backend cookbook downloader on every kitchen run.
-      default_config :always_update_cookbooks, false
+      default_config :always_update_cookbooks, true
       default_config :cookbook_files_glob, %w(
         README.* VERSION metadata.{json,rb} attributes.rb recipe.rb
         attributes/**/* definitions/**/* files/**/* libraries/**/*


### PR DESCRIPTION
# Description

Without this the user doesn't get their updated cookbooks transferred to
the box.
The user shouldn't need to set this.

## Issues Resolved

n/a

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
