### PR TITLE
fix: improve error handling

### DIFF
--- a/lib/kitchen/command.rb
+++ b/lib/kitchen/command.rb
@@ -15,6 +15,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require_relative "errors"
+require_relative "logging"
+
 module Kitchen
   module Command
     # Base class for CLI commands.

--- a/lib/kitchen/command/test.rb
+++ b/lib/kitchen/command/test.rb
@@ -16,6 +16,7 @@
 # limitations under the License.
 
 require_relative "../command"
+require_relative "../errors"
 
 require "benchmark" unless defined?(Benchmark)
 
@@ -30,7 +31,7 @@ module Kitchen
       # Invoke the command.
       def call
         unless %w{passing always never}.include?(options[:destroy])
-          raise ArgumentError, "Destroy mode must be passing, always, or never."
+          raise UserError, "Destroy mode must be passing, always, or never."
         end
 
         banner "Starting Test Kitchen (v#{Kitchen::VERSION})"

--- a/lib/kitchen/instance.rb
+++ b/lib/kitchen/instance.rb
@@ -654,7 +654,15 @@ module Kitchen
       end
 
       def call(what, &block)
-        state = state_file.read
+        state = nil
+        begin
+          state = state_file.read
+        rescue ::StandardError => e
+          log_failure(what, e)
+          raise ActionFailed,
+            "Failed to complete ##{what} action: [#{e.message}]", e.backtrace
+        end
+
         action_id = new_id
         session_id = state[:instance_session_id] || new_id
         instance.logger.with_metadata(
@@ -672,19 +680,19 @@ module Kitchen
           elapsed
         rescue ActionFailed => e
           log_failure(what, e)
-          record_attempt(state, what, action_id, session_id) if state
-          state[:last_error] = e.class.name if state
+          record_attempt(state, what, action_id, session_id)
+          state[:last_error] = e.class.name
           raise(InstanceFailure, failure_message(what) +
             "  Please see .kitchen/logs/#{instance.name}.log for more details",
             e.backtrace)
-        rescue Exception => e # rubocop:disable Lint/RescueException
+        rescue ::StandardError => e
           log_failure(what, e)
-          record_attempt(state, what, action_id, session_id) if state
-          state[:last_error] = e.class.name if state
+          record_attempt(state, what, action_id, session_id)
+          state[:last_error] = e.class.name
           raise ActionFailed,
             "Failed to complete ##{what} action: [#{e.message}]", e.backtrace
         ensure
-          state_file.write(state) if state
+          state_file.write(state)
         end
       end
 

--- a/lib/kitchen/lifecycle_hook/remote.rb
+++ b/lib/kitchen/lifecycle_hook/remote.rb
@@ -22,7 +22,10 @@ module Kitchen
           conn = instance.transport.connection(state_file.read)
           conn.execute(command)
         rescue Kitchen::Transport::TransportFailed => e
-          return if hook[:skippable] && e.message.match(/^SSH exited \(\d{1,3}\) for command: \[.+\]$/)
+          if hook[:skippable] && e.message.match(/^SSH exited \(\d{1,3}\) for command: \[.+\]$/)
+            logger.debug("Skipping remote lifecycle hook #{command.inspect}: #{e.message}")
+            return
+          end
 
           raise
         end

--- a/lib/kitchen/provisioner/base.rb
+++ b/lib/kitchen/provisioner/base.rb
@@ -339,13 +339,8 @@ module Kitchen
 
         # Replace $env:TEMP with the actual Windows temp directory based on the transport username
         if resolved_path.include?("$env:TEMP")
-          # Try to get username from transport configuration
           # For Windows systems, fallback to "Administrator" if not found
-          username = begin
-            instance.transport[:username]
-                     rescue
-                       nil
-          end
+          username = instance.transport[:username] if instance.transport.respond_to?(:[])
           username ||= "Administrator"
 
           temp_path = "C:/Users/#{username}/AppData/Local/Temp"

--- a/lib/kitchen/shell_out.rb
+++ b/lib/kitchen/shell_out.rb
@@ -68,7 +68,7 @@ module Kitchen
       sh.stdout
     rescue Mixlib::ShellOut::ShellCommandFailed => ex
       raise ShellCommandFailed, ex.message
-    rescue Exception => error # rubocop:disable Lint/RescueException
+    rescue ::StandardError => error
       error.extend(Kitchen::Error)
       raise
     end

--- a/lib/kitchen/transport/base.rb
+++ b/lib/kitchen/transport/base.rb
@@ -128,7 +128,7 @@ module Kitchen
             tries += 1
             debug("Attempting to execute command - try #{tries} of #{max_retries}.")
             execute(command)
-          rescue Exception => e
+          rescue ::StandardError => e
             if retry?(tries, max_retries, retryable_exit_codes, e)
               close
               sleep wait_time

--- a/lib/kitchen/transport/ssh.rb
+++ b/lib/kitchen/transport/ssh.rb
@@ -211,14 +211,14 @@ module Kitchen
           Array(remotes).each do |file|
             logger.debug("Attempting to download '#{file}' as file")
             session.scp.download!(file, local)
-          rescue Net::SCP::Error
+          rescue Net::SCP::Error => file_error
             begin
               logger.debug("Attempting to download '#{file}' as directory")
               session.scp.download!(file, local, recursive: true)
-            rescue Net::SCP::Error
-              logger.warn(
-                "SCP download failed for file or directory '#{file}', perhaps it does not exist?"
-              )
+            rescue Net::SCP::Error => directory_error
+              raise SshFailed,
+                "SCP download failed for file or directory '#{file}' " \
+                "(file: #{file_error.message}; directory: #{directory_error.message})"
             end
           end
         rescue Net::SSH::Exception => ex

--- a/spec/kitchen/command_diagnose_spec.rb
+++ b/spec/kitchen/command_diagnose_spec.rb
@@ -1,0 +1,47 @@
+#
+# Author:: Fletcher Nichol (<fnichol@nichol.ca>)
+#
+# Copyright (C) 2013, Fletcher Nichol
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative "../spec_helper"
+
+require "yaml"
+
+require "kitchen/command/diagnose"
+require "kitchen/errors"
+
+describe Kitchen::Command::Diagnose do
+  let(:config) do
+    mock("config").tap do |config|
+      config.stubs(:instances).raises(Kitchen::UserError, "bad config")
+    end
+  end
+
+  let(:command) do
+    Kitchen::Command::Diagnose.new(
+      ["all"], { all: true }, config: config, shell: mock("shell")
+    )
+  end
+
+  it "returns structured error data for instance load failures" do
+    stdout, = capture_io { command.call }
+    result = YAML.safe_load(stdout, permitted_classes: [Symbol], aliases: true)
+    error = result["instances"]["error"]
+
+    _(error["exception"]).must_match(/Kitchen::UserError/)
+    _(error["message"]).must_equal "bad config"
+    _(error["backtrace"]).must_be_kind_of Array
+  end
+end

--- a/spec/kitchen/command_test_spec.rb
+++ b/spec/kitchen/command_test_spec.rb
@@ -1,0 +1,32 @@
+#
+# Author:: Fletcher Nichol (<fnichol@nichol.ca>)
+#
+# Copyright (C) 2013, Fletcher Nichol
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative "../spec_helper"
+
+require "kitchen/command/test"
+
+describe Kitchen::Command::Test do
+  let(:command) do
+    Kitchen::Command::Test.new([], { destroy: "sometimes" }, shell: mock("shell"))
+  end
+
+  it "raises UserError for an invalid destroy mode" do
+    error = _ { command.call }.must_raise Kitchen::UserError
+
+    _(error.message).must_equal "Destroy mode must be passing, always, or never."
+  end
+end

--- a/spec/kitchen/instance_spec.rb
+++ b/spec/kitchen/instance_spec.rb
@@ -1115,6 +1115,24 @@ describe Kitchen::Instance do
       end
     end
 
+    describe "when the state file cannot be loaded" do
+      let(:state_file) do
+        mock("state_file").tap do |sf|
+          sf.expects(:read).raises(Kitchen::StateFileLoadError, "invalid state")
+          sf.expects(:write).never
+        end
+      end
+
+      it "raises an ActionFailed with the state error as original" do
+        error = _ { instance.send(:action, :create) {} }
+          .must_raise Kitchen::ActionFailed
+
+        _(error.message)
+          .must_match regex_for("Failed to complete #create action: [invalid state]")
+        _(error.original).must_be_kind_of Kitchen::StateFileLoadError
+      end
+    end
+
     describe "crashes preserve last action for desired verify action" do
       before do
         verifier.stubs(:call).raises(Kitchen::ActionFailed, "death")

--- a/spec/kitchen/lifecycle_hooks_spec.rb
+++ b/spec/kitchen/lifecycle_hooks_spec.rb
@@ -28,8 +28,9 @@ describe Kitchen::LifecycleHooks do
   let(:state_file) { mock("state_file").tap { |s| s.stubs(read: { hostname: "localhost" }) } }
   let(:connection) { mock("connection") }
   let(:transport) { mock("transport").tap { |t| t.stubs(:connection).with({ hostname: "localhost" }).returns(connection) } }
+  let(:logger) { mock("logger").tap { |l| l.stubs(:debug) } }
   let(:last_action) { :create }
-  let(:instance) { mock("instance").tap { |i| i.stubs(name: "default-toaster-10", transport: transport, last_action: last_action, suite: suite, platform: platform, state_file: state_file) } }
+  let(:instance) { mock("instance").tap { |i| i.stubs(name: "default-toaster-10", transport: transport, last_action: last_action, suite: suite, platform: platform, state_file: state_file, logger: logger) } }
   let(:kitchen_root) do
     if RUBY_PLATFORM =~ /mswin|mingw|windows/
       "#{ENV["SYSTEMDRIVE"]}/kitchen"
@@ -236,6 +237,8 @@ describe Kitchen::LifecycleHooks do
       config.update(post_create: [hook])
       error = Kitchen::Transport::TransportFailed.new("SSH exited (1) for command: [echo foo]")
       connection.expects(:execute).with(hook[:remote]).raises(error)
+      logger.expects(:debug)
+        .with("Skipping remote lifecycle hook \"echo foo\": SSH exited (1) for command: [echo foo]")
       run_lifecycle_hooks
     end
 

--- a/spec/kitchen/shell_out_spec.rb
+++ b/spec/kitchen/shell_out_spec.rb
@@ -100,6 +100,12 @@ describe Kitchen::ShellOut do
       _(err.message).must_equal "boom bad"
     end
 
+    it "does not catch fatal exceptions" do
+      command.stubs(:error!).raises(SystemExit.new(42))
+
+      _ { subject.run_command("boom") }.must_raise SystemExit
+    end
+
     it "prepends with sudo if :use_sudo is truthy" do
       Mixlib::ShellOut.unstub(:new)
       Mixlib::ShellOut.expects(:new).with("sudo -E yo", opts).returns(command)

--- a/spec/kitchen/transport/base_spec.rb
+++ b/spec/kitchen/transport/base_spec.rb
@@ -149,6 +149,13 @@ describe Kitchen::Transport::Base::Connection do
 
       _(connection.execute_with_retry("Hi", [123], 3, 1)).must_equal "Hello"
     end
+
+    it "does not catch fatal exceptions" do
+      connection.stubs(:execute).raises(SystemExit.new(42))
+
+      _ { connection.execute_with_retry("Hi", [123], 3, 1) }
+        .must_raise SystemExit
+    end
   end
 
   describe "#retry?" do

--- a/spec/kitchen/transport/ssh_spec.rb
+++ b/spec/kitchen/transport/ssh_spec.rb
@@ -1283,19 +1283,17 @@ describe Kitchen::Transport::Ssh::Connection do
     end
 
     describe "for a file that does not exist" do
-      it "logs a warning" do
+      it "raises SshFailed with the attempted remote path" do
         FileUtils.expects(:mkdir_p).with(@local_parent)
         scp.expects(:download!).with("/remote", @local).raises(Net::SCP::Error)
         scp.expects(:download!).with("/remote", @local, recursive: true)
           .raises(Net::SCP::Error)
 
-        connection.download("/remote", @local)
+        e = _ { connection.download("/remote", @local) }
+          .must_raise Kitchen::Transport::SshFailed
 
-        _(logged_output.string.lines.count do |l|
-          l =~ warn_line_with(
-            "SCP download failed for file or directory '/remote', perhaps it does not exist?"
-          )
-        end).must_equal 1
+        _(e.message)
+          .must_match regexify("SCP download failed for file or directory '/remote'")
       end
     end
 


### PR DESCRIPTION
## Summary
- Narrow broad production rescues so fatal exceptions are not swallowed and Kitchen errors preserve useful original context.
- Surface previously hidden failures in intentional non-failing paths: skippable remote hooks now log skipped transport errors and diagnose command failures remain structured in output.
- Make user-facing failures more actionable by using UserError for invalid test destroy modes and raising SshFailed when requested downloads cannot be fetched as either files or directories.

## Reviewer notes
- SSH download behavior changes intentionally: a requested remote path that fails both file and recursive directory download now fails the action instead of warning and continuing.
- The command base now requires its direct dependencies so command specs can load command classes without the full Kitchen entrypoint.