### PR TITLE
update debug logs to mask password

### DIFF
--- a/lib/kitchen/ssh.rb
+++ b/lib/kitchen/ssh.rb
@@ -76,7 +76,9 @@ module Kitchen
     # @param cmd [String] command string to execute
     # @raise [SSHFailed] if the command does not exit with a 0 code
     def exec(cmd)
-      logger.debug("[SSH] #{Util.mask_values(self, %w{password ssh_http_proxy_password})} (#{cmd})")
+      string_to_mask = "[SSH] #{self} (#{cmd})"
+      masked_string = Util.mask_values(string_to_mask, %w{password ssh_http_proxy_password})
+      logger.debug(masked_string)
       exit_code = exec_with_exit(cmd)
 
       if exit_code != 0
@@ -138,7 +140,9 @@ module Kitchen
     def shutdown
       return if @session.nil?
 
-      logger.debug("[SSH] closing connection to #{Util.mask_values(self, %w{password ssh_http_proxy_password})}")
+      string_to_mask = "[SSH] closing connection to #{self}"
+      masked_string = Util.mask_values(string_to_mask, %w{password ssh_http_proxy_password})
+      logger.debug(masked_string)
       session.shutdown!
     ensure
       @session = nil
@@ -213,7 +217,9 @@ module Kitchen
       retries = options[:ssh_retries] || 3
 
       begin
-        logger.debug("[SSH] opening connection to #{Util.mask_values(self, %w{password ssh_http_proxy_password})}")
+        string_to_mask = "[SSH] opening connection to #{self}"
+        masked_string = Util.mask_values(string_to_mask, %w{password ssh_http_proxy_password})
+        logger.debug(masked_string)
         Net::SSH.start(hostname, username, options)
       rescue *rescue_exceptions => e
         retries -= 1

--- a/lib/kitchen/ssh.rb
+++ b/lib/kitchen/ssh.rb
@@ -76,7 +76,7 @@ module Kitchen
     # @param cmd [String] command string to execute
     # @raise [SSHFailed] if the command does not exit with a 0 code
     def exec(cmd)
-      logger.debug("[SSH] #{Util.attributes(self).except(:password, :ssh_http_proxy_password)} (#{cmd})")
+      logger.debug("[SSH] #{Util.mask_values(self, %w{password ssh_http_proxy_password})} (#{cmd})")
       exit_code = exec_with_exit(cmd)
 
       if exit_code != 0
@@ -138,7 +138,7 @@ module Kitchen
     def shutdown
       return if @session.nil?
 
-      logger.debug("[SSH] closing connection to #{Util.attributes(self).except(:password, :ssh_http_proxy_password)}")
+      logger.debug("[SSH] closing connection to #{Util.mask_values(self, %w{password ssh_http_proxy_password})}")
       session.shutdown!
     ensure
       @session = nil
@@ -213,7 +213,7 @@ module Kitchen
       retries = options[:ssh_retries] || 3
 
       begin
-        logger.debug("[SSH] opening connection to #{Util.attributes(self).except(:password, :ssh_http_proxy_password)}")
+        logger.debug("[SSH] opening connection to #{Util.mask_values(self, %w{password ssh_http_proxy_password})}")
         Net::SSH.start(hostname, username, options)
       rescue *rescue_exceptions => e
         retries -= 1

--- a/lib/kitchen/ssh.rb
+++ b/lib/kitchen/ssh.rb
@@ -23,6 +23,7 @@ require "socket" unless defined?(Socket)
 
 require_relative "errors"
 require_relative "login_command"
+require_relative "util"
 
 module Kitchen
   # Wrapped exception for any internally raised SSH-related errors.
@@ -75,7 +76,7 @@ module Kitchen
     # @param cmd [String] command string to execute
     # @raise [SSHFailed] if the command does not exit with a 0 code
     def exec(cmd)
-      logger.debug("[SSH] #{self} (#{cmd})")
+      logger.debug("[SSH] #{Util.attributes(self).except(:password, :ssh_http_proxy_password)} (#{cmd})")
       exit_code = exec_with_exit(cmd)
 
       if exit_code != 0
@@ -137,7 +138,7 @@ module Kitchen
     def shutdown
       return if @session.nil?
 
-      logger.debug("[SSH] closing connection to #{self}")
+      logger.debug("[SSH] closing connection to #{Util.attributes(self).except(:password, :ssh_http_proxy_password)}")
       session.shutdown!
     ensure
       @session = nil
