### PR TITLE
Update Kitchen -> Test Kitchen in the docs

### DIFF
--- a/docs/content/docs/reference/configuration.md
+++ b/docs/content/docs/reference/configuration.md
@@ -6,12 +6,12 @@ menu:
     weight: 5
 ---
 
-There are a few basic ways of dynamically configuring Kitchen:
+There are a few basic ways of dynamically configuring Test Kitchen:
 
 * A local configuration will be looked for in `kitchen.local.yml` which could be used for development purposes. This is a file that is not typically checked into version control.
 * A global configuration file will also be looked for in `$HOME/.kitchen/config.yml` to set preferred defaults for all your projects.
 * Each YAML file can contain ERB fragments, which you could use for selecting drivers, etc. based on which platform you're currently running, or based off environment variables.
-* Finally, Kitchen also has several environment variables where you can set a path to a `kitchen.yml` or `$HOME/.kitchen/config.yml` file. This can be useful if you wish to use Kitchen with a continuous integration (CI) system.
+* Finally, Test Kitchen also has several environment variables where you can set a path to a `kitchen.yml` or `$HOME/.kitchen/config.yml` file. This can be useful if you wish to use Test Kitchen with a continuous integration (CI) system.
 
 To specify a path to a global `config.yml`, project or local `kitchen.yml` file, set the following environment variables:
 
@@ -21,7 +21,7 @@ export KITCHEN_YAML=/path/to/your/project/kitchen.yml
 export KITCHEN_LOCAL_YAML=/path/to/your/local/kitchen.local.yml
 ~~~
 
-**Note:** If `$HOME/.kitchen/config.yml` is present, kitchen will merge this file with your project's `kitchen.yml`, and/or `kitchen.local.yml` file. Merge precedence is:
+**Note:** If `$HOME/.kitchen/config.yml` is present, Test Kitchen will merge this file with your project's `kitchen.yml`, and/or `kitchen.local.yml` file. Merge precedence is:
 
 1. `kitchen.local.yml`
 2. `kitchen.yml`
@@ -43,7 +43,7 @@ driver:
 Keep in mind, this assumes you have an OpenStack deployment setup and ready to use. This is only an example so to illustrate using environment variables via ERB snippets in the configuration file.
 
 Another handy use of the ERB fragments is to dynamically override the log_level of
-the provisioner. Since Kitchen 1.7.0 the log level for the provisioner is now independent of the Kitchen log level. Using the following snippet, allows the environment to override the provisioner log level without modifying the config file.:
+the provisioner. Since Test Kitchen 1.7.0 the log level for the provisioner is now independent of the Test Kitchen log level. Using the following snippet, allows the environment to override the provisioner log level without modifying the config file.:
 
 ~~~
 ---

--- a/docs/content/docs/reference/faq.md
+++ b/docs/content/docs/reference/faq.md
@@ -47,7 +47,7 @@ transport:
 
 ##### I need to set up a cache or proxy using Vagrant, what are some options for me?
 
-So there are a few things that already exist that sort of cover this in the kitchen world:
+So there are a few things that already exist that sort of cover this in the Test Kitchen world:
 
 - the host ENV vars for proxies are automatically passed to instances
 - Example of using [polipo](https://gist.github.com/fnichol/7551540) locally

--- a/docs/content/docs/reference/glossary.md
+++ b/docs/content/docs/reference/glossary.md
@@ -6,7 +6,7 @@ menu:
     weight: 25
 ---
 
-Berksfile 
+Berksfile
 : the file `berks` loads to determine sources and dependencies
 
 Berkshelf
@@ -16,7 +16,7 @@ hypervisor
 : a piece of software that allows one to create and run virtual machines
 
 regular expression
-: a "a sequence of characters that define a search pattern", in the context of kitchen we allow a user to specify instances with regular expressions like `^default-ubuntu`
+: a "a sequence of characters that define a search pattern", in the context of Test Kitchen we allow a user to specify instances with regular expressions like `^default-ubuntu`
 
 Vagrant
 : a piece of software that makes abstracts away hypervisor details to provide a consistent experience and interface to virtual machines


### PR DESCRIPTION
Historically we've had way to many names for Test Kitchen. Use the full
name to avoid confusion.

Signed-off-by: Tim Smith <tsmith@chef.io>