### PR TITLE
Fix MiniTest deprecations in transport specs

### DIFF
--- a/spec/kitchen/diagnostic_spec.rb
+++ b/spec/kitchen/diagnostic_spec.rb
@@ -115,7 +115,7 @@ describe Kitchen::Diagnostic do
     _(Kitchen::Diagnostic.new(
       instances: { error: "shoot" }, plugins: true
     ).read["plugins"])
-    .must_equal("error" => "shoot")
+      .must_equal("error" => "shoot")
   end
 
   it "#read returns the instances' diganose hashes if instances are present" do
@@ -125,6 +125,6 @@ describe Kitchen::Diagnostic do
 
   it "#read returns an error hash for instances if error hash is passed in" do
     _(Kitchen::Diagnostic.new(instances: { error: "shoot" }).read["instances"])
-    .must_equal("error" => "shoot")
+      .must_equal("error" => "shoot")
   end
 end

--- a/spec/kitchen/instance_spec.rb
+++ b/spec/kitchen/instance_spec.rb
@@ -980,8 +980,7 @@ describe Kitchen::Instance do
           instance.public_send(action)
         rescue Kitchen::Error => e
           _(e.message)
-            .must_match regex_for("Create failed on instance #{instance.to_str}"
-          )
+            .must_match regex_for("Create failed on instance #{instance.to_str}")
         end
 
         it "logs the failure" do
@@ -992,8 +991,7 @@ describe Kitchen::Instance do
           end
 
           _(logger_io.string)
-            .must_match regex_for("Create failed on instance #{instance.to_str}"
-          )
+            .must_match regex_for("Create failed on instance #{instance.to_str}")
         end
       end
 
@@ -1021,8 +1019,7 @@ describe Kitchen::Instance do
           instance.public_send(action)
         rescue Kitchen::Error => e
           _(e.message)
-            .must_match regex_for("Failed to complete #create action: [watwat]"
-          )
+            .must_match regex_for("Failed to complete #create action: [watwat]")
         end
 
         it "logs the failure" do
@@ -1033,8 +1030,7 @@ describe Kitchen::Instance do
           end
 
           _(logger_io.string)
-            .must_match regex_for("Create failed on instance #{instance.to_str}"
-          )
+            .must_match regex_for("Create failed on instance #{instance.to_str}")
         end
       end
     end

--- a/spec/kitchen/transport/base_spec.rb
+++ b/spec/kitchen/transport/base_spec.rb
@@ -51,14 +51,14 @@ describe Kitchen::Transport::Base do
     after   { Kitchen.logger = @klog }
 
     it "returns the instance's logger" do
-      transport.send(:logger).must_equal logger
+      _(transport.send(:logger)).must_equal logger
     end
 
     it "returns the default logger if instance's logger is not set" do
       transport = Kitchen::Transport::Base.new(config)
       Kitchen.logger = "yep"
 
-      transport.send(:logger).must_equal Kitchen.logger
+      _(transport.send(:logger)).must_equal Kitchen.logger
     end
   end
 
@@ -68,30 +68,30 @@ describe Kitchen::Transport::Base do
 
     describe "when no exit code is provided" do
       it "#exit_code is nil" do
-        failure_with_no_exit_code.exit_code.must_be_nil
+        _(failure_with_no_exit_code.exit_code).must_be_nil
       end
     end
 
     describe "when an exit code is provided" do
       it "#exit_code returns the supplied exit code" do
-        failure_with_exit_code.exit_code.must_equal 123
+        _(failure_with_exit_code.exit_code).must_equal 123
       end
     end
   end
 
   describe ".no_parallel_for" do
     it "registers no serial actions when none are declared" do
-      Kitchen::Transport::TestingDummy.serial_actions.must_be_nil
+      _(Kitchen::Transport::TestingDummy.serial_actions).must_be_nil
     end
 
     it "registers a single serial action method" do
-      Kitchen::Transport::Dodgy.serial_actions.must_equal [:setup]
+      _(Kitchen::Transport::Dodgy.serial_actions).must_equal [:setup]
     end
 
     it "raises a ClientError if value is not an action method" do
-      proc do
+      _(proc do
         Class.new(Kitchen::Transport::Base) { no_parallel_for :telling_stories }
-      end.must_raise Kitchen::ClientError
+      end).must_raise Kitchen::ClientError
     end
   end
 end
@@ -106,7 +106,7 @@ describe Kitchen::Transport::Base::Connection do
   end
 
   it "has a #close method that does nothing" do
-    connection.close.must_be_nil
+    _(connection.close).must_be_nil
   end
 
   it "has an #execute method which raises a ClientError" do
@@ -128,7 +128,7 @@ describe Kitchen::Transport::Base::Connection do
   end
 
   it "has a #wait_until_ready method that does nothing" do
-    connection.wait_until_ready.must_be_nil
+    _(connection.wait_until_ready).must_be_nil
   end
 
   describe "#execute_with_retry" do
@@ -147,7 +147,7 @@ describe Kitchen::Transport::Base::Connection do
       connection.expects(:execute).with("Hi").raises(failure_with_exit_code)
       connection.expects(:debug).with("Attempting to execute command - try 1 of 3.")
 
-      connection.execute_with_retry("Hi", [123], 3, 1).must_equal "Hello"
+      _(connection.execute_with_retry("Hi", [123], 3, 1)).must_equal "Hello"
     end
   end
 
@@ -160,21 +160,21 @@ describe Kitchen::Transport::Base::Connection do
     end
 
     it "returns true when the retryable exit codes are formatted in a nested array" do
-      connection.retry?(1, 2, [[35, 1]], exception).must_equal true
-      connection.retry?(2, 2, [[35, 1]], exception).must_equal true
+      _(connection.retry?(1, 2, [[35, 1]], exception)).must_equal true
+      _(connection.retry?(2, 2, [[35, 1]], exception)).must_equal true
     end
 
     describe "when exception is anything other than Kitchen::Transport::TransportFailed" do
       let(:exception) { RuntimeError.new("failure message") }
 
       it "returns false when the exception is anything other than Kitchen::Transport::TransportFailed" do
-        connection.retry?(1, 2, [35, 1], exception).must_equal false
-        connection.retry?(2, 2, [35, 1], exception).must_equal false
+        _(connection.retry?(1, 2, [35, 1], exception)).must_equal false
+        _(connection.retry?(2, 2, [35, 1], exception)).must_equal false
       end
     end
 
     it "returns false when the maximum retries have been exceeded" do
