### PR TITLE
fix: reject invalid state files

### DIFF
--- a/lib/kitchen/state_file.rb
+++ b/lib/kitchen/state_file.rb
@@ -95,8 +95,11 @@ module Kitchen
     # @raise [StateFileLoadError] if the string document cannot be parsed
     # @api private
     def deserialize_string(string)
-      YAML.safe_load(string)
-    rescue SyntaxError, Psych::SyntaxError, Psych::DisallowedClass => ex
+      result = YAML.safe_load(string)
+      return result if result.is_a?(Hash)
+
+      raise StateFileLoadError, "Error parsing #{file_name} (expected a Hash)"
+    rescue SyntaxError, Psych::Exception => ex
       raise StateFileLoadError, "Error parsing #{file_name} (#{ex.message})"
     end
 

--- a/spec/kitchen/state_file_spec.rb
+++ b/spec/kitchen/state_file_spec.rb
@@ -73,6 +73,23 @@ describe Kitchen::StateFile do
 
       _ { state_file.read }.must_raise Kitchen::StateFileLoadError
     end
+
+    it "raises a StateFileLoadError if the state file uses yaml aliases" do
+      stub_state_file! <<-'YAML'.gsub(/^ {8}/, "")
+        ---
+        first: &first
+          value: 1
+        second: *first
+      YAML
+
+      _ { state_file.read }.must_raise Kitchen::StateFileLoadError
+    end
+
+    it "raises a StateFileLoadError if the state file is not a hash" do
+      stub_state_file!("--- nope")
+
+      _ { state_file.read }.must_raise Kitchen::StateFileLoadError
+    end
   end
 
   describe "#write" do


### PR DESCRIPTION
## Summary
- Treat state files that do not deserialize to a Hash as invalid state
- Preserve the existing safe_load YAML policy, including rejecting aliases unless that policy is changed intentionally
- Wrap Psych YAML failures consistently as StateFileLoadError so callers keep one failure path