### PR TITLE
chore: bump net-ssh

### DIFF
--- a/test-kitchen.gemspec
+++ b/test-kitchen.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "mixlib-shellout",    ">= 1.2", "< 4.0"
   gem.add_dependency "net-scp",            ">= 1.1", "< 4.0" # pinning until we can confirm 4+ works
-  gem.add_dependency "net-ssh",            ">= 2.9", "< 7.0" # pinning until we can confirm 7+ works
+  gem.add_dependency "net-ssh",            ">= 2.9", "< 8.0" # pinning until we can confirm 8+ works
   gem.add_dependency "net-ssh-gateway",    ">= 1.2", "< 3.0" # pinning until we can confirm 3+ works
   gem.add_dependency "ed25519",            "~> 1.2" # ed25519 ssh key support
   gem.add_dependency "bcrypt_pbkdf",       "~> 1.0" # ed25519 ssh key support


### PR DESCRIPTION
# Description

Update net-ssh requirement from >= 2.9, < 7.0 to >= 2.9, < 8.0 to support RSA keys on recent versions of OpenSSH, see https://www.openssh.com/txt/release-8.7 for more context.

## Issues Resolved

https://github.com/test-kitchen/test-kitchen/issues/1904

## Type of Change

Our release process assumes you are using [Conventional Commit messages](https://www.conventionalcommits.org/en/v1.0.0/).

The most important prefixes you should have in mind are:

- `_fix_`: which represents bug fixes, and correlates to a SemVer patch.
- `_feat_`: which represents a new feature, and correlates to a SemVer minor.
- `_feat!_`:, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the !) and will result in a major version change.

If you have not included a conventional commit message this can be fixed on merge.

## Check List

- [ ] New functionality includes tests
- [x] All tests pass
- [x] Commit message includes a [Conventional Commit Message](https://www.conventionalcommits.org/en/v1.0.0)
