### PR TITLE
Start the slow migration to chef_infra provisioner

### DIFF
--- a/docs/content/docs/provisioners/chef.md
+++ b/docs/content/docs/provisioners/chef.md
@@ -7,7 +7,7 @@ menu:
     weight: 5
 ---
 
-Test Kitchen includes two provisioners for Chef Infra, `chef_solo` and `chef_zero`, which support nearly identical options. Note: In Test Kitchen 3.0 and later the `chef_zero` provisioner has been renamed to `chef_infra` for improved clarity. You may use either name going forward, but older releases of Test Kitchen will still need to use `chef_zero`.
+Test Kitchen includes two provisioners for Chef Infra, `chef_solo` and `chef_infra`, that support similar options.  `chef_zero` was renamed `chef_infra` in Test Kitchen 3.0. This change is backward-compatible, and both names work starting with Test Kitchen 3.0. In older releases, you will need to use `chef_zero`.
 
 ```
 ---

--- a/docs/content/docs/provisioners/chef.md
+++ b/docs/content/docs/provisioners/chef.md
@@ -7,7 +7,7 @@ menu:
     weight: 5
 ---
 
-Test Kitchen includes two provisioners for Chef Infra, `chef_solo` and `chef_zero`, which support nearly identical options.
+Test Kitchen includes two provisioners for Chef Infra, `chef_solo` and `chef_zero`, which support nearly identical options. Note: In Test Kitchen 3.0 and later the `chef_zero` provisioner has been renamed to `chef_infra` for improved clarity. You may use either name going forward, but older releases of Test Kitchen will still need to use `chef_zero`.
 
 ```
 ---

--- a/kitchen.linux-product.yml
+++ b/kitchen.linux-product.yml
@@ -8,7 +8,7 @@ driver:
   password: <%= ENV["MACHINE_PASS"] %>
 
 provisioner:
-  name: chef_zero
+  name: chef_infra
   # Using product_name exercises a different code path in the chef client installer
   product_name: chef
   chef_license: accept-no-persist

--- a/kitchen.proxy.yml
+++ b/kitchen.proxy.yml
@@ -8,7 +8,7 @@ driver:
   password: <%= ENV["MACHINE_PASS"] %>
 
 provisioner:
-  name: chef_zero
+  name: chef_infra
   chef_license: accept-no-persist
 
 platforms:

--- a/kitchen.windows-product.yml
+++ b/kitchen.windows-product.yml
@@ -8,7 +8,7 @@ driver:
   password: <%= ENV["machine_pass"] %>
 
 provisioner:
-  name: chef_zero
+  name: chef_infra
   # Using product_name exercises a different code path in the chef client installer
   product_name: chef
   chef_license: accept-no-persist

--- a/kitchen.windows.yml
+++ b/kitchen.windows.yml
@@ -8,7 +8,7 @@ driver:
   password: <%= ENV["machine_pass"] %>
 
 provisioner:
-  name: chef_zero
+  name: chef_infra
   chef_license: accept-no-persist
 
 platforms:


### PR DESCRIPTION
We need to make sure Workstation releases in the wild can support this before we cutover docs and generators, but step 1 is at least calling out the new name in docs.

Signed-off-by: Tim Smith <tsmith@chef.io>4