### PR TITLE
Always download files even if verifier fails

### DIFF
--- a/lib/kitchen/verifier/base.rb
+++ b/lib/kitchen/verifier/base.rb
@@ -73,14 +73,17 @@ module Kitchen
           conn.upload(sandbox_dirs, config[:root_path])
           debug("Transfer complete")
           conn.execute(prepare_command)
-          conn.execute(run_command)
-
-          info("Downloading files from #{instance.to_str}")
-          config[:downloads].to_h.each do |remotes, local|
-            debug("Downloading #{Array(remotes).join(", ")} to #{local}")
-            conn.download(remotes, local)
+          
+          begin
+            conn.execute(run_command)
+          ensure
+            info("Downloading files from #{instance.to_str}")
+            config[:downloads].to_h.each do |remotes, local|
+              debug("Downloading #{Array(remotes).join(", ")} to #{local}")
+              conn.download(remotes, local)
+            end
+            debug("Download complete")
           end
-          debug("Download complete")
         end
       rescue Kitchen::Transport::TransportFailed => ex
         raise ActionFailed, ex.message

--- a/spec/kitchen/verifier/base_spec.rb
+++ b/spec/kitchen/verifier/base_spec.rb
@@ -250,6 +250,22 @@ describe Kitchen::Verifier::Base do
       cmd
     end
 
+    it "downloads files when run fails" do
+      connection.expects(:download).with(
+        ["/tmp/kitchen/nodes", "/tmp/kitchen/data_bags"],
+        "./test/fixtures"
+      )
+
+      connection.expects(:download).with("/remote", "/local")
+
+      connection.expects(:execute).with("run").raises
+
+      begin
+        cmd
+      rescue
+      end
+    end
+
     it "raises an ActionFailed on transfer when TransportFailed is raised" do
       connection.stubs(:upload)
         .raises(Kitchen::Transport::TransportFailed.new("dang"))


### PR DESCRIPTION
# Description

Download files, even if the verifier run command fails.

## Issues Resolved

#1643 

## Type of Change

Fix

## Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] Commit message includes a [Conventional Commit Message](https://www.conventionalcommits.org/en/v1.0.0)
