### PR TITLE
Use not @tag instead of ~@tag to ignore Cucumber tags

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -6,7 +6,7 @@ end
 
 def cucumber_opts
   cucumber_cli = "--no-profile --color --format progress --strict"
-  cucumber_cli += " --tags ~@spawn" if RUBY_PLATFORM.match?(/mswin|mingw|windows/)
+  cucumber_cli += " --tags not @spawn" if RUBY_PLATFORM.match?(/mswin|mingw|windows/)
 
   { all_on_start: false, cli: cucumber_cli }
 end

--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,7 @@ begin
   require "cucumber"
   require "cucumber/rake/task"
   Cucumber::Rake::Task.new(:features) do |t|
-    t.cucumber_opts = ["features", "-x", "--format progress", "--no-color", "--tags ~@ignore"]
+    t.cucumber_opts = ["features", "-x", "--format progress", "--no-color", "--tags 'not @ignore'"]
   end
 rescue LoadError
   puts "cucumber is not available. (sudo) gem install cucumber to run tests."


### PR DESCRIPTION
Use not @tag instead of ~@tag to ignore Cucumber tags
Resolves #1773

Signed-off-by: Dan Webb <dan.webb@damacus.io>


