### PR TITLE
[INFCT-7] Unit tests are failing on master branch

### DIFF
--- a/lib/kitchen/driver/ssh_base.rb
+++ b/lib/kitchen/driver/ssh_base.rb
@@ -70,7 +70,7 @@ module Kitchen
       def converge(state) # rubocop:disable Metrics/AbcSize
         provisioner = instance.provisioner
         provisioner.create_sandbox
-        sandbox_dirs = Util.list_directory(provisioner.sandbox_path)
+        sandbox_dirs = provisioner.sandbox_dirs
 
         instance.transport.connection(backcompat_merged_state(state)) do |conn|
           conn.execute(env_cmd(provisioner.install_command))

--- a/lib/kitchen/provisioner/base.rb
+++ b/lib/kitchen/provisioner/base.rb
@@ -182,6 +182,13 @@ module Kitchen
           "trying to access the path."
       end
 
+      # Returns the list of items in the sandbox directory
+      #
+      # @return [String] path of items in the sandbox directory
+      def sandbox_dirs
+        Util.list_directory sandbox_path
+      end
+
       # Deletes the sandbox path. Without calling this method, the sandbox path
       # will persist after the process terminates. In other words, cleanup is
       # explicit. This method is safe to call multiple times.

--- a/lib/kitchen/provisioner/base.rb
+++ b/lib/kitchen/provisioner/base.rb
@@ -185,7 +185,7 @@ module Kitchen
       #
       # @return [String] path of items in the sandbox directory
       def sandbox_dirs
-        Util.list_directory sandbox_path
+        Util.list_directory(sandbox_path)
       end
 
       # Deletes the sandbox path. Without calling this method, the sandbox path

--- a/lib/kitchen/provisioner/base.rb
+++ b/lib/kitchen/provisioner/base.rb
@@ -70,7 +70,6 @@ module Kitchen
       # rubocop:disable Metrics/AbcSize
       def call(state)
         create_sandbox
-        sandbox_dirs = Util.list_directory(sandbox_path)
 
         instance.transport.connection(state) do |conn|
           config[:uploads].to_h.each do |locals, remote|

--- a/lib/kitchen/verifier/base.rb
+++ b/lib/kitchen/verifier/base.rb
@@ -65,7 +65,6 @@ module Kitchen
       # @raise [ActionFailed] if the action could not be completed
       def call(state)
         create_sandbox
-        sandbox_dirs = Util.list_directory(sandbox_path)
 
         instance.transport.connection(state) do |conn|
           conn.execute(install_command)
@@ -172,6 +171,13 @@ module Kitchen
         @sandbox_path ||= raise ClientError, "Sandbox directory has not yet " \
            "been created. Please run #{self.class}#create_sandox before " \
            "trying to access the path."
+      end
+
+      # Returns the list of items in the sandbox directory
+      #
+      # @return [String] the absolute path of sandbox directory files
+      def sandbox_dirs
+        Util.list_directory(sandbox_path)
       end
 
       # Sets the API version for this verifier. If the verifier does not set

--- a/spec/kitchen/driver/ssh_base_spec.rb
+++ b/spec/kitchen/driver/ssh_base_spec.rb
@@ -77,7 +77,8 @@ describe Kitchen::Driver::SSHBase do
       run_command: "run",
       create_sandbox: true,
       cleanup_sandbox: true,
-      sandbox_path: "/tmp/sandbox"
+      sandbox_path: "/tmp/sandbox",
+      sandbox_dirs: ["/tmp/sandbox/stuff"]
     )
   end
 
@@ -445,8 +446,6 @@ describe Kitchen::Driver::SSHBase do
     describe "transferring files" do
       before do
         transport.stubs(:connection).yields(connection)
-        connection.stubs(:upload)
-        FileUtils.mkdir_p "/tmp/sandbox/stuff"
       end
 
       it "uploads files" do

--- a/spec/kitchen/provisioner/base_spec.rb
+++ b/spec/kitchen/provisioner/base_spec.rb
@@ -53,6 +53,10 @@ module Kitchen
       def sandbox_path
         "/tmp/sandbox"
       end
+
+      def sandbox_dirs
+        ["/tmp/sandbox/stuff"]
+      end
     end
 
     class Dodgy < Kitchen::Provisioner::Base

--- a/spec/kitchen/verifier/base_spec.rb
+++ b/spec/kitchen/verifier/base_spec.rb
@@ -56,6 +56,10 @@ module Kitchen
       def sandbox_path
         "/tmp/sandbox"
       end
+
+      def sandbox_dirs
+        ["/tmp/sandbox/stuff"]
+      end
     end
 
     class Dodgy < Kitchen::Verifier::Base


### PR DESCRIPTION
# Description

Some of the unit tests are failing on master branch. This is causing the azure builds to fail for all the open pull requests. The tests are failing on Windows platform only.

Due to the different folder structure in windows when compared to the Mac/Linux, the file util is creating a single file instead of the complete path. This is causing the expectation to fail. The fix for the issue is to stub the method that fetch the items in the directory as well. 

## Issues Resolved

https://github.com/test-kitchen/test-kitchen/issues/1826

## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