@@ -212,7 +213,7 @@ module Kitchen
       retries = options[:ssh_retries] || 3
 
       begin
-        logger.debug("[SSH] opening connection to #{self}")
+        logger.debug("[SSH] opening connection to #{Util.attributes(self).except(:password, :ssh_http_proxy_password)}")
         Net::SSH.start(hostname, username, options)
       rescue *rescue_exceptions => e
         retries -= 1

--- a/lib/kitchen/transport/ssh.rb
+++ b/lib/kitchen/transport/ssh.rb
@@ -103,7 +103,7 @@ module Kitchen
       # (see Base#cleanup!)
       def cleanup!
         if @connection
-          logger.debug("[SSH] shutting previous connection #{Util.mask_values(@connection, ['password', 'ssh_http_proxy_password'])}")
+          logger.debug("[SSH] shutting previous connection #{Util.mask_values(@connection, %w{password ssh_http_proxy_password})}")
           @connection.close
           @connection = @connection_options = nil
         end
@@ -126,7 +126,7 @@ module Kitchen
         def close
           return if @session.nil?
 
-          logger.debug("[SSH] closing connection to #{Util.mask_values(self, ['password', 'ssh_http_proxy_password'])}")
+          logger.debug("[SSH] closing connection to #{Util.mask_values(self, %w{password ssh_http_proxy_password})}")
           session.close
         ensure
           @session = nil
@@ -136,7 +136,7 @@ module Kitchen
         def execute(command)
           return if command.nil?
 
-          logger.debug("[SSH] #{Util.mask_values(self, ['password', 'ssh_http_proxy_password'])} (#{command})")
+          logger.debug("[SSH] #{Util.mask_values(self, %w{password ssh_http_proxy_password})} (#{command})")
           exit_code = execute_with_exit_code(command)
 
           if exit_code != 0
@@ -351,7 +351,7 @@ module Kitchen
         # @return [Net::SSH::Connection::Session] the SSH connection session
         # @api private
         def retry_connection(opts)
-          log_msg = "[SSH] opening connection to #{Util.mask_values(self, ['password', 'ssh_http_proxy_password'])}}"
+          log_msg = "[SSH] opening connection to #{Util.mask_values(self, %w{password ssh_http_proxy_password})}}"
           log_msg += " via #{ssh_gateway_username}@#{ssh_gateway}:#{ssh_gateway_port}" if ssh_gateway
           logger.debug(log_msg)
           yield
@@ -556,7 +556,7 @@ module Kitchen
       # @return [Ssh::Connection] an SSH Connection instance
       # @api private
       def reuse_connection
-        logger.debug("[SSH] reusing existing connection #{Util.mask_values(@connection, ['password', 'ssh_http_proxy_password'])}")
+        logger.debug("[SSH] reusing existing connection #{Util.mask_values(@connection, %w{password ssh_http_proxy_password})}")
         yield @connection if block_given?
         @connection
       end

--- a/lib/kitchen/transport/ssh.rb
+++ b/lib/kitchen/transport/ssh.rb
@@ -103,7 +103,9 @@ module Kitchen
       # (see Base#cleanup!)
       def cleanup!
         if @connection
-          logger.debug("[SSH] shutting previous connection #{Util.mask_values(@connection, %w{password ssh_http_proxy_password})}")
+          string_to_mask = "[SSH] shutting previous connection #{@connection}"
+          masked_string = Util.mask_values(string_to_mask, %w{password ssh_http_proxy_password})
+          logger.debug(masked_string)
           @connection.close
           @connection = @connection_options = nil
         end
@@ -126,7 +128,9 @@ module Kitchen
         def close
           return if @session.nil?
 
-          logger.debug("[SSH] closing connection to #{Util.mask_values(self, %w{password ssh_http_proxy_password})}")
+          string_to_mask = "[SSH] closing connection to #{self}"
+          masked_string = Util.mask_values(string_to_mask, %w{password ssh_http_proxy_password})
+          logger.debug(masked_string)
           session.close
         ensure
           @session = nil
@@ -136,7 +140,9 @@ module Kitchen
         def execute(command)
           return if command.nil?
 
-          logger.debug("[SSH] #{Util.mask_values(self, %w{password ssh_http_proxy_password})} (#{command})")
+          string_to_mask = "[SSH] #{self} (#{command})"
+          masked_string = Util.mask_values(string_to_mask, %w{password ssh_http_proxy_password})
+          logger.debug(masked_string)
           exit_code = execute_with_exit_code(command)
 
           if exit_code != 0
