### PR TITLE
gracefully handle winrm errors

### DIFF
--- a/spec/kitchen/transport/base_spec.rb
+++ b/spec/kitchen/transport/base_spec.rb
@@ -152,14 +152,29 @@ describe Kitchen::Transport::Base::Connection do
   end
 
   describe "#retry?" do
+    let(:exception) { Kitchen::Transport::TransportFailed.new("failure message", 35) }
+
     it "raises an exception when multiple retryable exit codes are passed as a String" do
-      proc { connection.retry?(2, 2, "35 1", 35) }
+      proc { connection.retry?(2, 2, "35 1", exception) }
         .must_raise("undefined method `flatten' for \"35 1\":String")
     end
 
     it "returns true when the retryable exit codes are formatted in a nested array" do
-      connection.retry?(1, 2, [[35, 1]], 35).must_equal true
+      connection.retry?(1, 2, [[35, 1]], exception).must_equal true
+      connection.retry?(2, 2, [[35, 1]], exception).must_equal true
+    end
+
+    describe "when exception is anything other than Kitchen::Transport::TransportFailed" do
+      let(:exception) { RuntimeError.new("failure message") }
+
+      it "returns false when the exception is anything other than Kitchen::Transport::TransportFailed" do
+        connection.retry?(1, 2, [35, 1], exception).must_equal false
+        connection.retry?(2, 2, [35, 1], exception).must_equal false
+      end
+    end
+
+    it "returns false when the maximum retries have been exceeded" do
+      connection.retry?(3, 2, [35, 1], exception).must_equal false
     end
   end
-
 end


### PR DESCRIPTION
# Description

This change allows for gracefully handling odd scenarios such as the Chef Infra Client convergence restarting the winrm service mid convergence or reconfiguring, etc.

```yaml
# kitchen.yml

provisioner:
  name: chef_zero
  max_retries: 6
  wait_for_retry: 10

transport:
  name: winrm
  connection_retries: 180
  connection_retry_sleep: 5
```

This magic config ^^ plus these changes resolved all of our issues. In other words it made test-kitchen resilient to random windows server reboots and random winrm service reboots.

## Issues Resolved

N/A

## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
