### PR TITLE
docs: add digitalocean driver missing server_name attribute

### DIFF
--- a/docs/content/docs/drivers/digitalocean.md
+++ b/docs/content/docs/drivers/digitalocean.md
@@ -52,6 +52,17 @@ Note that your `SSH_KEY_ID` must be the numeric id of your ssh key, not the symb
 curl -X GET https://api.digitalocean.com/v2/account/keys -H "Authorization: Bearer $DIGITALOCEAN_ACCESS_TOKEN"
 ```
 
+#### server_name
+
+The `server_name` configuration option allows you to specify the hostname of the Droplet. By default, the hostname is set to the combination of base name, username, hostname, random string as well as seperators.
+
+For example to set the hostname provide the server_name attribute
+
+```yaml
+driver:
+  server_name: my_server
+```
+
 #### image
 
 The `image` configuration option allows you to control the operating system of the Droplet. DigitalOcean features many different images for creating Droplets that can be used by specifying the following image names:


### PR DESCRIPTION
# Description

The attribute `server_name` for driver digitalocean exists but is not documented.
https://github.com/test-kitchen/kitchen-digitalocean/blob/a96cf71544118b7f543438ca034ed2a702bfebfc/lib/kitchen/driver/digitalocean.rb#L189

Add missing documentation.

## Issues Resolved

Nothing as far as I can see there were no issues related to this exact missing attribute in documentation.

## Type of Change

Documentation change.

## Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] Commit message includes a [Conventional Commit Message](https://www.conventionalcommits.org/en/v1.0.0)