-      connection.retry?(3, 2, [35, 1], exception).must_equal false
+      _(connection.retry?(3, 2, [35, 1], exception)).must_equal false
     end
   end
 end

--- a/spec/kitchen/transport/exec_spec.rb
+++ b/spec/kitchen/transport/exec_spec.rb
@@ -36,11 +36,11 @@ describe Kitchen::Transport::Exec do
   end
 
   it "provisioner api_version is 1" do
-    transport.diagnose_plugin[:api_version].must_equal 1
+    _(transport.diagnose_plugin[:api_version]).must_equal 1
   end
 
   it "plugin_version is set to Kitchen::VERSION" do
-    transport.diagnose_plugin[:version].must_equal Kitchen::VERSION
+    _(transport.diagnose_plugin[:version]).must_equal Kitchen::VERSION
   end
 
   describe "#connection" do
@@ -52,7 +52,7 @@ describe Kitchen::Transport::Exec do
       end
 
       it "returns a Kitchen::Transport::Exec::Connection object" do
-        transport.connection(state).must_be_kind_of klass
+        _(transport.connection(state)).must_be_kind_of klass
       end
 
       it "sets :instance_name to the instance's name" do

--- a/spec/kitchen/transport/ssh_spec.rb
+++ b/spec/kitchen/transport/ssh_spec.rb
@@ -35,121 +35,121 @@ describe Kitchen::Transport::Ssh do
   end
 
   it "provisioner api_version is 1" do
-    transport.diagnose_plugin[:api_version].must_equal 1
+    _(transport.diagnose_plugin[:api_version]).must_equal 1
   end
 
   it "plugin_version is set to Kitchen::VERSION" do
-    transport.diagnose_plugin[:version].must_equal Kitchen::VERSION
+    _(transport.diagnose_plugin[:version]).must_equal Kitchen::VERSION
   end
 
   describe "default_config" do
     it "sets :port to 22 by default" do
-      transport[:port].must_equal 22
+      _(transport[:port]).must_equal 22
     end
 
     it "sets :username to root by default" do
-      transport[:username].must_equal "root"
+      _(transport[:username]).must_equal "root"
     end
 
     it "sets :compression to true by default" do
-      transport[:compression].must_equal false
+      _(transport[:compression]).must_equal false
     end
 
     it "sets :compression to false if set to none" do
       config[:compression] = "none"
 
-      transport[:compression].must_equal false
+      _(transport[:compression]).must_equal false
     end
 
     it "sets :compression to zlib@openssh.com if set to zlib" do
       config[:compression] = "zlib"
 
-      transport[:compression].must_equal "zlib@openssh.com"
+      _(transport[:compression]).must_equal "zlib@openssh.com"
     end
 
     it "sets :compression_level to 6 by default" do
-      transport[:compression_level].must_equal 0
+      _(transport[:compression_level]).must_equal 0
     end
 
     it "sets :compression_level to 6 if :compression is set to true" do
       config[:compression] = true
 
-      transport[:compression_level].must_equal 6
+      _(transport[:compression_level]).must_equal 6
     end
 
     it "sets :keepalive to true by default" do
-      transport[:keepalive].must_equal true
+      _(transport[:keepalive]).must_equal true
     end
 
     it "sets :keepalive_interval to 60 by default" do
-      transport[:keepalive_interval].must_equal 60
+      _(transport[:keepalive_interval]).must_equal 60
     end
 
     it "sets :keepalive_maxcount to 3 by default" do
-      transport[:keepalive_maxcount].must_equal 3
+      _(transport[:keepalive_maxcount]).must_equal 3
     end
 
     it "sets :connection_timeout to 15 by default" do
-      transport[:connection_timeout].must_equal 15
+      _(transport[:connection_timeout]).must_equal 15
     end
 
     it "sets :connection_retries to 5 by default" do
-      transport[:connection_retries].must_equal 5
+      _(transport[:connection_retries]).must_equal 5
     end
 
     it "sets :connection_retry_sleep to 1 by default" do
-      transport[:connection_retry_sleep].must_equal 1
+      _(transport[:connection_retry_sleep]).must_equal 1
     end
 
     it "sets :max_wait_until_ready to 600 by default" do
-      transport[:max_wait_until_ready].must_equal 600
+      _(transport[:max_wait_until_ready]).must_equal 600
     end
 
     it "sets :ssh_key to nil by default" do
-      transport[:ssh_key].must_be_nil
+      _(transport[:ssh_key]).must_be_nil
     end
 
     it "sets :ssh_key_only to nil by default" do
-      transport[:ssh_key_only].must_be_nil
+      _(transport[:ssh_key_only]).must_be_nil
     end
 
     it "expands :ssh_path path if set" do
       config[:kitchen_root] = "/rooty"
       config[:ssh_key] = "my_key"
 
-      transport[:ssh_key].must_equal os_safe_root_path("/rooty/my_key")
+      _(transport[:ssh_key]).must_equal os_safe_root_path("/rooty/my_key")
     end
 
     it "sets :max_ssh_sessions to 9 by default" do
-      transport[:max_ssh_sessions].must_equal 9
+      _(transport[:max_ssh_sessions]).must_equal 9
     end
 
     it "sets :ssh_http_proxy to nil by default" do
-      transport[:ssh_http_proxy].must_be_nil
+      _(transport[:ssh_http_proxy]).must_be_nil
     end
 
     it "sets :ssh_http_proxy_port to nil by default" do
-      transport[:ssh_http_proxy_port].must_be_nil
+      _(transport[:ssh_http_proxy_port]).must_be_nil
     end
 
     it "sets :ssh_http_proxy_user to nil by default" do
-      transport[:ssh_http_proxy_user].must_be_nil
+      _(transport[:ssh_http_proxy_user]).must_be_nil
     end
 
     it "sets :ssh_http_proxy_password to nil by default" do
-      transport[:ssh_http_proxy_password].must_be_nil
+      _(transport[:ssh_http_proxy_password]).must_be_nil
     end
 
     it "sets :ssh_gateway to nil by default" do
-      transport[:ssh_gateway].must_be_nil
+      _(transport[:ssh_gateway]).must_be_nil
     end
 
     it "sets :ssh_gateway_username to nil by default" do
