### PR TITLE
Allow to use regexp in includes/excludes to filter platforms

### DIFF
--- a/docs/content/docs/getting-started/17-excluding-platforms.md
+++ b/docs/content/docs/getting-started/17-excluding-platforms.md
@@ -54,6 +54,8 @@ suites:
       - centos-8
 ```
 
+**Note:** in above example the `centos-8` platform is explicitly excluded. You could have use a regexp syntax `/<pattern>/` to exclude any platform matching the given pattern.
+
 Now let's run `kitchen list` to ensure the instance is gone:
 
 ```ruby

--- a/lib/kitchen/lifecycle_hook/base.rb
+++ b/lib/kitchen/lifecycle_hook/base.rb
@@ -1,3 +1,5 @@
+require_relative "../platform_filter"
+
 module Kitchen
   class LifecycleHook
     class Base
@@ -59,14 +61,14 @@ module Kitchen
         lifecycle_hooks.state_file
       end
 
-      # @return [Array<String>] names of excluded platforms
+      # @return [Array<PlatformFilter>] names of excluded platforms
       def excludes
-        @excludes ||= hook.fetch(:excludes, [])
+        @excludes ||= PlatformFilter.convert(hook.fetch(:excludes, []))
       end
 
-      # @return [Array<String>] names of only included platforms
+      # @return [Array<PlatformFilter>] names of only included platforms
       def includes
-        @includes ||= hook.fetch(:includes, [])
+        @includes ||= PlatformFilter.convert(hook.fetch(:includes, []))
       end
 
       # @return [String]

--- a/lib/kitchen/platform_filter.rb
+++ b/lib/kitchen/platform_filter.rb
@@ -1,0 +1,72 @@
+#
+# Author:: Baptiste Courtois (<b.courtois@criteo.com>)
+#
+# Copyright (C) 2021, Baptiste Courtois
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Kitchen
+  # A wrapper on Regexp and strings to mix them in platform filters.
+  #
+  # This should handle backward compatibility in most cases were
+  # platform are matched against a filters array using Array.include?
+  #
+  # This wrapper does not work if filters arrays are converted to Set.
+  #
+  # @author Baptiste Courtois <b.courtois@criteo.com>
+  class PlatformFilter
+    # Pattern used to determine whether a filter should be handled as a Regexp
+    REGEXP_LIKE_PATTERN = %r{^/(?<pattern>.*)/(?<options>[ix]*)$}.freeze
+
+    # Converts platform filters into an array of PlatformFilter handling both strings and Regexp.
+    # A string "looks-like" a regexp if it starts by / and end by / + Regexp options i or x
+    #
+    # @return [Array] filters with regexp-like string converted to PlatformRegexpFilter
+    def self.convert(filters)
+      ::Kernel.Array(filters).map do |filter|
+        if (match = filter.match(REGEXP_LIKE_PATTERN))
+          options = match["options"].include?("i") ? ::Regexp::IGNORECASE : 0
+          options |= ::Regexp::EXTENDED if match["options"].include?("x")
+          filter = ::Regexp.new(match["pattern"], options)
+        end
+        new(filter)
+      end
+    end
+
+    # @return [Regexp] value of this filter
+    attr_reader :value
+
+    # Constructs a new filter.
+    #
+    # @param [Regexp,String] value of the filter
+    def initialize(value)
+      raise ::ArgumentError, "PlatformFilter#new requires value to be a String or a Regexp" unless value.is_a?(::Regexp) || value.is_a?(::String)
+
+      @value = value
+    end
+
+    # Override of the equality operator to check whether the wrapped Regexp match the given object.
+    #
+    # @param [Object] other object to compare to
+    # @return [Boolean] whether the objects are equal or the wrapped Regexp matches the given string or symbol
+    def ==(other)
+      if @value.is_a?(::Regexp) && (other.is_a?(::String) || other.is_a?(::Symbol))
+        @value =~ other
+      else
+        other == @value
+      end
+    end
+
+    alias eq? ==
+  end
+end

--- a/lib/kitchen/suite.rb
+++ b/lib/kitchen/suite.rb
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require_relative "platform_filter"
+
 module Kitchen
   # A logical configuration representing a test case or fixture that will be
   # executed on a platform.
@@ -41,8 +43,8 @@ module Kitchen
       @name = options.fetch(:name) do
         raise ClientError, "Suite#new requires option :name"
       end
-      @excludes = options.fetch(:excludes, [])
-      @includes = options.fetch(:includes, [])
+      @excludes = PlatformFilter.convert(options.fetch(:excludes, []))
+      @includes = PlatformFilter.convert(options.fetch(:includes, []))
     end
   end
 end

--- a/spec/kitchen/config_spec.rb
+++ b/spec/kitchen/config_spec.rb
@@ -406,10 +406,11 @@ describe Kitchen::Config do
       config.stubs(:suites).returns([
                                       stub(name: "selecta", includes: %w{good one}, excludes: []),
                                       stub(name: "allem", includes: [], excludes: []),
+                                      stub(name: "regexp", includes: [Kitchen::PlatformFilter.new(/^good|one$/)], excludes: []),
                                     ])
 
       _(config.instances.as_names).must_equal %w{
-        selecta-good selecta-one allem-good allem-nope allem-one
+        selecta-good selecta-one allem-good allem-nope allem-one regexp-good regexp-one
       }
     end
   end
