### PR TITLE
Remove reference to duplicate catalog_id

### DIFF
--- a/docs/content/docs/drivers/vra.md
+++ b/docs/content/docs/drivers/vra.md
@@ -71,10 +71,6 @@ If you don't want to explicitly specify username and password in the kitchen.yml
 
 The `domain` attribute is required, which you can utilize to specify which domain should be used to authenticate the users.
 
-#### catalog_id
-
-id of the catalog item from which you are requesting the deployment
-
 #### project_id
 
 id of the project


### PR DESCRIPTION
catalog_id is mentioned in 2 places. It is confusing to find it as "catalog_id" and further down  the page as "catalog_id, catalog_name".   It is better to remove the first mention and leave the second as users should be aware of the catalog_id and the catalog_name as they are often used together.

# Description
catalog_id is mentioned in 2 places. It is confusing to find it as "catalog_id" and further down  the page as "catalog_id, catalog_name".   It is better to remove the first mention and leave the second as users should be aware of the catalog_id and the catalog_name as they are often used together.

Please describe what this change achieves
less confusing documentation
## Issues Resolved
readability

List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant

## Type of Change
- `_fix_`
Our release process assumes you are using [Conventional Commit messages](https://www.conventionalcommits.org/en/v1.0.0/).

The most important prefixes you should have in mind are:

- `_fix_`: which represents bug fixes, and correlates to a SemVer patch.
- `_feat_`: which represents a new feature, and correlates to a SemVer minor.
- `_feat!_`:, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the !) and will result in a major version change.

If you have not included a conventional commit message this can be fixed on merge.

## Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] Commit message includes a [Conventional Commit Message](https://www.conventionalcommits.org/en/v1.0.0)
