### PR TITLE
Remove support for Ruby 2.5

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['2.5', '2.6', '2.7', '3.0']
+        ruby: ['2.6', '2.7', '3.0']
     name: Chefstyle on Ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['2.5', '2.6', '2.7', '3.0']
+        ruby: ['2.6', '2.7', '3.0']
     name: Unit test on Ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@v2

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 ---
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.6
 Naming/FileName:
   Exclude:
     - 'support/**/*'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,12 +22,6 @@ stages:
       - job: Windows
         strategy:
           matrix:
-            Windows_Ruby25:
-              version: 2.5
-              machine_user: test_user
-              machine_pass: Pass@word1
-              machine_port: 5985
-              KITCHEN_YAML: kitchen.windows.yml
             Windows_Ruby26:
               version: 2.6
               machine_user: test_user
@@ -87,8 +81,6 @@ stages:
       - job: Mac
         strategy:
           matrix:
-            Mac_Ruby25:
-              version: 2.5
             Mac_Ruby26:
               version: 2.6
             Mac_Ruby27:
@@ -128,8 +120,6 @@ stages:
       - job: Linux
         strategy:
           matrix:
-            Linux_Ruby25:
-              version: 2.5
             Linux_Ruby26:
               version: 2.6
             Linux_Ruby27:

--- a/test-kitchen.gemspec
+++ b/test-kitchen.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.executables   = %w{kitchen}
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.5"
+  gem.required_ruby_version = ">= 2.6"
 
   gem.add_dependency "mixlib-shellout",    ">= 1.2", "< 4.0"
   gem.add_dependency "net-scp",            ">= 1.1", "< 4.0" # pinning until we can confirm 4+ works


### PR DESCRIPTION
It's EOL

Signed-off-by: Tim Smith <tsmith@chef.io>