### PR TITLE
Improved error message on false ami_id

### DIFF
--- a/lib/kitchen/instance.rb
+++ b/lib/kitchen/instance.rb
@@ -536,7 +536,7 @@ module Kitchen
       log_failure(what, e)
       state[:last_error] = e.class.name
       raise ActionFailed,
-      "Failed to complete ##{what} action: [#{e.message} in the specified region #{self.driver.config[:region]}. Please check this AMI is available in this region.]", e.backtrace
+        "Failed to complete ##{what} action: [#{e.message} in the specified region #{self.driver.config[:region]}. Please check this AMI is available in this region.]", e.backtrace
     ensure
       state_file.write(state)
     end

--- a/lib/kitchen/instance.rb
+++ b/lib/kitchen/instance.rb
@@ -536,7 +536,7 @@ module Kitchen
       log_failure(what, e)
       state[:last_error] = e.class.name
       raise ActionFailed,
-        "Failed to complete ##{what} action: [#{e.message}]", e.backtrace
+      "Failed to complete ##{what} action: [#{e.message} in the specified region #{self.driver.config[:region]}. Please check this AMI is available in this region.]", e.backtrace
     ensure
       state_file.write(state)
     end


### PR DESCRIPTION
Signed-off-by: Nikhil Gupta <nikhilgupta2102@gmail.com>

# Description
Improved the message when a bogus/invalid ami_id is passed.


## Issues Resolved

Fixes [https://github.com/test-kitchen/kitchen-ec2/issues/230](url)