-      transport[:ssh_gateway_username].must_be_nil
+      _(transport[:ssh_gateway_username]).must_be_nil
     end
 
     it "sets :ssh_gateway_port to 22 by default" do
-      transport[:ssh_gateway_port].must_equal 22
+      _(transport[:ssh_gateway_port]).must_equal 22
     end
   end
 
@@ -171,7 +171,7 @@ describe Kitchen::Transport::Ssh do
       end
 
       it "returns a Kitchen::Transport::Ssh::Connection object" do
-        transport.connection(state).must_be_kind_of klass
+        _(transport.connection(state)).must_be_kind_of klass
       end
 
       it "sets the :logger to the transport's logger" do
@@ -608,23 +608,23 @@ describe Kitchen::Transport::Ssh do
         first_connection  = make_connection(state)
         second_connection = make_connection(state)
 
-        first_connection.object_id.must_equal second_connection.object_id
+        _(first_connection.object_id).must_equal second_connection.object_id
       end
 
       it "logs a debug message when the connection is reused" do
         make_connection(state)
         make_connection(state)
 
-        logged_output.string.lines.count do |l|
+        _(logged_output.string.lines.count do |l|
           l =~ debug_line_with("[SSH] reusing existing connection ")
-        end.must_equal 1
+        end).must_equal 1
       end
 
       it "returns a new connection when called again if state differs" do
         first_connection  = make_connection(state)
         second_connection = make_connection(state.merge(port: 9000))
 
-        first_connection.object_id.wont_equal second_connection.object_id
+        _(first_connection.object_id).wont_equal second_connection.object_id
       end
 
       it "closes first connection when a second is created" do
@@ -638,9 +638,9 @@ describe Kitchen::Transport::Ssh do
         make_connection(state)
         make_connection(state.merge(port: 9000))
 
-        logged_output.string.lines.count do |l|
+        _(logged_output.string.lines.count do |l|
           l =~ debug_line_with("[SSH] shutting previous connection ")
-        end.must_equal 1
+        end).must_equal 1
       end
     end
     # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
@@ -714,10 +714,10 @@ describe Kitchen::Transport::Ssh::Connection do
         end
 
         it "raises an SshFailed exception" do
-          e = proc do
-            connection.execute("nope")
-          end.must_raise Kitchen::Transport::SshFailed
-          e.message.must_match regexify("SSH session could not be established")
+          e = _{ connection.execute("nope") }
+            .must_raise Kitchen::Transport::SshFailed
+
+          _(e.message).must_match regexify("SSH session could not be established")
         end
 
         it "attempts to connect :connection_retries times" do
@@ -727,9 +727,9 @@ describe Kitchen::Transport::Ssh::Connection do
             # the raise is not what is being tested here, rather its side-effect
           end
 
-          logged_output.string.lines.count do |l|
+          _(logged_output.string.lines.count do |l|
             l =~ debug_line("[SSH] opening connection to me@foo<{:port=>22}>")
-          end.must_equal 3
+          end).must_equal 3
         end
 
         it "sleeps for :connection_retry_sleep seconds between retries" do
@@ -750,11 +750,11 @@ describe Kitchen::Transport::Ssh::Connection do
             # the raise is not what is being tested here, rather its side-effect
           end
 
-          logged_output.string.lines.count do |l|
+          _(logged_output.string.lines.count do |l|
             l =~ info_line_with(
               "[SSH] connection failed, retrying in 7 seconds"
             )
-          end.must_equal 2
+          end).must_equal 2
         end
 
         it "logs the last retry failures on warn" do
@@ -764,9 +764,9 @@ describe Kitchen::Transport::Ssh::Connection do
             # the raise is not what is being tested here, rather its side-effect
           end
 
-          logged_output.string.lines.count do |l|
+          _(logged_output.string.lines.count do |l|
             l =~ warn_line_with("[SSH] connection failed, terminating ")
-          end.must_equal 1
+          end).must_equal 1
         end
       end
     end
@@ -793,7 +793,7 @@ describe Kitchen::Transport::Ssh::Connection do
         connection.close
       end
 