@@ -351,9 +357,11 @@ module Kitchen
         # @return [Net::SSH::Connection::Session] the SSH connection session
         # @api private
         def retry_connection(opts)
-          log_msg = "[SSH] opening connection to #{Util.mask_values(self, %w{password ssh_http_proxy_password})}}"
+          log_msg = "[SSH] opening connection to #{self}"
           log_msg += " via #{ssh_gateway_username}@#{ssh_gateway}:#{ssh_gateway_port}" if ssh_gateway
-          logger.debug(log_msg)
+          masked_string = Util.mask_values(log_msg, %w{password ssh_http_proxy_password})
+
+          logger.debug(masked_string)
           yield
         rescue *RESCUE_EXCEPTIONS_ON_ESTABLISH => e
           if (opts[:retries] -= 1) > 0
@@ -445,7 +453,7 @@ module Kitchen
         #
         # @api private
         def to_s
-          "#{username}@#{hostname}<#{options}>"
+          "#{username}@#{hostname}<#{options.inspect}>"
         end
       end
 
@@ -542,7 +550,7 @@ module Kitchen
       # Creates a new SSH Connection instance and save it for potential future
       # reuse.
       #
-      # @param options [Hash] conneciton options
+      # @param options [Hash] connection options
       # @return [Ssh::Connection] an SSH Connection instance
       # @api private
       def create_new_connection(options, &block)
@@ -556,7 +564,9 @@ module Kitchen
       # @return [Ssh::Connection] an SSH Connection instance
       # @api private
       def reuse_connection
-        logger.debug("[SSH] reusing existing connection #{Util.mask_values(@connection, %w{password ssh_http_proxy_password})}")
+        string_to_mask = "[SSH] reusing existing connection #{@connection}"
+        masked_string = Util.mask_values(string_to_mask, %w{password ssh_http_proxy_password})
+        logger.debug(masked_string)
         yield @connection if block_given?
         @connection
       end

--- a/lib/kitchen/transport/ssh.rb
+++ b/lib/kitchen/transport/ssh.rb
@@ -16,6 +16,7 @@
 # limitations under the License.
 
 require_relative "../../kitchen"
+require_relative "../util"
 
 require "fileutils" unless defined?(FileUtils)
 require "net/ssh" unless defined?(Net::SSH)
@@ -102,7 +103,7 @@ module Kitchen
       # (see Base#cleanup!)
       def cleanup!
         if @connection
-          logger.debug("[SSH] shutting previous connection #{@connection}")
+          logger.debug("[SSH] shutting previous connection #{Util.mask_values(@connection, ['password', 'ssh_http_proxy_password'])}")
           @connection.close
           @connection = @connection_options = nil
         end
@@ -125,7 +126,7 @@ module Kitchen
         def close
           return if @session.nil?
 
-          logger.debug("[SSH] closing connection to #{self}")
+          logger.debug("[SSH] closing connection to #{Util.mask_values(self, ['password', 'ssh_http_proxy_password'])}")
           session.close
         ensure
           @session = nil
@@ -135,7 +136,7 @@ module Kitchen
         def execute(command)
           return if command.nil?
 
-          logger.debug("[SSH] #{self} (#{command})")
+          logger.debug("[SSH] #{Util.mask_values(self, ['password', 'ssh_http_proxy_password'])} (#{command})")
           exit_code = execute_with_exit_code(command)
 
           if exit_code != 0
@@ -350,7 +351,7 @@ module Kitchen
         # @return [Net::SSH::Connection::Session] the SSH connection session
         # @api private
         def retry_connection(opts)
-          log_msg = "[SSH] opening connection to #{self}"
+          log_msg = "[SSH] opening connection to #{Util.mask_values(self, ['password', 'ssh_http_proxy_password'])}}"
           log_msg += " via #{ssh_gateway_username}@#{ssh_gateway}:#{ssh_gateway_port}" if ssh_gateway
           logger.debug(log_msg)
           yield
@@ -444,7 +445,7 @@ module Kitchen
         #
         # @api private
         def to_s
-          "#{username}@#{hostname}<#{options.inspect}>"
+          "#{username}@#{hostname}<#{options}>"
         end
       end
 
@@ -555,7 +556,7 @@ module Kitchen
       # @return [Ssh::Connection] an SSH Connection instance
       # @api private
       def reuse_connection
-        logger.debug("[SSH] reusing existing connection #{@connection}")
+        logger.debug("[SSH] reusing existing connection #{Util.mask_values(@connection, ['password', 'ssh_http_proxy_password'])}")
         yield @connection if block_given?
         @connection
       end