@@ -424,10 +425,11 @@ describe Kitchen::Config do
       config.stubs(:suites).returns([
                                       stub(name: "selecta", includes: [], excludes: ["nope"]),
                                       stub(name: "allem", includes: [], excludes: []),
+                                      stub(name: "regexp", includes: [], excludes: [Kitchen::PlatformFilter.new(/^nope$/)]),
                                     ])
 
       _(config.instances.as_names).must_equal %w{
-        selecta-good selecta-one allem-good allem-nope allem-one
+        selecta-good selecta-one allem-good allem-nope allem-one regexp-good regexp-one
       }
     end
   end

--- a/spec/kitchen/platform_filter_spec.rb
+++ b/spec/kitchen/platform_filter_spec.rb
@@ -1,0 +1,65 @@
+#
+# Author:: Baptiste Courtois (<b.courtois@criteo.com>)
+#
+# Copyright (C) 2021, Baptiste Courtois
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative "../spec_helper"
+
+require "kitchen/platform_filter"
+
+describe Kitchen::PlatformFilter do
+  describe ".convert" do
+    it "returns an array if a scalar is passed" do
+      Kitchen::PlatformFilter.convert(nil).must_equal []
+      Kitchen::PlatformFilter.convert("string").must_equal [Kitchen::PlatformFilter.new("string")]
+    end
+
+    it "just wraps simple strings" do
+      Kitchen::PlatformFilter.convert(%w{CentOS windows-2016}).must_equal [Kitchen::PlatformFilter.new("CentOS"),
+                                                                           Kitchen::PlatformFilter.new("windows-2016")]
+    end
+
+    it "converts regexp-like strings into Regexp before wraping" do
+      Kitchen::PlatformFilter.convert(%w{/^win/ /win$/}).must_equal [Kitchen::PlatformFilter.new(/^win/),
+                                                                     Kitchen::PlatformFilter.new(/win$/)]
+    end
+
+    it "supports IgnoreCase Regexp option" do
+      Kitchen::PlatformFilter.convert("/win/i").must_equal [Kitchen::PlatformFilter.new(/win/i)]
+    end
+
+    it "supports Extended Regexp option" do
+      Kitchen::PlatformFilter.convert("/win/x").must_equal [Kitchen::PlatformFilter.new(/win/x)]
+    end
+
+    it "supports combination of IgnoreCase & Extended Regexp options" do
+      Kitchen::PlatformFilter.convert(%w{/win/ix /win/xi}).must_equal [Kitchen::PlatformFilter.new(/win/ix),
+                                                                       Kitchen::PlatformFilter.new(/win/ix)]
+    end
+  end
+
+  describe ".new" do
+    it "raises an ArgumentError if value is neither a string nor Regexp" do
+      proc { Kitchen::PlatformFilter.new(Object.new) }.must_raise ::ArgumentError
+    end
+  end
+
+  describe "#value" do
+    it "returns the original value" do
+      Kitchen::PlatformFilter.new("string").value.must_equal "string"
+      Kitchen::PlatformFilter.new(/regexp/).value.must_equal(/regexp/)
+    end
+  end
+end

--- a/spec/kitchen/suite_spec.rb
+++ b/spec/kitchen/suite_spec.rb
@@ -24,8 +24,8 @@ describe Kitchen::Suite do
   let(:opts) do
     {
       name: "suitezy",
-      includes: %w{testbuntu testcent},
-      excludes: %w{prodbuntu},
+      includes: %w{testbuntu /win/},
+      excludes: %w{prodbuntu /darwin/},
     }
   end
 
@@ -40,8 +40,8 @@ describe Kitchen::Suite do
     _ { Kitchen::Suite.new(opts) }.must_raise Kitchen::ClientError
   end
 
-  it "returns the includes" do
-    _(suite.includes).must_equal %w{testbuntu testcent}
+  it "returns the includes as array of PlatformFilter" do
+    _(suite.includes).must_equal [Kitchen::PlatformFilter.new("testbuntu"), Kitchen::PlatformFilter.new(/win/)]
   end
 
   it "returns an empty Array when includes not given" do
@@ -50,7 +50,7 @@ describe Kitchen::Suite do
   end
 
   it "returns the excludes" do
-    _(suite.excludes).must_equal %w{prodbuntu}
+    _(suite.excludes).must_equal [Kitchen::PlatformFilter.new("prodbuntu"), Kitchen::PlatformFilter.new(/darwin/)]
   end
 
   it "returns an empty Array when excludes not given" do


### PR DESCRIPTION
# Description

In some cases you don't want to specify the exact platform name because it might change, or you want to match multiple platforms at once.

Kitchen commands allow to match suites using regexp but suites can't include/exclude platforms using regexp :(
This commit now provides that behavior by parsing the includes/excludes value and converting them into actual Regexp if they look like one.

A filter value is identified as regexp-like if it starts with '/' and ends with '/' or '/i' or '/x' or '/xi'.

So if you want to reduce the risk your suite run on a windows platform you can now use this syntax:

```yaml
suites:
  my_centos_suite:
    excludes:
      - darwin
      - /win/i
```

## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
