### PR TITLE
Fix Content-Security-Policy error

### DIFF
--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -7,10 +7,10 @@
     Strict-Transport-Security = "max-age=2592000"
     Permissions-Policy = "vibrate=(), geolocation=(), midi=(), notifications=(), push=(), sync-xhr=(), microphone=(), camera=(), magnetometer=(), gyroscope=(), speaker=(), vibrate=(), fullscreen=(), payment=()"
     Content-Security-Policy = '''
-    default-src 'self'
-    font-src 'self' data: https://fonts.gstatic.com 'unsafe-eval'
-    img-src 'self'
-    script-src * data: blob: 'unsafe-inline' 'unsafe-eval'
-    style-src 'self' https://fonts.googleapis.com https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css 'unsafe-inline' 'unsafe-eval'
-    frame-src 'self'
-    connect-src * data'''
+    default-src 'self';
+    font-src 'self' data: https://fonts.gstatic.com 'unsafe-eval';
+    img-src 'self';
+    script-src * data: blob: 'unsafe-inline' 'unsafe-eval';
+    style-src 'self' https://fonts.googleapis.com https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css 'unsafe-inline' 'unsafe-eval';
+    frame-src 'self';
+    connect-src * data;'''


### PR DESCRIPTION
# Description

Remove Content-Security-Policy error from browser console by adding semicolons.

![image](https://user-images.githubusercontent.com/90894396/147775289-00caf36c-4752-4c33-814a-9e7139d62c2c.png)


## Issues Resolved

- https://github.com/test-kitchen/test-kitchen/pull/1833
- https://github.com/test-kitchen/test-kitchen/issues/1810

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