--- a/lib/kitchen/transport/winrm.rb
+++ b/lib/kitchen/transport/winrm.rb
@@ -105,7 +105,9 @@ module Kitchen
         def execute(command)
           return if command.nil?
 
-          logger.debug("[WinRM] #{Util.mask_values(self, %w{password ssh_http_proxy_password})} (#{command})")
+          string_to_mask = "[WinRM] #{self} (#{command})"
+          masked_string = Util.mask_values(string_to_mask, %w{password ssh_http_proxy_password})
+          logger.debug(masked_string)
 
           exit_code, stderr = execute_with_exit_code(command)
 
@@ -412,7 +414,7 @@ module Kitchen
         #
         # @api private
         def to_s
-          "<#{options}>"
+          "<#{options.inspect}>"
         end
       end
 
@@ -495,12 +497,14 @@ module Kitchen
       # Creates a new WinRM Connection instance and save it for potential
       # future reuse.
       #
-      # @param options [Hash] conneciton options
+      # @param options [Hash] connection options
       # @return [Ssh::Connection] a WinRM Connection instance
       # @api private
       def create_new_connection(options, &block)
         if @connection
-          logger.debug("[WinRM] shutting previous connection #{Util.mask_values(@connection, %w{password ssh_http_proxy_password})}")
+          string_to_mask = "[WinRM] shutting previous connection #{@connection}"
+          masked_string = Util.mask_values(string_to_mask, %w{password ssh_http_proxy_password})
+          logger.debug(masked_string)
           @connection.close
         end
 
@@ -560,7 +564,9 @@ module Kitchen
       # @return [Winrm::Connection] a WinRM Connection instance
       # @api private
       def reuse_connection
-        logger.debug("[WinRM] reusing existing connection #{Util.mask_values(@connection, %w{password ssh_http_proxy_password})}")
+        string_to_mask = "[WinRM] reusing existing connection #{@connection}"
+        masked_string = Util.mask_values(string_to_mask, %w{password ssh_http_proxy_password})
+        logger.debug(masked_string)
         yield @connection if block_given?
         @connection
       end

--- a/lib/kitchen/transport/winrm.rb
+++ b/lib/kitchen/transport/winrm.rb
@@ -20,6 +20,7 @@
 require "rbconfig" unless defined?(RbConfig)
 require "uri" unless defined?(URI)
 require_relative "../../kitchen"
+require_relative "../util"
 require "winrm" unless defined?(WinRM::Connection)
 require "winrm/exceptions" unless defined?(WinRM::WinRMHTTPTransportError)
 
@@ -104,7 +105,7 @@ module Kitchen
         def execute(command)
           return if command.nil?
 
-          logger.debug("[WinRM] #{self} (#{command})")
+          logger.debug("[WinRM] #{Util.mask_values(self, ['password', 'ssh_http_proxy_password'])} (#{command})")
 
           exit_code, stderr = execute_with_exit_code(command)
 
@@ -411,7 +412,7 @@ module Kitchen
         #
         # @api private
         def to_s
-          "<#{options.inspect}>"
+          "<#{options}>"
         end
       end
 
@@ -499,7 +500,7 @@ module Kitchen
       # @api private
       def create_new_connection(options, &block)
         if @connection
-          logger.debug("[WinRM] shutting previous connection #{@connection}")
+          logger.debug("[WinRM] shutting previous connection #{Util.mask_values(@connection, ['password', 'ssh_http_proxy_password'])}")
           @connection.close
         end
 
@@ -559,7 +560,7 @@ module Kitchen
       # @return [Winrm::Connection] a WinRM Connection instance
       # @api private
       def reuse_connection
-        logger.debug("[WinRM] reusing existing connection #{@connection}")
+        logger.debug("[WinRM] reusing existing connection #{Util.mask_values(@connection, ['password', 'ssh_http_proxy_password'])}")
         yield @connection if block_given?
         @connection
       end

--- a/lib/kitchen/transport/winrm.rb
+++ b/lib/kitchen/transport/winrm.rb
@@ -105,7 +105,7 @@ module Kitchen
         def execute(command)
           return if command.nil?
 
-          logger.debug("[WinRM] #{Util.mask_values(self, ['password', 'ssh_http_proxy_password'])} (#{command})")
+          logger.debug("[WinRM] #{Util.mask_values(self, %w{password ssh_http_proxy_password})} (#{command})")
 
           exit_code, stderr = execute_with_exit_code(command)
 
