### PR TITLE
[1777] Fix Aruba depreaction warnings

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,7 +1,7 @@
 # Set up the environment for testing
 require "aruba/cucumber"
-require "aruba/in_process"
-require "aruba/spawn_process"
+require "aruba/processes/in_process"
+require "aruba/processes/spawn_process"
 require "kitchen"
 require "kitchen/cli"
 


### PR DESCRIPTION
Require the correct aruba libraries

Resolves #1777
