### PR TITLE
fix: Fixed the issue with the shell provisioner

### DIFF
--- a/lib/kitchen/provisioner/base.rb
+++ b/lib/kitchen/provisioner/base.rb
@@ -79,7 +79,7 @@ module Kitchen
           end
 
           # Run the init command to create the kitchen tmp directory
-          conn.execute(init_command)
+          conn.execute(encode_for_powershell(init_command))
 
           # Upload the install script instead of directly executing the command
           if install_command
@@ -293,6 +293,7 @@ module Kitchen
 
       def encode_for_powershell(script)
         return script unless windows_os?
+        return script if script.nil? || script.empty?
 
         utf16le = script.encode(Encoding::UTF_16LE)
         encoded = [utf16le].pack("m0")

--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -322,7 +322,7 @@ module Kitchen
                  init_command_vars_for_bourne(dirs)
                end
 
-        encode_for_powershell(prefix_command(shell_code_from_file(vars, "chef_base_init_command")))
+        prefix_command(shell_code_from_file(vars, "chef_base_init_command"))
       end
 
       # (see Base#install_command)

--- a/lib/kitchen/provisioner/shell.rb
+++ b/lib/kitchen/provisioner/shell.rb
@@ -115,7 +115,7 @@ module Kitchen
           end
         end
 
-        code = powershell_shell? ? %{& #{script}} : sudo(script)
+        code = powershell_shell? ? %{& "#{script}"} : sudo(script)
 
         prefix_command(wrap_shell_code(code))
       end

--- a/spec/kitchen/provisioner/shell_spec.rb
+++ b/spec/kitchen/provisioner/shell_spec.rb
@@ -444,7 +444,7 @@ describe Kitchen::Provisioner::Shell do
       it "invokes the bootstrap.ps1 script" do
         config[:root_path] = '\\r'
 
-        _(cmd).must_match regexify(%{& \\r\\bootstrap.ps1})
+        _(cmd).must_match regexify(%{& "\\r\\bootstrap.ps1"})
       end
     end
   end


### PR DESCRIPTION
# Description

When the support for SSH on Windows platforms was added, the shell provisioner broke. This PR will fix the issues with the shell provisioner.

## Issues Resolved
https://github.com/test-kitchen/test-kitchen/issues/2013

## Type of Change

Our release process assumes you are using [Conventional Commit messages](https://www.conventionalcommits.org/en/v1.0.0/).

The most important prefixes you should have in mind are:

- `_fix_`: which represents bug fixes, and correlates to a SemVer patch.
- `_feat_`: which represents a new feature, and correlates to a SemVer minor.
- `_feat!_`:, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the !) and will result in a major version change.

If you have not included a conventional commit message this can be fixed on merge.

## Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] Commit message includes a [Conventional Commit Message](https://www.conventionalcommits.org/en/v1.0.0)
