### PR TITLE
Moved the kitchen diagnose warnings to stderr

### DIFF
--- a/lib/kitchen/configurable.rb
+++ b/lib/kitchen/configurable.rb
@@ -241,7 +241,7 @@ module Kitchen
           #{deprecated_config.keys.join("\n")}
           Run 'kitchen doctor' for details.
         MSG
-        Error.stderr_warn(warning)
+        Error.warn_on_stderr(warning)
 
         # Set global var that the deprecation message has been printed
         @@has_been_warned_of_deprecations = true

--- a/lib/kitchen/configurable.rb
+++ b/lib/kitchen/configurable.rb
@@ -241,7 +241,7 @@ module Kitchen
           #{deprecated_config.keys.join("\n")}
           Run 'kitchen doctor' for details.
         MSG
-        warn(warning)
+        Error.stderr_warn(warning)
 
         # Set global var that the deprecation message has been printed
         @@has_been_warned_of_deprecations = true

--- a/lib/kitchen/errors.rb
+++ b/lib/kitchen/errors.rb
@@ -96,11 +96,12 @@ module Kitchen
     end
 
     # Log a warn message on STDERR device.
-    # This will help the developer to distinguish between the errors and
-    # output from other commands like diagnose.
+    # This will help to distinguish between the errors and
+    # output when parsing the output from the commands like
+    # kitchen diagnose.
     #
     # @params lines [Array<String>] Array of lines that needs to be printed
-    def self.stderr_warn(lines)
+    def self.warn_on_stderr(lines)
       Array(lines).each do |line|
         line = Color.colorize(line, :blue) if Kitchen.tty?
         $stderr.puts(line)

--- a/lib/kitchen/errors.rb
+++ b/lib/kitchen/errors.rb
@@ -94,6 +94,18 @@ module Kitchen
         "".center(22, "-"),
       ]
     end
+
+    # Log a warn message on STDERR device.
+    # This will help the developer to distinguish between the errors and
+    # output from other commands like diagnose.
+    #
+    # @params lines [Array<String>] Array of lines that needs to be printed
+    def self.stderr_warn(lines)
+      Array(lines).each do |line|
+        line = Color.colorize(line, :blue) if Kitchen.tty?
+        $stderr.puts(line)
+      end
+    end
   end
 
   # Base exception class from which all Kitchen exceptions derive. This class


### PR DESCRIPTION
Signed-off-by: Ashique Saidalavi <ashique.saidalavi@progress.com>

# Description

The deprecation warnings on the `kitchen diagnose` command is causing issues in parsing the YAML output since both the output and the warnings are printing on the `stdout` device. If the output was parsed automatically, these warning messages are causing issues. 

In this PR, these deprecation warning messages will be moved to `stderr` device and the output will be printed on `stdout` which will fix the parsing issues.   

## Issues Resolved
#1693 

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