@@ -500,7 +500,7 @@ module Kitchen
       # @api private
       def create_new_connection(options, &block)
         if @connection
-          logger.debug("[WinRM] shutting previous connection #{Util.mask_values(@connection, ['password', 'ssh_http_proxy_password'])}")
+          logger.debug("[WinRM] shutting previous connection #{Util.mask_values(@connection, %w{password ssh_http_proxy_password})}")
           @connection.close
         end
 
@@ -560,7 +560,7 @@ module Kitchen
       # @return [Winrm::Connection] a WinRM Connection instance
       # @api private
       def reuse_connection
-        logger.debug("[WinRM] reusing existing connection #{Util.mask_values(@connection, ['password', 'ssh_http_proxy_password'])}")
+        logger.debug("[WinRM] reusing existing connection #{Util.mask_values(@connection, %w{password ssh_http_proxy_password})}")
         yield @connection if block_given?
         @connection
       end

--- a/lib/kitchen/util.rb
+++ b/lib/kitchen/util.rb
@@ -88,16 +88,6 @@ module Kitchen
       end
     end
 
-    # Returns a new Hash with an object's attributes as key, value pairs.
-    #
-    # @param obj [Object] the object to be processed
-    # @return [Hash] a hash with instance properties as key, value pairs
-    def self.attributes(obj)
-      hash = {}
-      obj.instance_variables.each { |var| hash[var.to_s.delete("@")] = obj.instance_variable_get(var) }
-      hash
-    end
-
     # Returns a string with masked values for specified parameters.
     #
     # @param obj [Object] the object whose string representation is parsed

--- a/lib/kitchen/util.rb
+++ b/lib/kitchen/util.rb
@@ -88,6 +88,29 @@ module Kitchen
       end
     end
 
