### PR TITLE
fix: rescue TransportFailed instead of SshFailed in remote lifecycle hook

### DIFF
--- a/lib/kitchen/lifecycle_hook/remote.rb
+++ b/lib/kitchen/lifecycle_hook/remote.rb
@@ -21,7 +21,7 @@ module Kitchen
         begin
           conn = instance.transport.connection(state_file.read)
           conn.execute(command)
-        rescue Kitchen::Transport::SshFailed => e
+        rescue Kitchen::Transport::TransportFailed => e
           return if hook[:skippable] && e.message.match(/^SSH exited \(\d{1,3}\) for command: \[.+\]$/)
 
           raise

--- a/spec/kitchen/lifecycle_hooks_spec.rb
+++ b/spec/kitchen/lifecycle_hooks_spec.rb
@@ -19,6 +19,7 @@ require_relative "../spec_helper"
 
 require "kitchen/errors"
 require "kitchen/lifecycle_hooks"
+require "kitchen/transport/base"
 
 describe Kitchen::LifecycleHooks do
   let(:suite) { mock("suite").tap { |i| i.stubs(name: "default") } }
@@ -219,6 +220,32 @@ describe Kitchen::LifecycleHooks do
     expect_remote_hook_generated_and_not_run(:create, remote_hook)
 
     run_lifecycle_hooks
+  end
+
+  describe "remote hook with transport failure" do
+    it "re-raises a transport failure for a non-skippable hook" do
+      hook = { remote: "echo foo" }
+      config.update(post_create: [hook])
+      error = Kitchen::Transport::TransportFailed.new("SSH exited (1) for command: [echo foo]")
+      connection.expects(:execute).with(hook[:remote]).raises(error)
+      _ { run_lifecycle_hooks }.must_raise Kitchen::Transport::TransportFailed
+    end
+
+    it "skips a skippable hook when SSH exits with a non-zero status" do
+      hook = { remote: "echo foo", skippable: true }
+      config.update(post_create: [hook])
+      error = Kitchen::Transport::TransportFailed.new("SSH exited (1) for command: [echo foo]")
+      connection.expects(:execute).with(hook[:remote]).raises(error)
+      run_lifecycle_hooks
+    end
+
+    it "re-raises a non-SSH transport failure even for a skippable hook" do
+      hook = { remote: "echo foo", skippable: true }
+      config.update(post_create: [hook])
+      error = Kitchen::Transport::TransportFailed.new("connection timed out")
+      connection.expects(:execute).with(hook[:remote]).raises(error)
+      _ { run_lifecycle_hooks }.must_raise Kitchen::Transport::TransportFailed
+    end
   end
 
   describe "with no last_action" do


### PR DESCRIPTION
## Summary

Fixes #2049.

The root cause is slightly different from what the issue describes — `Kitchen::Transport::SshFailed` actually does exist (defined in `lib/kitchen/transport/ssh.rb`), but only when the SSH transport is loaded. On non-SSH transports like WinRM, `transport/ssh.rb` is never required, so the constant is undefined at runtime. Ruby raises a `NameError` when evaluating the `rescue` clause, which masks the real underlying error.

- Change `rescue Kitchen::Transport::SshFailed` → `rescue Kitchen::Transport::TransportFailed` in `lib/kitchen/lifecycle_hook/remote.rb`
- `TransportFailed` is defined in `transport/base.rb`, which `kitchen.rb` always requires — consistent with how `provisioner/base.rb` and `verifier/base.rb` already handle transport errors
- The SSH-exit message pattern check already limits the "skip" behavior to SSH non-zero exits; other transport failures (e.g. WinRM timeouts) are re-raised

## Test plan

- [x] Verify re-raises `TransportFailed` for non-skippable remote hooks
- [x] Verify silently skips when hook is skippable and SSH exit message matches
- [x] Verify re-raises even for skippable hooks when message doesn't match (e.g. connection timeout)