### PR TITLE
Allow overriding the `local` policy_group

### DIFF
--- a/lib/kitchen/data_munger.rb
+++ b/lib/kitchen/data_munger.rb
@@ -720,12 +720,14 @@ module Kitchen
         move_data_to!(:provisioner, suite, :attributes)
         move_data_to!(:provisioner, suite, :run_list)
         move_data_to!(:provisioner, suite, :named_run_list)
+        move_data_to!(:provisioner, suite, :policy_group)
       end
 
       data.fetch(:platforms, []).each do |platform|
         move_data_to!(:provisioner, platform, :attributes)
         move_data_to!(:provisioner, platform, :run_list)
         move_data_to!(:provisioner, platform, :named_run_list)
+        move_data_to!(:provisioner, platform, :policy_group)
       end
     end
 

--- a/lib/kitchen/provisioner/chef/policyfile.rb
+++ b/lib/kitchen/provisioner/chef/policyfile.rb
@@ -41,11 +41,12 @@ module Kitchen
         #   cookbooks
         # @param logger [Kitchen::Logger] a logger to use for output, defaults
         #   to `Kitchen.logger`
-        def initialize(policyfile, path, logger: Kitchen.logger, always_update: false)
+        def initialize(policyfile, path, logger: Kitchen.logger, always_update: false, policy_group: nil)
           @policyfile    = policyfile
           @path          = path
           @logger        = logger
           @always_update = always_update
+          @policy_group  = policy_group
         end
 
         # Loads the library code required to use the resolver.
@@ -59,8 +60,13 @@ module Kitchen
         # Performs the cookbook resolution and vendors the resulting cookbooks
         # in the desired path.
         def resolve
-          info("Exporting cookbook dependencies from Policyfile #{path} using `#{cli_path} export`...")
-          run_command("#{cli_path} export #{escape_path(policyfile)} #{escape_path(path)} --force")
+          if policy_group
+            info("Exporting cookbook dependencies from Policyfile #{path} with policy_group #{policy_group} using `#{cli_path} export`...")
+            run_command("#{cli_path} export #{escape_path(policyfile)} #{escape_path(path)} --policy_group #{policy_group} --force")
+          else
+            info("Exporting cookbook dependencies from Policyfile #{path} using `#{cli_path} export`...")
+            run_command("#{cli_path} export #{escape_path(policyfile)} #{escape_path(path)} --force")
+          end
         end
 
         # Runs `chef install` to determine the correct cookbook set and
@@ -103,6 +109,10 @@ module Kitchen
         # @return [Boolean] If true, always update cookbooks in the policy.
         # @api private
         attr_reader :always_update
+
+        # @return [String] name of the policy_group, nil results in "local"
+        # @api private
+        attr_reader :policy_group
 
         # Escape spaces in a path in way that works with both Sh (Unix) and
         # Windows.

--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -46,6 +46,7 @@ module Kitchen
       default_config :chef_omnibus_install_options, nil
       default_config :chef_license, nil
       default_config :run_list, []
+      default_config :policy_group, nil
       default_config :attributes, {}
       default_config :config_path, nil
       default_config :log_file, nil


### PR DESCRIPTION
Looks like this:

```
suites:
  - name: default
    policy_group: production
    run_list:
      - recipe[base]
```

Requires support from chef-cli export that has not yet been merged:

https://github.com/chef/chef-cli/pull/176