### PR TITLE
fix(provisioner): download provisioner files even when converge fails (#2036)

### DIFF
--- a/docs/content/docs/provisioners/_index.md
+++ b/docs/content/docs/provisioners/_index.md
@@ -24,7 +24,7 @@ provisioner:
   wait_for_retry: 30
   uploads: # a Hash of local => remote file mappings to upload at the start of invocation
     "contrib/some_file.cfg": "/etc"
-  downloads: # a Hash of remote => local file mappings to download post-converge
+  downloads: # a Hash of remote => local file mappings to download after converge (downloaded even when converge fails, so logs can be retrieved)
   # if the local value is an existing dir, the file will be copied into it
   # if the local value does not exist, a file with that value as name will be created
     "/tmp/kitchen/client.rb": "./downloads"

--- a/docs/superpowers/specs/2026-06-03-provisioner-downloads-on-converge-failure-design.md
+++ b/docs/superpowers/specs/2026-06-03-provisioner-downloads-on-converge-failure-design.md
@@ -1,0 +1,141 @@
+# Provisioner `downloads` on converge failure — Design
+
+- **Date:** 2026-06-03
+- **Issue:** [test-kitchen#2036 — Add ability to retrieve files after each step](https://github.com/test-kitchen/test-kitchen/issues/2036)
+- **Status:** Approved design, ready for implementation plan
+
+## Problem statement
+
+When a converge fails, Test Kitchen stops before the verify step. Users who rely
+on retrieving log files from the system under test (SUT) — to diagnose *why*
+converge failed — never get those files, because the only retrieval that runs is
+attached to the verifier, which never executes.
+
+The issue author's request: retrieve files/directories from the SUT after a step
+completes, **especially on failure**.
+
+## Root cause
+
+This is a concrete asymmetry between two plugins that already share the same
+`downloads:` feature, not a missing feature:
+
+- The **provisioner** has a documented `downloads:` config
+  (`lib/kitchen/provisioner/base.rb:55`, documented in
+  `docs/content/docs/provisioners/_index.md:27` as "download post-converge").
+- The **verifier** has the same `downloads:` feature, and thanks to
+  [PR #1916](https://github.com/test-kitchen/test-kitchen/pull/1916) ("Always
+  download files even if verifier fails") it wraps its run command in
+  `begin/ensure`, so downloads happen even when the run fails
+  (`lib/kitchen/verifier/base.rb:77-86`).
+- The **provisioner does not.** Its download loop runs inline *after*
+  `execute_with_retry`, so when converge fails the download is skipped entirely
+  (`lib/kitchen/provisioner/base.rb:107-119`).
+
+The test suites confirm the gap: the verifier spec has a
+`"downloads files when run fails"` test (`spec/kitchen/verifier/base_spec.rb:252`);
+the provisioner spec has only the success case.
+
+## Design
+
+Make the provisioner mirror the verifier. In `Kitchen::Provisioner::Base#call`,
+wrap the converge run command in `begin/ensure`, moving the existing `downloads`
+loop into the `ensure` block.
+
+### Before (`lib/kitchen/provisioner/base.rb:107-119`)
+
+```ruby
+debug("Executing run command: #{run_command}")
+conn.execute_with_retry(
+  encode_for_powershell(run_command),
+  config[:retry_on_exit_code],
+  config[:max_retries],
+  config[:wait_for_retry]
+)
+info("Downloading files from #{instance.to_str}")
+config[:downloads].to_h.each do |remotes, local|
+  debug("Downloading #{Array(remotes).join(", ")} to #{local}")
+  conn.download(remotes, local)
+end
+debug("Download complete")
+```
+
+### After
+
+```ruby
+debug("Executing run command: #{run_command}")
+begin
+  conn.execute_with_retry(
+    encode_for_powershell(run_command),
+    config[:retry_on_exit_code],
+    config[:max_retries],
+    config[:wait_for_retry]
+  )
+ensure
+  info("Downloading files from #{instance.to_str}")
+  config[:downloads].to_h.each do |remotes, local|
+    debug("Downloading #{Array(remotes).join(", ")} to #{local}")
+    conn.download(remotes, local)
+  end
+  debug("Download complete")
+end
+```
+
+When converge fails, the `ensure` still pulls the files, then the original
+exception propagates to the existing `rescue Kitchen::Transport::TransportFailed
+=> ex; raise ActionFailed` handler and the outer `ensure cleanup_sandbox`.
+
+This reuses the existing `downloads:` config — no new config surface, no new
+classes.
+
+## Testing (TDD)
+
+Add a `"downloads files when run fails"` test to
+`spec/kitchen/provisioner/base_spec.rb`, mirroring the verifier's test at
+`spec/kitchen/verifier/base_spec.rb:252`:
+
+- Stub `connection.execute_with_retry` to raise (the provisioner runs the converge
+  command via `execute_with_retry`, not `execute`).
+- Expect both `connection.download` calls (the two entries in the existing
+  `config[:downloads]` fixture set up in the spec's `before` block) still happen.
+- Wrap `cmd` in `begin/rescue` so the raised error doesn't fail the test.
+
+Write the test first. Against today's code it fails (downloads are skipped on
+failure). The source change makes it pass. The existing `"downloads files"`
+(success) test must continue to pass unchanged.
+
+## Documentation
+
+Update the provisioner `downloads` documentation
+(`docs/content/docs/provisioners/_index.md:27`) to note that downloads now run
+even when converge fails, so log retrieval works in the failure case. Small
+wording tweak to an existing comment/section.
+
+## Compatibility
+
+- **Success path:** unchanged — downloads still happen after a successful converge.
+- **Failure path:** downloads now happen (previously skipped). Purely additive.
+- No new or changed configuration keys; existing `downloads:` config drives it.
+
+## Known limitation (shared with the verifier)
+
+If converge fails **and** a listed file cannot be downloaded (e.g. it was never
+created because converge died early), the download's `TransportFailed` surfaces
+instead of the original converge error. The verifier already behaves exactly this
+way. We mirror it here for consistency. Fixing the error-masking for both plugins
+is intentionally out of scope for this change.
+
+## Out of scope
+
+- Separate on-success vs on-failure download sets (the issue's "perhaps" — the
+  "always download" behavior already covers retrieving-on-failure).
+- A general `download:` lifecycle hook type for arbitrary phases.
+- Changing the error-masking behavior described above.
+
+## Acceptance criteria
+
+1. With `downloads:` configured on the provisioner, a **failing** converge still
+   downloads the configured files to the local destinations.
+2. A **successful** converge continues to download exactly as before.
+3. New provisioner spec `"downloads files when run fails"` passes; existing
+   provisioner and verifier specs remain green.
+4. Provisioner `downloads` docs mention the on-failure behavior.

--- a/lib/kitchen/provisioner/base.rb
+++ b/lib/kitchen/provisioner/base.rb
@@ -105,18 +105,21 @@ module Kitchen
           debug("Executing prepare command: #{prepare_command}")
           conn.execute(prepare_command)
           debug("Executing run command: #{run_command}")
-          conn.execute_with_retry(
-            encode_for_powershell(run_command),
-            config[:retry_on_exit_code],
-            config[:max_retries],
-            config[:wait_for_retry]
-          )
-          info("Downloading files from #{instance.to_str}")
-          config[:downloads].to_h.each do |remotes, local|
-            debug("Downloading #{Array(remotes).join(", ")} to #{local}")
-            conn.download(remotes, local)
+          begin
+            conn.execute_with_retry(
+              encode_for_powershell(run_command),
+              config[:retry_on_exit_code],
+              config[:max_retries],
+              config[:wait_for_retry]
+            )
+          ensure
+            info("Downloading files from #{instance.to_str}")
+            config[:downloads].to_h.each do |remotes, local|
+              debug("Downloading #{Array(remotes).join(", ")} to #{local}")
+              conn.download(remotes, local)
+            end
+            debug("Download complete")
           end
-          debug("Download complete")
         end
       rescue Kitchen::Transport::TransportFailed => ex
         raise ActionFailed, ex.message

--- a/spec/kitchen/provisioner/base_spec.rb
+++ b/spec/kitchen/provisioner/base_spec.rb
@@ -278,6 +278,22 @@ describe Kitchen::Provisioner::Base do
       cmd
     end
 
+    it "downloads files when run fails" do
+      connection.expects(:download).with(
+        ["/tmp/kitchen/nodes", "/tmp/kitchen/data_bags"],
+        "./test/fixtures"
+      )
+
+      connection.expects(:download).with("/remote", "/local")
+
+      connection.expects(:execute_with_retry).raises
+
+      begin
+        cmd
+      rescue
+      end
+    end
+
     it "raises an ActionFailed on transfer when TransportFailed is raised" do
       connection.stubs(:upload)
         .raises(Kitchen::Transport::TransportFailed.new("dang"))


### PR DESCRIPTION
## What

Closes #2036.

Make the provisioner retrieve its configured `downloads:` files **even when converge fails**, by wrapping the converge run command in `begin/ensure`. Previously the download only ran after a *successful* converge, so log files needed to debug a failed converge were never retrieved.

## Why

[#2036](https://github.com/test-kitchen/test-kitchen/issues/2036) reports that when converge fails, the verify step never runs, so any file-retrieval attached to the verifier never happens — leaving no way to pull SUT logs that explain the failure.

This turned out to be a concrete asymmetry, not a missing feature:

- The **verifier** already downloads files even when its run fails — `Kitchen::Verifier::Base#call` wraps the run command in `begin/ensure` (added in #1916).
- The **provisioner** has the same `downloads:` feature, but ran the download loop *inline after* `execute_with_retry`, so a failed converge skipped it entirely.

This PR makes the provisioner mirror the verifier.

## Change

`lib/kitchen/provisioner/base.rb` — wrap `conn.execute_with_retry(...)` in `begin/ensure`, with the existing `downloads` loop in the `ensure`. On failure, files are downloaded, then the original exception propagates to the existing `rescue TransportFailed => raise ActionFailed`.

No new or changed configuration — it uses the existing `downloads:` key.

## Testing

- New spec `"downloads files when run fails"` in `spec/kitchen/provisioner/base_spec.rb`, mirroring the verifier's equivalent. Written test-first: it fails on the old code (downloads skipped on failure) and passes with the change.
- `provisioner` spec: **61 runs, 0 failures**. `verifier` spec: **40 runs, 0 failures**. `rake style`: clean.

## Reviewer notes

- **Known limitation (shared with the verifier):** if converge fails *and* a listed file can't be downloaded (e.g. it never got created), the download's `TransportFailed` surfaces instead of the converge error. The verifier already behaves this way; kept consistent here. Happy to address both separately if preferred.
- This branch also includes an internal design doc at `docs/superpowers/specs/2026-06-03-provisioner-downloads-on-converge-failure-design.md`. Let me know if you'd prefer it dropped from the PR.