-      logged_output.string.must_match debug_line(
+      _(logged_output.string).must_match debug_line(
         "[SSH] closing connection to me@foo<{:port=>22}>"
       )
     end
@@ -828,7 +828,7 @@ describe Kitchen::Transport::Ssh::Connection do
       it "logger displays command on debug" do
         assert_scripted { connection.execute("doit") }
 
-        logged_output.string.must_match debug_line(
+        _(logged_output.string).must_match debug_line(
           "[SSH] me@foo<{:port=>22}> (doit)"
         )
       end
@@ -836,7 +836,7 @@ describe Kitchen::Transport::Ssh::Connection do
       it "logger displays establishing connection on debug" do
         assert_scripted { connection.execute("doit") }
 
-        logged_output.string.must_match debug_line(
+        _(logged_output.string).must_match debug_line(
           "[SSH] opening connection to me@foo<{:port=>22}>"
         )
       end
@@ -844,13 +844,13 @@ describe Kitchen::Transport::Ssh::Connection do
       it "logger captures stdout" do
         assert_scripted { connection.execute("doit") }
 
-        logged_output.string.must_match(/^ok$/)
+        _(logged_output.string).must_match(/^ok$/)
       end
 
       it "logger captures stderr" do
         assert_scripted { connection.execute("doit") }
 
-        logged_output.string.must_match(/^some stderr stuffs$/)
+        _(logged_output.string).must_match(/^some stderr stuffs$/)
       end
     end
 
@@ -875,7 +875,7 @@ describe Kitchen::Transport::Ssh::Connection do
           # the raise is not what is being tested here, rather its side-effect
         end
 
-        logged_output.string.must_match debug_line(
+        _(logged_output.string).must_match debug_line(
           "[SSH] me@foo<{:port=>22}> (doit)"
         )
       end
@@ -887,7 +887,7 @@ describe Kitchen::Transport::Ssh::Connection do
           # the raise is not what is being tested here, rather its side-effect
         end
 
-        logged_output.string.must_match debug_line(
+        _(logged_output.string).must_match debug_line(
           "[SSH] opening connection to me@foo<{:port=>22}>"
         )
       end
@@ -899,7 +899,7 @@ describe Kitchen::Transport::Ssh::Connection do
           # the raise is not what is being tested here, rather its side-effect
         end
 
-        logged_output.string.must_match(/^nope$/)
+        _(logged_output.string).must_match(/^nope$/)
       end
 
       it "logger captures stderr" do
@@ -909,20 +909,20 @@ describe Kitchen::Transport::Ssh::Connection do
           # the raise is not what is being tested here, rather its side-effect
         end
 
-        logged_output.string.must_match(/^youdead$/)
+        _(logged_output.string).must_match(/^youdead$/)
       end
 
       it "raises an SshFailed exception" do
-        err = proc do
-          assert_scripted { connection.execute("doit") }
-        end.must_raise Kitchen::Transport::SshFailed
-        err.message.must_equal "SSH exited (42) for command: [doit]"
+        err = _ { assert_scripted { connection.execute("doit") } }
+          .must_raise Kitchen::Transport::SshFailed
+          
+        _(err.message).must_equal "SSH exited (42) for command: [doit]"
       end
 
       it "returns the exit code with an SshFailed exception" do
         assert_scripted { connection.execute("doit") }
       rescue Kitchen::Transport::SshFailed => e
-        e.exit_code.must_equal 42
+        _(e.exit_code).must_equal 42
       end
     end
 
@@ -936,10 +936,10 @@ describe Kitchen::Transport::Ssh::Connection do
       it "raises SshFailed when an SSH exception is raised" do
         conn.stubs(:open_channel).raises(Net::SSH::Exception)
 
-        e = proc do
-          connection.execute("nope")
-        end.must_raise Kitchen::Transport::SshFailed
-        e.message.must_match regexify("SSH command failed")
+        e = _ { connection.execute("nope") }
+          .must_raise Kitchen::Transport::SshFailed
+
+        _(e.message).must_match regexify("SSH command failed")
       end
     end
 
@@ -947,7 +947,7 @@ describe Kitchen::Transport::Ssh::Connection do
       it "does not log on debug" do
         connection.execute(nil)
 
-        logged_output.string.must_equal ""
+        _(logged_output.string).must_equal ""
       end
     end
   end
@@ -957,81 +957,81 @@ describe Kitchen::Transport::Ssh::Connection do
     let(:args)          { login_command.arguments.join(" ") }
 
     it "returns a LoginCommand" do
-      login_command.must_be_instance_of Kitchen::LoginCommand
+      _(login_command).must_be_instance_of Kitchen::LoginCommand
     end
 
     it "is an SSH command" do
-      login_command.command.must_equal "ssh"
-      args.must_match(/ me@foo$/)
+      _(login_command.command).must_equal "ssh"
+      _(args).must_match(/ me@foo$/)
     end
 
     it "sets the UserKnownHostsFile option" do
-      args.must_match regexify("-o UserKnownHostsFile=/dev/null ")
+      _(args).must_match regexify("-o UserKnownHostsFile=/dev/null ")
     end
 
     it "sets the StrictHostKeyChecking option" do
-      args.must_match regexify(" -o StrictHostKeyChecking=no ")
+      _(args).must_match regexify(" -o StrictHostKeyChecking=no ")
     end
 
     it "won't set IdentitiesOnly option by default" do
-      args.wont_match regexify(" -o IdentitiesOnly=")
+      _(args).wont_match regexify(" -o IdentitiesOnly=")
     end
 
     it "sets the IdentiesOnly option if :keys option is given" do
       options[:keys] = ["yep"]
 
-      args.must_match regexify(" -o IdentitiesOnly=yes ")
+      _(args).must_match regexify(" -o IdentitiesOnly=yes ")
     end
 
     it "sets the LogLevel option to VERBOSE if logger is set to debug" do
       logger.level = ::Logger::DEBUG
       options[:logger] = logger
 
-      args.must_match regexify(" -o LogLevel=VERBOSE ")
+      _(args).must_match regexify(" -o LogLevel=VERBOSE ")
     end
 
     it "sets the LogLevel option to ERROR if logger is not set to debug" do
       logger.level = ::Logger::INFO
       options[:logger] = logger
 
-      args.must_match regexify(" -o LogLevel=ERROR ")
+      _(args).must_match regexify(" -o LogLevel=ERROR ")
     end
 
     it "won't set the ForwardAgent option by default" do
-      args.wont_match regexify(" -o ForwardAgent=")
+      _(args).wont_match regexify(" -o ForwardAgent=")
     end
 
     it "sets the ForwardAgent option to yes if truthy" do
       options[:forward_agent] = "yep"
 
-      args.must_match regexify(" -o ForwardAgent=yes")
+      _(args).must_match regexify(" -o ForwardAgent=yes")
     end
 
     it "sets the ForwardAgent option to no if falsey" do
       options[:forward_agent] = false
 
-      args.must_match regexify(" -o ForwardAgent=no")
+      _(args).must_match regexify(" -o ForwardAgent=no")
     end
 
     it "won't add any SSH keys by default" do
-      args.wont_match regexify(" -i ")
+      _(args).wont_match regexify(" -i ")
     end
 
     it "sets SSH keys options if given" do
       options[:keys] = %w{one two}
 
-      args.must_match regexify(" -i one ")
-      args.must_match regexify(" -i two ")
+      _(args).must_match regexify(" -i one ")
+      _(args).must_match regexify(" -i two ")
     end
 
     it "sets the port option to 22 by default" do
-      args.must_match regexify(" -p 22 ")
+      _(args).must_match regexify(" -p 22 ")
     end
 
     it "sets the port option" do
       options[:port] = 1234
 
-      args.must_match regexify(" -p 1234 ")
+      _(args).must_match regexify(" -p 1234 ")
     end
   end
 
@@ -1074,9 +1074,9 @@ describe Kitchen::Transport::Ssh::Connection do
           connection.upload(src.path, "/tmp/remote")
         end
 
-        logged_output.string.lines.count do |l|
+        _(logged_output.string.lines.count do |l|
           l =~ debug_line("Async Uploaded #{src.path} (#{content.length} bytes)")
-        end.must_equal 1
+        end).must_equal 1
       end
     end
 
@@ -1142,9 +1142,9 @@ describe Kitchen::Transport::Ssh::Connection do
           assert_scripted { connection.upload(@dir, "/tmp/remote") }
         end
 
-        logged_output.string.lines.count do |l|
+        _(logged_output.string.lines.count do |l|
           l =~ debug_line_with("Async Uploaded ")
-        end.must_equal 3
+        end).must_equal 3
       end
     end
 
@@ -1158,10 +1158,10 @@ describe Kitchen::Transport::Ssh::Connection do
       it "raises SshFailed when an SSH exception is raised" do
         conn.stubs(:scp).raises(Net::SSH::Exception)
 
-        e = proc do
-          connection.upload("nope", "fail")
-        end.must_raise Kitchen::Transport::SshFailed
-        e.message.must_match regexify("SCP upload failed")
+        e = _ { connection.upload("nope", "fail") }
+          .must_raise Kitchen::Transport::SshFailed
+
+        _(e.message).must_match regexify("SCP upload failed")
       end
     end
   end
@@ -1219,11 +1219,11 @@ describe Kitchen::Transport::Ssh::Connection do
 
         connection.download("/remote", @local)
 
-        logged_output.string.lines.count do |l|
+        _(logged_output.string.lines.count do |l|
           l =~ warn_line_with(
             "SCP download failed for file or directory '/remote', perhaps it does not exist?"
           )
-        end.must_equal 1
+        end).must_equal 1
       end
     end
 
@@ -1231,10 +1231,10 @@ describe Kitchen::Transport::Ssh::Connection do
       it "raises SshFailed when an SSH exception is raised" do
         conn.stubs(:scp).raises(Net::SSH::Exception)
 
-        e = proc do
-          connection.download("nope", "fail")
-        end.must_raise Kitchen::Transport::SshFailed
-        e.message.must_match regexify("SCP download failed")
+        e = _{ connection.download("nope", "fail") }
+          .must_raise Kitchen::Transport::SshFailed
+
+        _(e.message).must_match regexify("SCP download failed")
       end
     end
   end
@@ -1257,17 +1257,20 @@ describe Kitchen::Transport::Ssh::Connection do
           # the raise is not what is being tested here, rather its side-effect
         end
 
-        logged_output.string.lines.count do |l|
+        _(logged_output.string.lines.count do |l|
           l =~ info_line_with(
             "Waiting for SSH service on foo:22, retrying in 3 seconds"
           )
-        end.must_equal((300 / 3) - 1)
-        logged_output.string.lines.count do |l|
+        end).must_equal((300 / 3) - 1)
+
+        _(logged_output.string.lines.count do |l|
           l =~ debug_line_with("[SSH] connection failed ")
-        end.must_equal((300 / 3) - 1)
-        logged_output.string.lines.count do |l|
+        end).must_equal((300 / 3) - 1)
+
+        _(logged_output.string.lines.count do |l|
           l =~ warn_line_with("[SSH] connection failed, terminating ")
-        end.must_equal 1
+        end).must_equal 1
+
       end
 
       it "sleeps for 3 seconds between retries" do
@@ -1302,7 +1305,7 @@ describe Kitchen::Transport::Ssh::Connection do
       it "logger captures stdout" do
         assert_scripted { connection.wait_until_ready }
 
-        logged_output.string.must_match(/^\[SSH\] Established$/)
+        _(logged_output.string).must_match(/^\[SSH\] Established$/)
       end
     end
   end

--- a/spec/kitchen/transport/ssh_spec.rb
+++ b/spec/kitchen/transport/ssh_spec.rb
@@ -714,7 +714,7 @@ describe Kitchen::Transport::Ssh::Connection do
         end
 
         it "raises an SshFailed exception" do
-          e = _{ connection.execute("nope") }
+          e = _ { connection.execute("nope") }
             .must_raise Kitchen::Transport::SshFailed
 
           _(e.message).must_match regexify("SSH session could not be established")
@@ -915,7 +915,7 @@ describe Kitchen::Transport::Ssh::Connection do
       it "raises an SshFailed exception" do
         err = _ { assert_scripted { connection.execute("doit") } }
           .must_raise Kitchen::Transport::SshFailed
-          
+
         _(err.message).must_equal "SSH exited (42) for command: [doit]"
       end
 
@@ -1231,7 +1231,7 @@ describe Kitchen::Transport::Ssh::Connection do
       it "raises SshFailed when an SSH exception is raised" do
         conn.stubs(:scp).raises(Net::SSH::Exception)
 
-        e = _{ connection.download("nope", "fail") }
+        e = _ { connection.download("nope", "fail") }
           .must_raise Kitchen::Transport::SshFailed
 
         _(e.message).must_match regexify("SCP download failed")

--- a/spec/kitchen/transport/winrm_spec.rb
+++ b/spec/kitchen/transport/winrm_spec.rb
@@ -64,52 +64,52 @@ describe Kitchen::Transport::Winrm do
   end
 
   it "provisioner api_version is 1" do
-    transport.diagnose_plugin[:api_version].must_equal 1
+    _(transport.diagnose_plugin[:api_version]).must_equal 1
   end
 
   it "plugin_version is set to Kitchen::VERSION" do
-    transport.diagnose_plugin[:version].must_equal Kitchen::VERSION
+    _(transport.diagnose_plugin[:version]).must_equal Kitchen::VERSION
   end
 
   describe "default_config" do
     it "sets :scheme to http by default" do
-      transport[:scheme].must_equal "http"
+      _(transport[:scheme]).must_equal "http"
     end
 
     it "sets :port to 5985 by default" do
-      transport[:port].must_equal 5985
+      _(transport[:port]).must_equal 5985
     end
 
     it "sets :username to administrator by default" do
-      transport[:username].must_equal "administrator"
+      _(transport[:username]).must_equal "administrator"
     end
 
     it "sets :password to nil by default" do
-      transport[:password].must_be_nil
+      _(transport[:password]).must_be_nil
     end
 
     it "sets :rdp_port to 3389 by default" do
-      transport[:rdp_port].must_equal 3389
+      _(transport[:rdp_port]).must_equal 3389
     end
 
     it "sets :connection_retries to 5 by default" do
-      transport[:connection_retries].must_equal 5
+      _(transport[:connection_retries]).must_equal 5
     end
 
     it "sets :connection_retry_sleep to 1 by default" do
-      transport[:connection_retry_sleep].must_equal 1
+      _(transport[:connection_retry_sleep]).must_equal 1
     end
 
     it "sets :max_wait_until_ready to 600 by default" do
-      transport[:max_wait_until_ready].must_equal 600
+      _(transport[:max_wait_until_ready]).must_equal 600
     end
 
     it "sets :winrm_transport to :negotiate" do
-      transport[:winrm_transport].must_equal :negotiate
+      _(transport[:winrm_transport]).must_equal :negotiate
     end
 
     it "sets :elevated to false" do
-      transport[:elevated].must_equal false
+      _(transport[:elevated]).must_equal false
     end
   end
 
@@ -125,7 +125,7 @@ describe Kitchen::Transport::Winrm do
       end
 
       it "returns a Kitchen::Transport::Winrm::Connection object" do
-        transport.connection(state).must_be_kind_of klass
+        _(transport.connection(state)).must_be_kind_of klass
       end
 
       it "sets :instance_name to the instance's name" do
@@ -412,23 +412,23 @@ describe Kitchen::Transport::Winrm do
         first_connection  = make_connection(state)
         second_connection = make_connection(state)
 
-        first_connection.object_id.must_equal second_connection.object_id
+        _(first_connection.object_id).must_equal second_connection.object_id
       end
 
       it "logs a debug message when the connection is reused" do
         make_connection(state)
         make_connection(state)
 
-        logged_output.string.lines.count do |l|
+        _(logged_output.string.lines.count do |l|
           l =~ debug_line_with("[WinRM] reusing existing connection ")
-        end.must_equal 1
+        end).must_equal 1
       end
 
       it "returns a new connection when called again if state differs" do
         first_connection  = make_connection(state)
         second_connection = make_connection(state.merge(port: 9000))
 
-        first_connection.object_id.wont_equal second_connection.object_id
+        _(first_connection.object_id).wont_equal second_connection.object_id
       end
 
       it "closes first connection when a second is created" do
@@ -442,9 +442,9 @@ describe Kitchen::Transport::Winrm do
         make_connection(state)
         make_connection(state.merge(port: 9000))
 
-        logged_output.string.lines.count do |l|
+        _(logged_output.string.lines.count do |l|
           l =~ debug_line_with("[WinRM] shutting previous connection ")
-        end.must_equal 1
+        end).must_equal 1
       end
     end
     # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
@@ -609,16 +609,16 @@ describe Kitchen::Transport::Winrm do
     end
 
     it "returns true when the retryable exit codes are formatted in a nested array" do
-      connection.retry?(1, 2, [[35, 1]], exception).must_equal true
-      connection.retry?(2, 2, [[35, 1]], exception).must_equal true
+      _(connection.retry?(1, 2, [[35, 1]], exception)).must_equal true
+      _(connection.retry?(2, 2, [[35, 1]], exception)).must_equal true
     end
 
     describe "when exception is anything other than Kitchen::Transport::TransportFailed" do
       let(:exception) { RuntimeError.new("failure message") }
 
       it "returns false when the exception is anything other than Kitchen::Transport::TransportFailed" do
-        connection.retry?(1, 2, [35, 1], exception).must_equal false
-        connection.retry?(2, 2, [35, 1], exception).must_equal false
+        _(connection.retry?(1, 2, [35, 1], exception)).must_equal false
+        _(connection.retry?(2, 2, [35, 1], exception)).must_equal false
       end
     end
 
@@ -629,7 +629,7 @@ describe Kitchen::Transport::Winrm do
         let(:exception) { WinRM::WinRMHTTPTransportError.new("failure message", 400) }
 
         it "returns true" do
-          connection.retry?(1, 2, [35, 1], exception).must_equal true
+          _(connection.retry?(1, 2, [35, 1], exception)).must_equal true
         end
       end
 
@@ -637,7 +637,7 @@ describe Kitchen::Transport::Winrm do
         let(:exception) { WinRM::WinRMHTTPTransportError.new("failure message", 401) }
 
         it "returns false" do
-          connection.retry?(1, 2, [35, 1], exception).must_equal false
+          _(connection.retry?(1, 2, [35, 1], exception)).must_equal false
         end
       end
 
@@ -645,7 +645,7 @@ describe Kitchen::Transport::Winrm do
         let(:exception) { WinRM::WinRMHTTPTransportError.new("failure message", 500) }
 
         it "returns true" do
-          connection.retry?(1, 2, [35, 1], exception).must_equal true
+          _(connection.retry?(1, 2, [35, 1], exception)).must_equal true
         end
       end
     end
@@ -654,12 +654,12 @@ describe Kitchen::Transport::Winrm do
       let(:exception) { WinRM::WinRMWSManFault.new("failure message", 42) }
 
       it "returns true" do
-        connection.retry?(1, 2, [35, 1], exception).must_equal true
+        _(connection.retry?(1, 2, [35, 1], exception)).must_equal true
       end
     end
 
     it "returns false when the maximum retries have been exceeded" do
-      connection.retry?(3, 2, [35, 1], exception).must_equal false
+      _(connection.retry?(3, 2, [35, 1], exception)).must_equal false
     end
   end
 
@@ -698,7 +698,7 @@ describe Kitchen::Transport::Winrm do
       it "logs a message to debug that code will be loaded" do
         transport
 
-        logged_output.string.must_match debug_line_with(
+        _(logged_output.string).must_match debug_line_with(
           "winrm-fs requested, loading winrm-fs gem"
         )
       end
@@ -709,7 +709,7 @@ describe Kitchen::Transport::Winrm do
         transport.stubs(:require).with("winrm-fs").returns(true)
         transport.finalize_config!(instance)
 
-        logged_output.string.must_match(
+        _(logged_output.string).must_match(
           /winrm-fs is loaded/
         )
       end
@@ -720,7 +720,7 @@ describe Kitchen::Transport::Winrm do
         transport.stubs(:require).with("winrm-fs").returns(false)
         transport.finalize_config!(instance)
 
-        logged_output.string.must_match(
+        _(logged_output.string).must_match(
           /winrm-fs was already loaded/
         )
       end
@@ -736,7 +736,7 @@ describe Kitchen::Transport::Winrm do
           # we are interested in the log output, not this exception
         end
 
-        logged_output.string.must_match fatal_line_with(
+        _(logged_output.string).must_match fatal_line_with(
           "The `winrm-fs` gem is missing and must be installed"
         )
       end
@@ -747,10 +747,10 @@ describe Kitchen::Transport::Winrm do
         transport.stubs(:require).with("winrm-fs")
           .raises(LoadError, "uh oh")
 
-        err = proc do
-          transport.finalize_config!(instance)
-        end.must_raise Kitchen::UserError
-        err.message.must_match(/^Could not load or activate winrm-fs\. /)
+        err = _ { transport.finalize_config!(instance) }
+          .must_raise Kitchen::UserError
+
+        _(err.message).must_match(/^Could not load or activate winrm-fs\. /)
       end
     end
 
@@ -761,7 +761,7 @@ describe Kitchen::Transport::Winrm do
         transport.stubs(:require)
         transport.finalize_config!(instance)
 
-        logged_output.string.must_match debug_line_with(
+        _(logged_output.string).must_match debug_line_with(
           "winrm requested, loading winrm gem"
         )
       end
@@ -773,7 +773,7 @@ describe Kitchen::Transport::Winrm do
 
         transport.finalize_config!(instance)
 
-        logged_output.string.must_match(
+        _(logged_output.string).must_match(
           /winrm is loaded/
         )
       end
@@ -785,7 +785,7 @@ describe Kitchen::Transport::Winrm do
 
         transport.finalize_config!(instance)
 
-        logged_output.string.must_match(
+        _(logged_output.string).must_match(
           /winrm was already loaded/
         )
       end
@@ -800,7 +800,7 @@ describe Kitchen::Transport::Winrm do
           # we are interested in the log output, not this exception
         end
 
-        logged_output.string.must_match fatal_line_with(
+        _(logged_output.string).must_match fatal_line_with(
           "The `winrm` gem is missing and must be installed"
         )
       end
@@ -810,10 +810,10 @@ describe Kitchen::Transport::Winrm do
         transport.stubs(:require).with("winrm-fs", anything)
         transport.stubs(:require).raises(LoadError, "uh oh")
 
-        err = proc do
-          transport.finalize_config!(instance)
-        end.must_raise Kitchen::UserError
-        err.message.must_match(/^Could not load or activate winrm\. /)
+        err = _ { transport.finalize_config!(instance) }
+          .must_raise Kitchen::UserError
+
+        _(err.message).must_match(/^Could not load or activate winrm\. /)
       end
     end
   end
@@ -955,7 +955,7 @@ describe Kitchen::Transport::Winrm::Connection do
       it "logger displays command on debug" do
         connection.execute("doit")
 
-        logged_output.string.must_match debug_line(
+        _(logged_output.string).must_match debug_line(
           "[WinRM] #{info} (doit)"
         )
       end
@@ -963,21 +963,21 @@ describe Kitchen::Transport::Winrm::Connection do
       it "logger captures stdout" do
         connection.execute("doit")
 
-        logged_output.string.must_match(/^ok$/)
+        _(logged_output.string).must_match(/^ok$/)
       end
 
       it "logger captures stderr on warn if logger is at debug level" do
         logger.level = Logger::DEBUG
         connection.execute("doit")
 
-        logged_output.string.must_match warn_line("congrats")
+        _(logged_output.string).must_match warn_line("congrats")
       end
 
       it "logger does not log stderr on warn if logger is below debug level" do
         logger.level = Logger::INFO
         connection.execute("doit")
 
-        logged_output.string.wont_match warn_line("congrats")
+        _(logged_output.string).wont_match warn_line("congrats")
       end
     end
 
@@ -1025,7 +1025,7 @@ describe Kitchen::Transport::Winrm::Connection do
         it "logger captures stdout" do
           connection.execute("doit")
 
-          logged_output.string.must_match(/^ok$/)
+          _(logged_output.string).must_match(/^ok$/)
         end
       end
 
@@ -1046,7 +1046,7 @@ describe Kitchen::Transport::Winrm::Connection do
         it "logger captures stdout" do
           connection.execute("doit")
 
-          logged_output.string.must_match(/^ok$/)
+          _(logged_output.string).must_match(/^ok$/)
         end
       end
     end
@@ -1092,7 +1092,7 @@ describe Kitchen::Transport::Winrm::Connection do
             # the raise is not what is being tested here, rather its side-effect
           end
 
-          logged_output.string.must_match debug_line(
+          _(logged_output.string).must_match debug_line(
             "[WinRM] #{info} (doit)"
           )
         end
@@ -1104,7 +1104,7 @@ describe Kitchen::Transport::Winrm::Connection do
             # the raise is not what is being tested here, rather its side-effect
           end
 
-          logged_output.string.must_match(/^nope$/)
+          _(logged_output.string).must_match(/^nope$/)
         end
 
         it "stderr is printed on logger warn level" do
@@ -1127,7 +1127,7 @@ describe Kitchen::Transport::Winrm::Connection do
           MSG
 
           message.lines.each do |line|
-            logged_output.string.must_match warn_line(line.chomp)
+            _(logged_output.string).must_match warn_line(line.chomp)
           end
         end
       end
@@ -1137,16 +1137,16 @@ describe Kitchen::Transport::Winrm::Connection do
         common_failed_command_specs
 
         it "raises a WinrmFailed exception" do
-          err = proc do
-            connection.execute("doit")
-          end.must_raise Kitchen::Transport::WinrmFailed
-          err.message.must_equal "WinRM exited (1) for command: [doit]"
+          err = _ { connection.execute("doit") }
+            .must_raise Kitchen::Transport::WinrmFailed
+
+          _(err.message).must_equal "WinRM exited (1) for command: [doit]"
         end
 
         it "raises WinrmFailed exception with the exit code of the failure" do
           connection.execute("doit")
         rescue Kitchen::Transport::WinrmFailed => e
-          e.exit_code.must_equal 1
+          _(e.exit_code).must_equal 1
         end
       end
     end
@@ -1156,7 +1156,7 @@ describe Kitchen::Transport::Winrm::Connection do
         executor.expects(:open).never
         connection.execute(nil)
 
-        logged_output.string.must_equal ""
+        _(logged_output.string).must_equal ""
       end
     end
 
@@ -1204,7 +1204,7 @@ describe Kitchen::Transport::Winrm::Connection do
       it "returns a LoginCommand" do
         with_fake_fs do
           FileUtils.mkdir_p(File.dirname(rdp_doc))
-          login_command.must_be_instance_of Kitchen::LoginCommand
+          _(login_command).must_be_instance_of Kitchen::LoginCommand
         end
       end
 
@@ -1216,7 +1216,7 @@ describe Kitchen::Transport::Winrm::Connection do
           actual = IO.read(rdp_doc)
         end
 
-        actual.must_equal Kitchen::Util.outdent!(<<-RDP)
+        _(actual).must_equal Kitchen::Util.outdent!(<<-RDP)
           drivestoredirect:s:*
           full address:s:foo:rdpyeah
           prompt for credentials:i:1
@@ -1239,7 +1239,7 @@ describe Kitchen::Transport::Winrm::Connection do
           username:s:me
           ------------
         OUTPUT
-        debug_output(logged_output.string).must_match expected
+        _(debug_output(logged_output.string)).must_match expected
       end
 
       it "returns a LoginCommand which calls open on the rdp document" do
@@ -1249,7 +1249,7 @@ describe Kitchen::Transport::Winrm::Connection do
           actual = login_command
         end
 
-        actual.exec_args.must_equal ["open", rdp_doc, {}]
+        _(actual.exec_args).must_equal ["open", rdp_doc, {}]
       end
     end
 
@@ -1261,7 +1261,7 @@ describe Kitchen::Transport::Winrm::Connection do
       it "returns a LoginCommand" do
         with_fake_fs do
           FileUtils.mkdir_p(File.dirname(rdp_doc))
-          login_command.must_be_instance_of Kitchen::LoginCommand
+          _(login_command).must_be_instance_of Kitchen::LoginCommand
         end
       end
 
@@ -1273,7 +1273,7 @@ describe Kitchen::Transport::Winrm::Connection do
           actual = IO.read(rdp_doc)
         end
 
-        actual.must_equal Kitchen::Util.outdent!(<<-RDP)
+        _(actual).must_equal Kitchen::Util.outdent!(<<-RDP)
           full address:s:foo:rdpyeah
           prompt for credentials:i:1
           username:s:me
@@ -1294,7 +1294,7 @@ describe Kitchen::Transport::Winrm::Connection do
           username:s:me
           ------------
         OUTPUT
-        debug_output(logged_output.string).must_match expected
+        _(debug_output(logged_output.string)).must_match expected
       end
 
       it "returns a LoginCommand which calls mstsc on the rdp document" do
@@ -1304,7 +1304,7 @@ describe Kitchen::Transport::Winrm::Connection do
           actual = login_command
         end
 
-        actual.exec_args.must_equal ["mstsc", rdp_doc, {}]
+        _(actual.exec_args).must_equal ["mstsc", rdp_doc, {}]
       end
     end
 
@@ -1315,26 +1315,26 @@ describe Kitchen::Transport::Winrm::Connection do
       end
 
       it "returns a LoginCommand" do
-        login_command.must_be_instance_of Kitchen::LoginCommand
+        _(login_command).must_be_instance_of Kitchen::LoginCommand
       end
 
       it "is an xfreerdp command" do
-        login_command.command.must_equal "/usr/bin/xfreerdp"
-        args.must_match(%r{ /cert-tofu$})
+        _(login_command.command).must_equal "/usr/bin/xfreerdp"
+        _(args).must_match(%r{ /cert-tofu$})
       end
 
       it "sets the user" do
-        args.must_match regexify("/u:me ")
+        _(args).must_match regexify("/u:me ")
       end
 
       it "sets the pass if given" do
-        args.must_match regexify(" /p:haha ")
+        _(args).must_match regexify(" /p:haha ")
       end
 
       it "won't set the pass if not given" do
         options.delete(:password)
 
-        args.wont_match regexify(" /p:haha ")
+        _(args).wont_match regexify(" /p:haha ")
       end
 
       describe "xfreerdp binary not found in path" do
@@ -1345,7 +1345,7 @@ describe Kitchen::Transport::Winrm::Connection do
 
         it "raises an WinrmFailed error" do
           err = _ { login_command }.must_raise Kitchen::Transport::WinrmFailed
-          err.message.must_equal "xfreerdp binary not found. Please install freerdp2-x11 on Debian-based systems or freerdp on Redhat-based systems."
+          _(err.message).must_equal "xfreerdp binary not found. Please install freerdp2-x11 on Debian-based systems or freerdp on Redhat-based systems."
         end
       end
     end
@@ -1357,7 +1357,7 @@ describe Kitchen::Transport::Winrm::Connection do
 
       it "raises an ActionFailed error" do
         err = _ { login_command }.must_raise Kitchen::ActionFailed
-        err.message.must_equal "Remote login not supported in " \
+        _(err.message).must_equal "Remote login not supported in " \
           "Kitchen::Transport::Winrm::Connection from host OS 'cray'."
       end
     end
@@ -1451,10 +1451,10 @@ describe Kitchen::Transport::Winrm::Connection do
       end
 
       it "executes an empty command string to ensure working" do
-        err = proc do
-          connection.wait_until_ready
-        end.must_raise Kitchen::Transport::WinrmFailed
-        err.message.must_equal "WinRM exited (42) for command: " \
+        err = _ { connection.wait_until_ready }
+          .must_raise Kitchen::Transport::WinrmFailed
+
+        _(err.message).must_equal "WinRM exited (42) for command: " \
           "[Write-Host '[WinRM] Established\n']"
       end
 
@@ -1465,7 +1465,7 @@ describe Kitchen::Transport::Winrm::Connection do
           # the raise is not what is being tested here, rather its side-effect
         end
 
-        logged_output.string.must_match warn_line("Ah crap.\n")
+        _(logged_output.string).must_match warn_line("Ah crap.\n")
       end
     end
 
@@ -1477,9 +1477,7 @@ describe Kitchen::Transport::Winrm::Connection do
       end
 
       it "fails with SSL error" do
-        proc do
-          connection.wait_until_ready
-        end.must_raise OpenSSL::SSL::SSLError
+        _ { connection.wait_until_ready }.must_raise OpenSSL::SSL::SSLError
       end
     end
 
@@ -1493,9 +1491,7 @@ describe Kitchen::Transport::Winrm::Connection do
       end
 
       it "fails with SSL error" do
-        proc do
-          connection.wait_until_ready
-        end.must_raise OpenSSL::SSL::SSLError
+        _ { connection.wait_until_ready }.must_raise OpenSSL::SSL::SSLError
       end
     end
   end


### PR DESCRIPTION
# Description

Fix MiniTest deprecations in transport specs

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
