### PR TITLE
Fix failing azure pipeline

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -61,7 +61,7 @@ jobs:
       MACHINE_USER: kitchen
       MACHINE_PASS: K1tch3nY@ml!
       MACHINE_PORT: 22
-      KITCHEN_YAML: ../../../../../../../kitchen.proxy.yml
+      KITCHEN_YAML: kitchen.proxy.yml
       PROXY_TESTS_DIR: proxy_tests/files/default/scripts
       PROXY_TESTS_REPO: proxy_tests/files/default/scripts/repo
     runs-on: ubuntu-latest
@@ -98,20 +98,18 @@ jobs:
           path: proxy_tests
       - name: Update path and sudo privs for Kitchen user
         run: |
-              sudo echo 'Defaults	secure_path="./vendor/bundle/ruby/2.7.0/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin"' | sudo tee /etc/sudoers.d/kitchen
-              sudo echo "" | sudo tee -a /etc/sudoers.d/kitchen
-              sudo echo "kitchen ALL=(ALL) NOPASSWD:ALL" | sudo tee -a /etc/sudoers.d/kitchen
-              sudo echo "" | sudo tee -a /etc/sudoers.d/kitchen
+          sudo echo 'Defaults	secure_path="./vendor/bundle/ruby/2.7.0/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin"' | sudo tee /etc/sudoers.d/kitchen
+          sudo echo "" | sudo tee -a /etc/sudoers.d/kitchen
+          sudo echo "kitchen ALL=(ALL) NOPASSWD:ALL" | sudo tee -a /etc/sudoers.d/kitchen
+          sudo echo "" | sudo tee -a /etc/sudoers.d/kitchen
       - name: Run the proxy test script
         run: |
-              sudo -E $PROXY_TESTS_DIR/run_tests.sh kitchen \* \* /tmp/out.txt
-              cat /tmp/out.txt
-
-              echo ""
-              echo "===================="
-              echo "Tests finished."
-              echo "===================="
-              echo ""
-
-              sudo cat /var/log/squid/cache.log
-              sudo cat /var/log/squid/access.log
+          sudo -E $PROXY_TESTS_DIR/run_tests.sh kitchen \* \* /tmp/out.txt
+          cat /tmp/out.txt
+          echo ""
+          echo "===================="
+          echo "Tests finished."
+          echo "===================="
+          echo ""
+          sudo cat /var/log/squid/cache.log
+          sudo cat /var/log/squid/access.log

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,32 +20,32 @@ stages:
       - job: Windows
         strategy:
           matrix:
-            Windows_Ruby26:
-              version: 2.6
+            Windows_Ruby27:
+              version: 2.7
               machine_user: test_user
               machine_pass: Pass@word1
               machine_port: 5985
               KITCHEN_YAML: kitchen.windows.yml
-            # Windows_Ruby27:
-            #   version: 2.7
-            #   machine_user: test_user
-            #   machine_pass: Pass@word1
-            #   machine_port: 5985
-            #   KITCHEN_YAML: kitchen.windows.yml
-            # WindowsProduct_Ruby27:
-            #   version: 2.7
-            #   machine_user: test_user
-            #   machine_pass: Pass@word1
-            #   machine_port: 5985
-            #   KITCHEN_YAML: kitchen.windows-product.yml
-            # WindowsProduct_Ruby30:
-            #   version: 3.0
-            #   machine_user: test_user
-            #   machine_pass: Pass@word1
-            #   machine_port: 5985
-            #   KITCHEN_YAML: kitchen.windows-product.yml
+            Windows_Ruby30:
+              version: 3.0
+              machine_user: test_user
+              machine_pass: Pass@word1
+              machine_port: 5985
+              KITCHEN_YAML: kitchen.windows.yml
+            WindowsProduct_Ruby27:
+              version: 2.7
+              machine_user: test_user
+              machine_pass: Pass@word1
+              machine_port: 5985
+              KITCHEN_YAML: kitchen.windows-product.yml
+            WindowsProduct_Ruby30:
+              version: 3.0
+              machine_user: test_user
+              machine_pass: Pass@word1
+              machine_port: 5985
+              KITCHEN_YAML: kitchen.windows-product.yml
         pool:
-          vmImage: windows-latest
+          vmImage: windows-2019
         steps:
           - task: Cache@2
             inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,24 +26,24 @@ stages:
               machine_pass: Pass@word1
               machine_port: 5985
               KITCHEN_YAML: kitchen.windows.yml
-            Windows_Ruby27:
-              version: 2.7
-              machine_user: test_user
-              machine_pass: Pass@word1
-              machine_port: 5985
-              KITCHEN_YAML: kitchen.windows.yml
-            WindowsProduct_Ruby27:
-              version: 2.7
-              machine_user: test_user
-              machine_pass: Pass@word1
-              machine_port: 5985
-              KITCHEN_YAML: kitchen.windows-product.yml
-            WindowsProduct_Ruby30:
-              version: 3.0
-              machine_user: test_user
-              machine_pass: Pass@word1
-              machine_port: 5985
-              KITCHEN_YAML: kitchen.windows-product.yml
+            # Windows_Ruby27:
+            #   version: 2.7
+            #   machine_user: test_user
+            #   machine_pass: Pass@word1
+            #   machine_port: 5985
+            #   KITCHEN_YAML: kitchen.windows.yml
+            # WindowsProduct_Ruby27:
+            #   version: 2.7
+            #   machine_user: test_user
+            #   machine_pass: Pass@word1
+            #   machine_port: 5985
+            #   KITCHEN_YAML: kitchen.windows-product.yml
+            # WindowsProduct_Ruby30:
+            #   version: 3.0
+            #   machine_user: test_user
+            #   machine_pass: Pass@word1
+            #   machine_port: 5985
+            #   KITCHEN_YAML: kitchen.windows-product.yml
         pool:
           vmImage: windows-latest
         steps:


### PR DESCRIPTION
# Description

1. Azure DevOps no longer supports ruby 2.6
2. windows-latest image which was earlier pointing to windows-2019, now points to windows server 2022 which causes bundle install to fail

## Issues Resolved
#1886 #1873 

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
