### PR TITLE
Support InSpec profiles in the cookbook compliance dir

### DIFF
--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -69,7 +69,7 @@ module Kitchen
         README.* VERSION metadata.{json,rb} attributes.rb recipe.rb
         attributes/**/* definitions/**/* files/**/* libraries/**/*
         providers/**/* recipes/**/* resources/**/* templates/**/*
-        ohai/**/*
+        ohai/**/* compliance/**/*
       ).join(",")
       # to ease upgrades, allow the user to turn deprecation warnings into errors
       default_config :deprecations_as_errors, false


### PR DESCRIPTION
I wasn't aware that we limited cookbook files in Test Kitchen and not via what chef-zero can handle.

Signed-off-by: Tim Smith <tsmith@chef.io>