### PR TITLE
fix: Update Hugo to the latest release

### DIFF
--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -1,5 +1,5 @@
 [build.environment]
-  HUGO_VERSION = "0.91.2"  
+  HUGO_VERSION = "0.148.1"
 
 [[headers]]
   for = "/*"

--- a/docs/themes/kitchen/layouts/partials/kitchen/head.html
+++ b/docs/themes/kitchen/layouts/partials/kitchen/head.html
@@ -1,6 +1,5 @@
 <head>
   {{ template "_internal/google_analytics.html" . }}
-  {{ template "_internal/google_analytics_async.html" . }}
   {{ partial "core/head" . }}
   <link rel="stylesheet" href="{{ "css/kitchen.css" | relURL }}" />
 </head>


### PR DESCRIPTION
# Description

Remove the async google tag template that's gone