+    # Returns a new Hash with an object's attributes as key, value pairs.
+    #
+    # @param obj [Object] the object to be processed
+    # @return [Hash] a hash with instance properties as key, value pairs
+    def self.attributes(obj)
+      hash = {}
+      obj.instance_variables.each { |var| hash[var.to_s.delete("@")] = obj.instance_variable_get(var) }
+      return hash
+    end
+
+    # Returns a string with masked values for specified parameters.
+    #
+    # @param obj [Object] the object whose string representation is parsed
+    # @param [Array] the list of keys whose values should be masked
+    # @return [String] the string representation of passed object with masked values
+    def self.mask_values(obj, keys)
+      mask_conn = "#{obj}"
+      for key in keys do
+        mask_conn.gsub!(/:#{key}=>"([^"]*)"/, %{:#{key}=>"******"})
+      end
+      return mask_conn
+    end
+
     # Returns a formatted string representing a duration in seconds.
     #
     # @param total [Integer] the total number of seconds

--- a/lib/kitchen/util.rb
+++ b/lib/kitchen/util.rb
@@ -95,7 +95,7 @@ module Kitchen
     def self.attributes(obj)
       hash = {}
       obj.instance_variables.each { |var| hash[var.to_s.delete("@")] = obj.instance_variable_get(var) }
-      return hash
+      hash
     end
 
     # Returns a string with masked values for specified parameters.
@@ -105,10 +105,10 @@ module Kitchen
     # @return [String] the string representation of passed object with masked values
     def self.mask_values(obj, keys)
       mask_conn = "#{obj}"
-      for key in keys do
+      keys.each do |key|
         mask_conn.gsub!(/:#{key}=>"([^"]*)"/, %{:#{key}=>"******"})
       end
-      return mask_conn
+      mask_conn
     end
 
     # Returns a formatted string representing a duration in seconds.

--- a/lib/kitchen/util.rb
+++ b/lib/kitchen/util.rb
@@ -90,15 +90,15 @@ module Kitchen
 
     # Returns a string with masked values for specified parameters.
     #
-    # @param obj [Object] the object whose string representation is parsed
+    # @param string_to_mask [String] the object whose string representation is parsed
     # @param [Array] the list of keys whose values should be masked
     # @return [String] the string representation of passed object with masked values
-    def self.mask_values(obj, keys)
-      mask_conn = "#{obj}"
+    def self.mask_values(string_to_mask, keys)
+      masked_string = string_to_mask
       keys.each do |key|
-        mask_conn.gsub!(/:#{key}=>"([^"]*)"/, %{:#{key}=>"******"})
+        masked_string.gsub!(/:#{key}=>"([^"]*)"/, %{:#{key}=>"******"})
       end
-      mask_conn
+      masked_string
     end
 
     # Returns a formatted string representing a duration in seconds.

--- a/spec/kitchen/transport/winrm_spec.rb
+++ b/spec/kitchen/transport/winrm_spec.rb
@@ -1094,7 +1094,7 @@ describe Kitchen::Transport::Winrm::Connection do
           end
 
           _(logged_output.string).must_match debug_line(
-            "[WinRM] #{info} (doit)"
+            "[WinRM] #{Util.mask_values(info, %w{password ssh_http_proxy_password})} (doit)"
           )
         end
 

--- a/spec/kitchen/transport/winrm_spec.rb
+++ b/spec/kitchen/transport/winrm_spec.rb
@@ -16,6 +16,7 @@
 # limitations under the License.
 
 require_relative "../../spec_helper"
+require_relative "../../../lib/kitchen/util"
 
 require "kitchen/transport/winrm"
 require "winrm"
@@ -956,7 +957,7 @@ describe Kitchen::Transport::Winrm::Connection do
         connection.execute("doit")
 
         _(logged_output.string).must_match debug_line(
-          "[WinRM] #{info} (doit)"
+          "[WinRM] #{Util.mask_values(info, %w{password ssh_http_proxy_password})} (doit)"
         )
       end
 

--- a/spec/kitchen/transport/winrm_spec.rb
+++ b/spec/kitchen/transport/winrm_spec.rb
@@ -16,7 +16,6 @@
 # limitations under the License.
 
 require_relative "../../spec_helper"
-require_relative "../../../lib/kitchen/util"
 
 require "kitchen/transport/winrm"
 require "winrm"
@@ -957,7 +956,7 @@ describe Kitchen::Transport::Winrm::Connection do
         connection.execute("doit")
 
         _(logged_output.string).must_match debug_line(
-          "[WinRM] #{Util.mask_values(info, %w{password ssh_http_proxy_password})} (doit)"
+          "[WinRM] #{Kitchen::Util.mask_values(info, %w{password ssh_http_proxy_password})} (doit)"
         )
       end
 
@@ -1094,7 +1093,7 @@ describe Kitchen::Transport::Winrm::Connection do
           end
 
           _(logged_output.string).must_match debug_line(
-            "[WinRM] #{Util.mask_values(info, %w{password ssh_http_proxy_password})} (doit)"
+            "[WinRM] #{Kitchen::Util.mask_values(info, %w{password ssh_http_proxy_password})} (doit)"
           )
         end
 

--- a/spec/kitchen/transport/winrm_spec.rb
+++ b/spec/kitchen/transport/winrm_spec.rb
@@ -955,8 +955,11 @@ describe Kitchen::Transport::Winrm::Connection do
       it "logger displays command on debug" do
         connection.execute("doit")
 
+        string_to_mask = "[WinRM] #{info} (doit)"
+        masked_string = Kitchen::Util.mask_values(string_to_mask, %w{password ssh_http_proxy_password})
+
         _(logged_output.string).must_match debug_line(
-          "[WinRM] #{Kitchen::Util.mask_values(info, %w{password ssh_http_proxy_password})} (doit)"
+          masked_string
         )
       end
 
@@ -1092,8 +1095,11 @@ describe Kitchen::Transport::Winrm::Connection do
             # the raise is not what is being tested here, rather its side-effect
           end
 
+          string_to_mask = "[WinRM] #{info} (doit)"
+          masked_string = Kitchen::Util.mask_values(string_to_mask, %w{password ssh_http_proxy_password})
+
           _(logged_output.string).must_match debug_line(
-            "[WinRM] #{Kitchen::Util.mask_values(info, %w{password ssh_http_proxy_password})} (doit)"
+            masked_string
           )
         end
 


### PR DESCRIPTION
Signed-off-by: Vikram Karve <vikram.karve@progress.com>

# Description

The transport debug logs include password in cleartext. The password have either been omitted or masked in the log.

## Type of Change

Our release process assumes you are using [Conventional Commit messages](https://www.conventionalcommits.org/en/v1.0.0/).

The most important prefixes you should have in mind are:

- `_fix_`: which represents bug fixes, and correlates to a SemVer patch.
- `_feat_`: which represents a new feature, and correlates to a SemVer minor.
- `_feat!_`:, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the !) and will result in a major version change.

If you have not included a conventional commit message this can be fixed on merge.

## Check List

- [ ] New functionality includes tests
- [x] All tests pass
- [x] Commit message includes a [Conventional Commit Message](https://www.conventionalcommits.org/en/v1.0.0)
