### PR TITLE
chore: upgrade hugo and add mise tasks

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,15 +8,15 @@ All documentation will be hosted on the official Kitchen website <https://kitche
 
 ## Running Locally
 
-### Install Hugo
+### Install tooling
 
-- On macOS run: `brew install hugo`
-- On Windows run: `choco install hugo`
-- On Ubuntu run: `apt install -y build-essential; snap install hugo --channel=extended`
+Run `mise install` from the repository root to install the pinned Hugo version.
 
 ### Run Hugo
 
-Run `hugo serve` and browse the the URL presented
+Run `mise run docs:serve` from the repository root and browse the URL presented.
+
+If you are not using mise, install Hugo 0.163.2 directly and run `hugo server` from this directory.
 
 ## Style Guide
 

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -1,5 +1,5 @@
 baseURL = "/"
-languageCode = "en-us"
+locale = "en-US"
 theme = "kitchen"
 googleAnalytics = 'G-GL7W81V957'
 

--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -1,5 +1,5 @@
 [build.environment]
-  HUGO_VERSION = "0.148.1"
+  HUGO_VERSION = "0.163.2"
 
 [[headers]]
   for = "/*"

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,109 @@
+[tools]
+hugo = "0.163.2"
+
+[tasks."docs:serve"]
+description = "Run the docs site locally with Hugo"
+dir = "docs"
+run = "hugo server"
+
+[tasks."docs:build"]
+description = "Build the docs site with Hugo"
+dir = "docs"
+run = "hugo"
+
+[tasks."rake:build"]
+description = "Build test-kitchen-4.0.0.gem into the pkg directory"
+run = "bundle exec rake build"
+
+[tasks."rake:build:checksum"]
+description = "Generate SHA512 checksum of test-kitchen-4.0.0.gem into the checksums directory"
+run = "bundle exec rake build:checksum"
+
+[tasks."rake:clean"]
+description = "Remove any temporary products"
+confirm = "Remove temporary build products?"
+run = "bundle exec rake clean"
+
+[tasks."rake:clobber"]
+description = "Remove any generated files"
+confirm = "Remove generated files?"
+run = "bundle exec rake clobber"
+
+[tasks."rake:docs:deploy"]
+description = "Deploy docs"
+confirm = "Deploy docs to S3 and invalidate CloudFront?"
+run = "bundle exec rake docs:deploy"
+
+[tasks."rake:features"]
+description = "Run Cucumber features"
+run = "bundle exec rake features"
+
+[tasks."rake:install"]
+description = "Build and install test-kitchen-4.0.0.gem into system gems"
+confirm = "Install the built gem into system gems?"
+run = "bundle exec rake install"
+
+[tasks."rake:install:local"]
+description = "Build and install test-kitchen-4.0.0.gem into system gems without network access"
+confirm = "Install the built gem into system gems without network access?"
+run = "bundle exec rake install:local"
+
+[tasks."rake:quality"]
+description = "Run all quality tasks"
+env = { RUBOCOP_CACHE_ROOT = "tmp/rubocop_cache" }
+run = "bundle exec rake quality"
+
+[tasks."rake:release"]
+description = "Create tag v4.0.0 and build and push test-kitchen-4.0.0.gem to rubygems.org"
+confirm = "Create a release tag and publish the gem?"
+run = "bundle exec rake release"
+
+[tasks."rake:stats"]
+description = "Display LOC stats"
+run = "bundle exec rake stats"
+
+[tasks."rake:style"]
+description = "Run RuboCop"
+env = { RUBOCOP_CACHE_ROOT = "tmp/rubocop_cache" }
+run = "bundle exec rake style"
+
+[tasks."rake:style:autocorrect"]
+description = "Autocorrect RuboCop offenses (only when it's safe)"
+confirm = "Autocorrect safe RuboCop offenses?"
+env = { RUBOCOP_CACHE_ROOT = "tmp/rubocop_cache" }
+run = "bundle exec rake style:autocorrect"
+
+[tasks."rake:style:autocorrect_all"]
+description = "Autocorrect RuboCop offenses (safe and unsafe)"
+confirm = "Autocorrect safe and unsafe RuboCop offenses?"
+env = { RUBOCOP_CACHE_ROOT = "tmp/rubocop_cache" }
+run = "bundle exec rake style:autocorrect_all"
+
+[tasks."rake:test"]
+description = "Run all test suites"
+run = "bundle exec rake test"
+
+[tasks."rake:unit"]
+description = "Run tests for unit"
+run = "bundle exec rake unit"
+
+[tasks.test]
+description = "Run all test suites"
+depends = ["rake:test"]
+
+[tasks.quality]
+description = "Run all quality tasks"
+depends = ["rake:quality"]
+
+[tasks.ci]
+description = "Run local CI checks"
+depends = ["rake:test", "rake:quality", "docs:build"]
+
+[tasks."kitchen:list"]
+description = "List Test Kitchen instances"
+run = "bundle exec kitchen list"
+
+[tasks."kitchen:verify"]
+description = "Verify Test Kitchen instances"
+raw_args = true
+run = "bundle exec kitchen verify"

--- a/renovate.json
+++ b/renovate.json
@@ -4,5 +4,31 @@
     "config:recommended",
     ":disableDependencyDashboard",
     "schedule:automergeEarlyMondays"
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Update Netlify Hugo version",
+      "managerFilePatterns": [
+        "/^docs\\/netlify\\.toml$/"
+      ],
+      "matchStrings": [
+        "HUGO_VERSION\\s*=\\s*\"(?<currentValue>[^\"]+)\""
+      ],
+      "depNameTemplate": "gohugoio/hugo",
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver"
+    }
+  ],
+  "packageRules": [
+    {
+      "description": "Group Hugo version updates",
+      "matchDepNames": [
+        "gohugoio/hugo",
+        "hugo"
+      ],
+      "groupName": "Hugo",
+      "groupSlug": "hugo"
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- Pin Hugo to 0.163.2 for Netlify and local mise-managed docs builds
- Add mise tasks for docs, rake wrappers, kitchen helpers, and common local workflows
- Configure Renovate to update the Netlify Hugo pin and group Hugo updates

## Test Plan
- [x] mise install
- [x] mise exec -- hugo version
- [x] mise run docs:build
- [x] mise run docs:serve
- [x] mise tasks
- [x] mise run rake:quality
- [x] mise run kitchen:list
- [x] jq . renovate.json
- [ ] mise run rake:test (fails in existing Cucumber scenario features/kitchen_action_commands.feature:39; reproduced with plain bundle exec cucumber, unrelated to mise wrapper)