### PR TITLE
fix progress reporting in ssh transport

### DIFF
--- a/lib/kitchen/transport/ssh.rb
+++ b/lib/kitchen/transport/ssh.rb
@@ -176,9 +176,11 @@ module Kitchen
             Array(locals).map do |local|
               opts = File.directory?(local) ? { recursive: true } : {}
 
-              waits.push session.scp.upload(local, remote, opts) do |_ch, name, sent, total|
-                logger.debug("Async Uploaded #{name} (#{total} bytes)") if sent == total
-              end
+              waits.push(
+                session.scp.upload(local, remote, opts) do |_ch, name, sent, total|
+                  logger.debug("Async Uploaded #{name} (#{total} bytes)") if sent == total
+                end
+              )
               waits.shift.wait while waits.length >= max_ssh_sessions
             end
             waits.each(&:wait)

--- a/spec/kitchen/transport/ssh_spec.rb
+++ b/spec/kitchen/transport/ssh_spec.rb
@@ -1068,6 +1068,16 @@ describe Kitchen::Transport::Ssh::Connection do
           connection.upload(src.path, "/tmp/remote")
         end
       end
+
+      it "logger reports uploaded file on debug" do
+        assert_scripted do
+          connection.upload(src.path, "/tmp/remote")
+        end
+
+        logged_output.string.lines.count do |l|
+          l =~ debug_line("Async Uploaded #{src.path} (#{content.length} bytes)")
+        end.must_equal 1
+      end
     end
 
     describe "for a path" do
@@ -1125,6 +1135,16 @@ describe Kitchen::Transport::Ssh::Connection do
         with_sorted_dir_entries do
           assert_scripted { connection.upload(@dir, "/tmp/remote") }
         end
+      end
+
+      it "logger reports three uploaded files on debug" do
+        with_sorted_dir_entries do
+          assert_scripted { connection.upload(@dir, "/tmp/remote") }
+        end
+
+        logged_output.string.lines.count do |l|
+          l =~ debug_line_with("Async Uploaded ")
+        end.must_equal 3
       end
     end
 


### PR DESCRIPTION
Signed-off-by: Doug Knight <doug.knight@karmix.org>

# Description

Add some tests and make a trivial fix:

Uploaded files are not being logged in debug output as intended.  It's pretty obvious in this case that the author meant to pass a code block to `session.scp.upload` instead of `waits.push`.

## Issues Resolved

_This only corrects info in debug logs; no issue created, see description._

## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [ ] ~~New functionality has been documented in the README if applicable.~~ (_N/A: Bug Fix._)
