### PR TITLE
HashRecursiveMerge: support arrays in recursive merge

### DIFF
--- a/lib/kitchen/loader/yaml.rb
+++ b/lib/kitchen/loader/yaml.rb
@@ -114,11 +114,11 @@ module Kitchen
       # @api private
       def combined_hash
         y = if @process_global
-              normalize(global_yaml).rmerge(normalize(yaml))
+              normalize(global_yaml).rmerge(normalize(yaml), merge_arrays=true)
             else
               normalize(yaml)
             end
-        @process_local ? y.rmerge(normalize(local_yaml)) : y
+        @process_local ? y.rmerge(normalize(local_yaml), merge_arrays=true) : y
       end
 
       # Loads and returns the Kitchen config YAML as a Hash.

--- a/lib/vendor/hash_recursive_merge.rb
+++ b/lib/vendor/hash_recursive_merge.rb
@@ -19,9 +19,10 @@ module HashRecursiveMerge
   # Adds the contents of +other_hash+ to +hsh+,
   # merging entries in +hsh+ with duplicate keys with those from +other_hash+.
   #
-  # Compared with Hash#merge!, this method supports nested hashes.
+  # Compared with Hash#merge!, this method supports nested hashes and
+  # arrays.
   # When both +hsh+ and +other_hash+ contains an entry with the same key,
-  # it merges and returns the values from both arrays.
+  # it merges and returns the values from both hashes or arrays.
   #
   # @example
   #
@@ -37,7 +38,13 @@ module HashRecursiveMerge
   #
   def rmerge!(other_hash)
     merge!(other_hash) do |_key, oldval, newval|
-      oldval.class == self.class ? oldval.rmerge!(newval) : newval
+      if oldval.class == self.class
+        oldval.rmerge!(newval)
+      elsif oldval.is_a?(Array) && newval.is_a?(Array)
+        oldval |= newval
+      else
+        newval
+      end
     end
   end
 
@@ -49,10 +56,10 @@ module HashRecursiveMerge
   # it merges and returns the values from both arrays.
   #
   # Compared with Hash#merge, this method provides a different approach
-  # for merging nested hashes.
-  # If the value of a given key is an Hash and both +other_hash+ and +hsh
-  # includes the same key, the value is merged instead replaced with
-  # +other_hash+ value.
+  # for merging nested hashes and arrays.
+  # If the value of a given key is an Hash or Array and both
+  # +other_hash+ and +hsh includes the same key, the value is merged
+  # instead of being replaced with +other_hash+ value.
   #
   # @example
   #
@@ -69,7 +76,13 @@ module HashRecursiveMerge
   def rmerge(other_hash)
     r = {}
     merge(other_hash) do |key, oldval, newval|
-      r[key] = oldval.class == self.class ? oldval.rmerge(newval) : newval
+      if oldval.class == self.class
+        r[key] = oldval.rmerge(newval)
+      elsif oldval.is_a?(Array) && newval.is_a?(Array)
+        r[key] = oldval | newval
+      else
+        newval
+      end
     end
   end
 end

--- a/lib/vendor/hash_recursive_merge.rb
+++ b/lib/vendor/hash_recursive_merge.rb
@@ -22,7 +22,9 @@ module HashRecursiveMerge
   # Compared with Hash#merge!, this method supports nested hashes and
   # arrays.
   # When both +hsh+ and +other_hash+ contains an entry with the same key,
-  # it merges and returns the values from both hashes or arrays.
+  # it merges and returns the values from both hashes.
+  # If the values are arrays and +merge_arrays+ is true, underlying
+  # arrays are also merged, as sets (guaranteeing unique values)
   #
   # @example
   #
@@ -36,11 +38,11 @@ module HashRecursiveMerge
   #
   #    h1.merge!(h2)    #=> {"a" => 100, "b" = >254, "c" => {"c1" => 16, "c3" => 94}}
   #
-  def rmerge!(other_hash)
+  def rmerge!(other_hash, merge_arrays=false)
     merge!(other_hash) do |_key, oldval, newval|
       if oldval.class == self.class
         oldval.rmerge!(newval)
-      elsif oldval.is_a?(Array) && newval.is_a?(Array)
+      elsif merge_arrays && oldval.is_a?(Array) && newval.is_a?(Array)
         oldval |= newval
       else
         newval
@@ -57,9 +59,12 @@ module HashRecursiveMerge
   #
   # Compared with Hash#merge, this method provides a different approach
   # for merging nested hashes and arrays.
-  # If the value of a given key is an Hash or Array and both
-  # +other_hash+ and +hsh includes the same key, the value is merged
-  # instead of being replaced with +other_hash+ value.
+  # If the value of a given key is an Hash and both +other_hash+ and
+  # +hsh+ includes the same key, the value is merged instead of being
+  # replaced with +other_hash+ value.
+  # If the value of a given key is an Array, +merge_arrays+ is true and
+  # both +other_hash+ and +hsh+ include the same key, the underlying
+  # arrays are also merged, as sets (guaranteeing unique values).
   #
   # @example
   #
@@ -73,12 +78,12 @@ module HashRecursiveMerge
   #
   #    h1.merge(h2)     #=> {"a" => 100, "b" = >254, "c" => {"c1" => 16, "c3" => 94}}
   #
-  def rmerge(other_hash)
+  def rmerge(other_hash, merge_arrays=false)
     r = {}
     merge(other_hash) do |key, oldval, newval|
       if oldval.class == self.class
         r[key] = oldval.rmerge(newval)
-      elsif oldval.is_a?(Array) && newval.is_a?(Array)
+      elsif merge_arrays && oldval.is_a?(Array) && newval.is_a?(Array)
         r[key] = oldval | newval
       else
         newval

--- a/lib/vendor/hash_recursive_merge.rb
+++ b/lib/vendor/hash_recursive_merge.rb
@@ -48,9 +48,9 @@ module HashRecursiveMerge
   # When both +hsh+ and +other_hash+ contains an entry with the same key,
   # it merges and returns the values from both arrays.
   #
-  # Compared with Hash#merge, this method provides a different approch
-  # for merging nasted hashes.
-  # If the value of a given key is an Hash and both +other_hash+ abd +hsh
+  # Compared with Hash#merge, this method provides a different approach
+  # for merging nested hashes.
+  # If the value of a given key is an Hash and both +other_hash+ and +hsh
   # includes the same key, the value is merged instead replaced with
   # +other_hash+ value.
   #


### PR DESCRIPTION
# Description

When HashRecursiveMerge currently encounters a non-Hash, it will simply return the "new" value. This is sub-optimal for cases where we might want to have some top-level defaults (e.g., for platforms) but certain cookbooks may want to define additional ones. The current code will only leverage the additional ones, instead of appending them to the global ones.

At this point, I'm looking for comments and if this seems like an appropriate direction, in which case I will add tests (and think harder about corner cases).

## Issues Resolved

https://github.com/test-kitchen/test-kitchen/issues/650
https://github.com/test-kitchen/test-kitchen/issues/778

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
