### PR TITLE
Update Docs readme to follow the guideline

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -32,25 +32,27 @@ To highlight a block of code, start and finish the block with three or more tild
 
 For example, this code:
 
-```yaml
+~~~~
+~~~yaml
 ---
 title: "KitchenCI Overview"
 next:
   url: installing-kitchen
   text: "Installing KitchenCI"
 ---
-```
+~~~
+~~~~
 
 ...yields this output:
 
-```yaml
+~~~yaml
 ---
 title: "KitchenCI Overview"
 next:
   url: installing-kitchen
   text: "Installing KitchenCI"
 ---
-```
+~~~
 
 See [the kramdown documentation](http://kramdown.gettalong.org/syntax.html#fenced-code-blocks) for more information.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,7 +32,7 @@ To highlight a block of code, start and finish the block with three or more tild
 
 For example, this code:
 
-~~~~
+~~~~markdown
 ~~~yaml
 ---
 title: "KitchenCI Overview"


### PR DESCRIPTION
# Description

The readme for the docs directory says to use tildes for codeblocks, then proceeds to use backticks. It also missed wrapping the sample code block in a larger codeblock so it doesn't render as expected.

## Issues Resolved

None. I came here looking to file an issue about the documentation and this stood out to me.

## Type of Change

Minor documentation change.

Our release process assumes you are using [Conventional Commit messages](https://www.conventionalcommits.org/en/v1.0.0/).

The most important prefixes you should have in mind are:

- `_fix_`: which represents bug fixes, and correlates to a SemVer patch.
- `_feat_`: which represents a new feature, and correlates to a SemVer minor.
- `_feat!_`:, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the !) and will result in a major version change.

If you have not included a conventional commit message this can be fixed on merge.

## Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] Commit message includes a [Conventional Commit Message](https://www.conventionalcommits.org/en/v1.0.0)


## Additional details

This is what it looks like prior to the change:

![image](https://user-images.githubusercontent.com/30301021/196996389-d11244e9-429e-4864-9b39-0db7fb2c1198.png)

This is what it looks like after the change (mostly, I took the screenshot before I changed the backticks to tildes):

![image](https://user-images.githubusercontent.com/30301021/196996452-597d6138-0dd4-4880-a536-9aafadd5e33b.png)
