### PR TITLE
fix: Prevent Test Kitchen from requiring Chef license acceptance when using cinc

### DIFF
--- a/lib/kitchen/provisioner/chef/policyfile.rb
+++ b/lib/kitchen/provisioner/chef/policyfile.rb
@@ -63,10 +63,10 @@ module Kitchen
         def resolve
           if policy_group
             info("Exporting cookbook dependencies from Policyfile #{path} with policy_group #{policy_group} using `#{cli_path} export`...")
-            run_command("#{cli_path} export #{escape_path(policyfile)} #{escape_path(path)} --policy_group #{policy_group} --force --chef-license #{license}")
+            run_command("#{cli_path} export #{escape_path(policyfile)} #{escape_path(path)} --policy_group #{policy_group} --force #{chef_license(license)}")
           else
             info("Exporting cookbook dependencies from Policyfile #{path} using `#{cli_path} export`...")
-            run_command("#{cli_path} export #{escape_path(policyfile)} #{escape_path(path)} --force --chef-license #{license}")
+            run_command("#{cli_path} export #{escape_path(policyfile)} #{escape_path(path)} --force #{chef_license(license)}")
           end
         end
 
@@ -78,11 +78,11 @@ module Kitchen
           else
             info("Policy lock file doesn't exist, running `#{cli_path} install` for Policyfile #{policyfile}...")
           end
-          run_command("#{cli_path} install #{escape_path(policyfile)} --chef-license #{license}")
+          run_command("#{cli_path} install #{escape_path(policyfile)} #{chef_license(license)}")
 
           if always_update
             info("Updating policy lock using `#{cli_path} update`")
-            run_command("#{cli_path} update #{escape_path(policyfile)} --chef-license #{license}")
+            run_command("#{cli_path} update #{escape_path(policyfile)} #{chef_license(license)}")
           end
         end
 
@@ -161,6 +161,12 @@ module Kitchen
                         "setting includes the path to the `chef` or `chef-cli` commands.")
           raise UserError, "Could not find the chef or chef-cli executables in your PATH."
         end
+
+        # Return `"--chef-license #{license}"` when `license` is not nil or empty and the empty string otherwise.
+        def chef_license(license)
+          (license.nil? || license.empty?) ? "" : "--chef-license #{license}"
+        end
+          
       end
     end
   end

--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -273,7 +273,7 @@ module Kitchen
       # @return [String] license id to prompt for acceptance
       def license_acceptance_id
         case
-          when File.exist?(policyfile)
+          when File.exist?(policyfile) && (config[:product_name].nil? || config[:product_name].start_with?('chef'))
             "chef-workstation"
           when config[:product_name]
             config[:product_name]

--- a/spec/kitchen/provisioner/chef/policyfile_spec.rb
+++ b/spec/kitchen/provisioner/chef/policyfile_spec.rb
@@ -85,6 +85,16 @@ describe Kitchen::Provisioner::Chef::Policyfile do
           subject
         end
       end
+
+      describe "with simple paths and product_name is not chef " do
+        let(:policyfile) { "/home/user/cookbook/Policyfile.rb" }
+        let(:path) { "/tmp/kitchen/cookbooks" }
+        let(:license) { nil }
+        it do
+          described_object.expects(:run_command).with("chef export /home/user/cookbook/Policyfile.rb /tmp/kitchen/cookbooks --force ")
+          subject
+        end
+      end
     end
 
     describe "on Unix with chef-cli" do

--- a/spec/kitchen/provisioner/chef_base_spec.rb
+++ b/spec/kitchen/provisioner/chef_base_spec.rb
@@ -837,6 +837,24 @@ describe Kitchen::Provisioner::ChefBase do
         assert_equal("chef-workstation", provisioner.license_acceptance_id)
       end
     end
+
+    describe "when a policyfile exists and an alternative distribution is used" do
+      before do
+        @root = Dir.mktmpdir
+        config[:kitchen_root] = @root
+        config[:product_name] = 'foobar'
+        FileUtils.touch("#{config[:kitchen_root]}/Policyfile.rb")
+        Kitchen::Provisioner::Chef::Policyfile.stubs(:load!)
+      end
+
+      after do
+        FileUtils.remove_entry(@root)
+      end
+
+      it "returns 'foobar'" do
+        assert_equal("foobar", provisioner.license_acceptance_id)
+      end
+    end
   end
 
   describe "#check_license" do


### PR DESCRIPTION
… an alternative distribution (such as cinc) is used with a Policyfile.

# Description

Using `cinc-workstation` as the `product_name` still results in a prompt for Chef license acceptance when a Policyfile is in use. This fixes that.

## Issues Resolved

## Type of Change

Fix

If you have not included a conventional commit message this can be fixed on merge.

## Check List

- [X] New functionality includes tests
- [X] All tests pass
- [X] Commit message includes a [Conventional Commit Message](https://www.conventionalcommits.org/en/v1.0.0)
