### PR TITLE
docs: record plugin contracts

### DIFF
--- a/.adr-dir
+++ b/.adr-dir
@@ -1,0 +1,1 @@
+docs/adr

--- a/docs/adr/0001-record-architecture-decisions.md
+++ b/docs/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,19 @@
+# 1. Record architecture decisions
+
+Date: 2026-06-18
+
+## Status
+
+Accepted
+
+## Context
+
+We need to record the architectural decisions made on this project.
+
+## Decision
+
+We will use Architecture Decision Records, as [described by Michael Nygard](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions).
+
+## Consequences
+
+See Michael Nygard's article, linked above. For a lightweight ADR toolset, see Nat Pryce's [adr-tools](https://github.com/npryce/adr-tools).

--- a/docs/adr/0002-use-an-external-provider-protocol-for-provisioners.md
+++ b/docs/adr/0002-use-an-external-provider-protocol-for-provisioners.md
@@ -1,0 +1,132 @@
+# 2. Use an external provider protocol for provisioners
+
+Date: 2026-06-18
+
+## Status
+
+Proposed
+
+## Context
+
+Test Kitchen providers are currently implemented as Ruby plugins. That keeps
+providers close to Kitchen internals, but it makes it hard to implement a
+provider in another language while preserving the normal Kitchen user
+experience: YAML configuration, lifecycle commands, instance state, logging,
+and predictable failure reporting.
+
+The first concrete use case is a Go-based Cinc provisioner. The design should
+not require v1 to solve every provider type, but it should leave room for
+drivers, transports, and verifiers later.
+
+This ADR records the direction proposed in
+[issue 2056](https://github.com/test-kitchen/test-kitchen/issues/2056).
+
+## Decision
+
+We will define a versioned external provider protocol for Test Kitchen, starting
+with provisioners only.
+
+Kitchen configuration will use an explicit built-in external adapter:
+
+```yaml
+provisioner:
+  name: external
+  command: kitchen-provider-cinc
+```
+
+Provider-specific configuration can remain under the provisioner configuration
+and be passed to the external provider as normalized JSON.
+
+For v1, Kitchen will invoke short-lived provider subcommands:
+
+```text
+kitchen-provider-cinc capabilities
+kitchen-provider-cinc validate --config config.json
+kitchen-provider-cinc run --context context.json
+```
+
+Runtime events emitted by `run` will use newline-delimited JSON. `capabilities`,
+`validate`, and any schema-related commands can use normal JSON output unless a
+single parser for every command becomes preferable.
+
+Kitchen should retain transport ownership for v1 unless the first provider
+requires lower-level control. The external provisioner should receive enough
+context to generate commands, upload files through Kitchen-owned mechanisms,
+and report events, while Kitchen continues to execute SSH and WinRM operations.
+
+Provider state will be namespaced under a provider-owned key to avoid
+collisions with Kitchen state:
+
+```json
+{
+  "providers": {
+    "cinc": {
+      "client_version": "18.6.2"
+    }
+  }
+}
+```
+
+Protocol failures and provisioner failures will be reported differently:
+
+- Provider protocol errors, such as invalid JSON, unsupported protocol versions,
+  missing commands, or malformed event streams, exit non-zero.
+- Normal provisioner failures, such as a failed Cinc run or policy failure,
+  should be emitted as structured result events so Kitchen can report them as
+  user-facing converge failures.
+
+The protocol specification will define how Kitchen converts Ruby and YAML data
+into provider JSON. ERB-rendered YAML is evaluated before provider invocation,
+Ruby symbols and hash keys become JSON strings, unsupported Ruby objects are
+rejected during validation, and mutable Kitchen state is serialized through a
+stable versioned shape.
+
+Secrets must have explicit handling rules before implementation. v1 should
+prefer passing secret references, file paths, or environment variable names over
+raw secret values. If raw secrets must be passed, providers must identify
+sensitive fields and Kitchen must redact those values from logs and emitted
+events.
+
+The initial documentation and schemas should live in predictable project paths,
+for example:
+
+```text
+docs/external-provider-protocol.md
+schemas/provider-request.v1.json
+schemas/provider-event.v1.json
+schemas/provider-result.v1.json
+```
+
+## Consequences
+
+External provisioners can be implemented outside Ruby without changing the
+Kitchen workflow users already understand.
+
+The explicit `name: external` configuration makes it clear that Kitchen is
+loading a built-in adapter and invoking an executable provider, rather than
+loading a Ruby plugin named after the provider.
+
+Starting with provisioners keeps the first protocol small enough to implement
+and test against a real provider. Driver, transport, and verifier support can be
+added after the process, state, event, failure, and redaction contracts have
+been proven.
+
+Keeping transport in Kitchen reduces the v1 security surface and avoids asking
+each provider to reimplement SSH and WinRM behavior. It may constrain providers
+that need direct transport control, so the transport boundary must be validated
+against the Go Cinc provisioner before the protocol is considered stable.
+
+The protocol adds new compatibility responsibilities. Kitchen and providers need
+clear version negotiation, schema enforcement rules, stdout and stderr
+contracts, event presentation in Kitchen logs, and acceptance tests using a fake
+external provisioner.
+
+Before implementation, maintainers still need to settle these details:
+
+- Whether providers may update only their own state namespace or request changes
+  to shared instance state.
+- Whether state writes happen only through the final result event.
+- Whether `validate` and `run` receive input through file paths, stdin, or both.
+- Whether schemas are documentation only or enforced by Kitchen.
+- Whether the first audience for the specification is Test Kitchen maintainers,
+  external provider authors, or the initial Go Cinc provider implementation.

--- a/docs/adr/0003-record-current-driver-contract.md
+++ b/docs/adr/0003-record-current-driver-contract.md
@@ -1,0 +1,65 @@
+# 3. Record current driver contract
+
+Date: 2026-06-18
+
+## Status
+
+Accepted
+
+## Context
+
+Test Kitchen supports external drivers through Ruby plugins. The current driver
+contract is not a separate protocol; it is the behavior exposed by the
+`Kitchen::Driver::Base` class, the shared plugin loader, the instance lifecycle,
+and the existing built-in drivers and specs.
+
+We need to record that current state before improving or replacing it with a
+clearer contract.
+
+## Decision
+
+We will document the current driver contract as it exists today.
+
+Drivers are Ruby plugins loaded by name. `Kitchen::Driver.for_plugin` delegates
+to the shared plugin loader, which requires `kitchen/driver/<name>`, resolves a
+class under `Kitchen::Driver`, and initializes it with a config hash.
+
+Kitchen finalizes each driver with `finalize_config!(instance)` before lifecycle
+actions. Finalization gives the driver access to the `Kitchen::Instance`, lazy
+configuration, diagnostics, logging helpers, dependency checks, validations, and
+path expansion.
+
+The current live lifecycle methods Kitchen calls on drivers are:
+
+- `create(state)`
+- `destroy(state)`
+
+Kitchen also calls these driver methods from explicit commands:
+
+- `package(state)`
+- `doctor(state)`
+
+The `state` argument is the mutable instance state hash read from the state
+file. Drivers may write connection details or resource identifiers into it, and
+Kitchen persists that state after the action.
+
+Although older examples and some built-in classes mention `setup` and `verify`,
+the current instance lifecycle does not call driver `setup` or driver `verify`.
+`setup` is currently an empty instance action, and `verify` is handled by the
+verifier.
+
+Drivers should raise `Kitchen::ActionFailed` for expected action failures. The
+instance action wrapper records `last_error`, preserves the previous
+`last_action`, logs failure details, and raises `Kitchen::InstanceFailure` for
+the user-facing command failure.
+
+We will add the user-facing documentation note at
+`docs/content/docs/reference/current-driver-contract.md`.
+
+## Consequences
+
+This records the current behavior without trying to clean it up.
+
+Future work can use this record to decide what should become a stable public
+contract, what should remain Ruby-only base-class behavior, and what should be
+changed or removed from a future external provider protocol.

--- a/docs/adr/0004-record-current-transport-contract.md
+++ b/docs/adr/0004-record-current-transport-contract.md
@@ -1,0 +1,73 @@
+# 4. Record current transport contract
+
+Date: 2026-06-18
+
+## Status
+
+Accepted
+
+## Context
+
+Test Kitchen supports external transports through Ruby plugins. Transports are
+the current boundary for command execution, file upload and download, login
+commands, and connection reuse. Provisioners, verifiers, remote lifecycle hooks,
+and login commands all depend on this surface.
+
+The current transport contract is not a language-neutral protocol. It is the
+Ruby object surface implemented by `Kitchen::Transport::Base`, its nested
+connection class, the built-in transports, and the call sites that consume them.
+
+## Decision
+
+We will document the current transport contract as it exists today.
+
+Transports are Ruby plugins loaded by name. `Kitchen::Transport.for_plugin`
+delegates to the shared plugin loader, which requires `kitchen/transport/<name>`,
+resolves a class under `Kitchen::Transport`, and initializes it with a config
+hash.
+
+Kitchen finalizes each transport with `finalize_config!(instance)` before use.
+Finalization gives the transport access to the `Kitchen::Instance`, lazy
+configuration, diagnostics, logging helpers, dependency checks, validations, and
+path expansion.
+
+The required transport method is:
+
+- `connection(state)`
+
+The `connection` method should return or yield a connection object. Current core
+call sites use block form, but Kitchen does not automatically close the
+connection after the block. Transports own connection caching, reuse, closing,
+and cleanup.
+
+The connection object is expected to support:
+
+- `execute(command)`
+- `execute_with_retry(command, retryable_exit_codes, max_retries, wait_time)`
+- `upload(locals, remote)`
+- `download(remotes, local)`
+- `login_command`
+- `close`
+- `wait_until_ready`
+
+In practice, `execute(nil)` is expected to be a silent no-op. Non-zero command
+exits should be represented as `Kitchen::Transport::TransportFailed` or a
+subclass with an `exit_code` when possible. Provisioners and verifiers translate
+transport failures into `Kitchen::ActionFailed`.
+
+Built-in SSH and WinRM transports merge configuration and state so state values
+override config values for connection details such as host, port, username, and
+password. This state-over-config behavior is part of the practical current
+contract.
+
+We will add the user-facing documentation note at
+`docs/content/docs/reference/current-transport-contract.md`.
+
+## Consequences
+
+This records the command, file, login, state, and failure behavior that external
+transport authors must understand today.
+
+Future work can use this record to decide whether Kitchen should keep transport
+ownership for external providers, expose a smaller serialized command/file API,
+or define a clearer connection lifecycle and error model.

--- a/docs/adr/0005-record-current-provisioner-contract.md
+++ b/docs/adr/0005-record-current-provisioner-contract.md
@@ -1,0 +1,73 @@
+# 5. Record current provisioner contract
+
+Date: 2026-06-18
+
+## Status
+
+Accepted
+
+## Context
+
+Test Kitchen supports external provisioners through Ruby plugins. Provisioners
+are the main current integration point for configuring an instance after it has
+been created and before verification runs.
+
+The current provisioner contract is not a separate protocol. It is the Ruby
+object surface implemented by `Kitchen::Provisioner::Base`, the shared
+configuration and lifecycle helpers, the built-in provisioners, and the
+transport connection API that provisioners consume.
+
+## Decision
+
+We will document the current provisioner contract as it exists today.
+
+Provisioners are Ruby plugins loaded by name. `Kitchen::Provisioner.for_plugin`
+delegates to the shared plugin loader, which requires
+`kitchen/provisioner/<name>`, resolves a class under `Kitchen::Provisioner`, and
+initializes it with a config hash.
+
+Kitchen finalizes each provisioner with `finalize_config!(instance)` before use.
+Finalization gives the provisioner access to the `Kitchen::Instance`, lazy
+configuration, diagnostics, logging helpers, dependency checks, validations, and
+path expansion.
+
+The current provisioner methods Kitchen depends on are:
+
+- `check_license`
+- `call(state)`
+- `doctor(state)`
+
+The `state` argument is the mutable instance state hash read from the state
+file. Provisioners may read and write that state. Kitchen records
+`last_action` and `last_error` around the action.
+
+Provisioners that subclass `Kitchen::Provisioner::Base` can use its default
+sandbox and transport workflow. That workflow creates a local sandbox, uploads
+configured files and sandbox contents, then runs optional command hooks:
+
+- `install_command`
+- `init_command`
+- `prepare_command`
+- `run_command`
+
+The base workflow uses `instance.transport.connection(state)` and calls
+`upload`, `execute`, `execute_with_retry`, and `download` on the transport
+connection. Provisioners may also override `call(state)` entirely and avoid the
+base workflow.
+
+Provisioners should raise `Kitchen::ActionFailed` for expected converge
+failures. `Kitchen::Transport::TransportFailed` raised by the base workflow is
+converted into `Kitchen::ActionFailed`.
+
+We will add the user-facing documentation note at
+`docs/content/docs/reference/current-provisioner-contract.md`.
+
+## Consequences
+
+This records the current provisioner behavior without treating it as clean or
+complete.
+
+Future work can use this record to identify which parts of the provisioner
+surface should become an external provider protocol, including serialized
+configuration, state ownership, event output, failure behavior, secret handling,
+and the boundary between provisioners and transports.

--- a/docs/adr/0006-record-current-verifier-contract.md
+++ b/docs/adr/0006-record-current-verifier-contract.md
@@ -1,0 +1,76 @@
+# 6. Record current verifier contract
+
+Date: 2026-06-18
+
+## Status
+
+Accepted
+
+## Context
+
+Test Kitchen supports external verifiers through Ruby plugins. Verifiers are the
+current integration point for running tests or checks after create, converge,
+and setup have completed.
+
+The current verifier contract is not a separate protocol. It is the Ruby object
+surface implemented by `Kitchen::Verifier::Base`, the shared configuration and
+lifecycle helpers, built-in verifier behavior, and the transport connection API
+that remote verifiers consume.
+
+## Decision
+
+We will document the current verifier contract as it exists today.
+
+Verifiers are Ruby plugins loaded by name. `Kitchen::Verifier.for_plugin`
+delegates to the shared plugin loader, which requires `kitchen/verifier/<name>`,
+resolves a class under `Kitchen::Verifier`, and initializes it with a config
+hash.
+
+Kitchen finalizes each verifier with `finalize_config!(instance)` before use.
+Finalization gives the verifier access to the `Kitchen::Instance`, lazy
+configuration, diagnostics, logging helpers, dependency checks, validations, and
+path expansion.
+
+The current verifier method Kitchen depends on is:
+
+- `call(state)`
+
+Verifiers may also implement:
+
+- `doctor(state)`
+
+The `state` argument is the mutable instance state hash read from the state
+file. Verifiers may read and write that state. Kitchen records `last_action` and
+`last_error` around the action.
+
+Verifiers that subclass `Kitchen::Verifier::Base` can use its default sandbox
+and transport workflow. That workflow creates a local sandbox, uploads sandbox
+contents, then runs optional command hooks:
+
+- `install_command`
+- `init_command`
+- `prepare_command`
+- `run_command`
+
+The base workflow uses `instance.transport.connection(state)` and calls
+`execute`, `upload`, and `download` on the transport connection. Verifiers may
+also override `call(state)` entirely. The shell verifier demonstrates that a
+verifier can run locally by default and only use remote execution when
+configured to do so.
+
+Verifiers should raise `Kitchen::ActionFailed` for expected verification
+failures. `Kitchen::Transport::TransportFailed` raised by the base workflow is
+converted into `Kitchen::ActionFailed`.
+
+We will add the user-facing documentation note at
+`docs/content/docs/reference/current-verifier-contract.md`.
+
+## Consequences
+
+This records the current verifier behavior without treating it as clean or
+complete.
+
+Future work can use this record to decide what belongs in a stable verifier
+contract, what should be shared with provisioners, and how Kitchen should make
+local execution, remote execution, state, and failures easier for plugin authors
+to reason about.

--- a/docs/content/docs/reference/current-driver-contract.md
+++ b/docs/content/docs/reference/current-driver-contract.md
@@ -1,0 +1,134 @@
+---
+title: Current Driver Contract
+menu:
+  docs:
+    parent: reference
+    weight: 20
+---
+
+This page records the current Test Kitchen driver contract. It describes how
+Kitchen uses drivers today, including behavior that exists because of the Ruby
+base classes and current implementation details.
+
+This is not a redesign of the driver API. It is a snapshot of the current state
+so future work can make the contract clearer.
+
+## How Kitchen loads drivers
+
+Drivers are Ruby plugins. Kitchen loads a driver by calling
+`Kitchen::Driver.for_plugin(name, config)`, which delegates to the shared plugin
+loader.
+
+For a driver named `example`, Kitchen expects to be able to require:
+
+```text
+kitchen/driver/example
+```
+
+and find a class under `Kitchen::Driver`, such as:
+
+```ruby
+module Kitchen
+  module Driver
+    class Example < Kitchen::Driver::Base
+    end
+  end
+end
+```
+
+Kitchen initializes the driver with a config hash:
+
+```ruby
+driver = Kitchen::Driver::Example.new(config)
+```
+
+Kitchen then finalizes it with the instance before actions run:
+
+```ruby
+driver.finalize_config!(instance)
+```
+
+## Methods Kitchen calls
+
+The current core lifecycle calls these driver methods:
+
+```ruby
+create(state)
+destroy(state)
+```
+
+Kitchen also calls these methods from explicit commands:
+
+```ruby
+package(state)
+doctor(state)
+```
+
+`Kitchen::Driver::Base` provides no-op defaults for `destroy`, `package`, and
+`doctor`. Its default `create` only supports the legacy `pre_create_command`
+behavior.
+
+Although some older code and examples mention driver `setup` and driver
+`verify`, Kitchen does not currently call driver `setup` or driver `verify`.
+The instance `setup` action is empty, and verification is handled by the
+verifier.
+
+## State
+
+Every driver action receives a mutable `state` hash:
+
+```ruby
+def create(state)
+  state[:hostname] = "192.0.2.10"
+end
+```
+
+Kitchen reads this hash from the instance state file before the action and
+writes it back after the action. Drivers commonly use it to persist resource
+identifiers and connection details that transports later consume.
+
+Kitchen also writes `last_action` and `last_error` around lifecycle actions.
+
+## What the base class provides
+
+Drivers normally subclass `Kitchen::Driver::Base`. The base class provides:
+
+* configuration defaults and validation helpers
+* `finalize_config!(instance)`
+* access to `instance`
+* hash-like config lookup with `[]`
+* diagnostics through `diagnose` and `diagnose_plugin`
+* logging helpers such as `debug`, `info`, `warn`, and `error`
+* shell-out support through `run_command`
+* plugin metadata helpers such as `plugin_version` and
+  `kitchen_driver_api_version`
+* `no_parallel_for` support for serialized actions
+
+The shared configuration helper expands paths, runs deprecation checks,
+validates required config, and loads dependencies during finalization.
+
+## Failure behavior
+
+Drivers should raise `Kitchen::ActionFailed` for expected action failures.
+
+When an action raises `Kitchen::ActionFailed`, Kitchen records the failure in
+state, logs the detailed error, preserves the previous successful lifecycle
+state, and raises `Kitchen::InstanceFailure` for the user-facing command.
+
+Unexpected exceptions are wrapped by Kitchen as action failures.
+
+## Current rough edges
+
+The current driver contract is broader and less precise than the live lifecycle
+requires. In particular:
+
+* `setup` and `verify` appear in some older driver-oriented behavior but are not
+  called as driver actions today.
+* Drivers may interact with `instance.transport` directly, as built-in proxy and
+  exec-style drivers do.
+* Drivers write arbitrary keys into shared instance state, and those keys may be
+  interpreted later by transports or other plugins.
+
+Future work should make the driver contract explicit, reduce reliance on
+shared mutable state, and clarify which responsibilities belong to drivers
+versus transports and other plugin types.

--- a/docs/content/docs/reference/current-provisioner-contract.md
+++ b/docs/content/docs/reference/current-provisioner-contract.md
@@ -1,0 +1,137 @@
+---
+title: Current Provisioner Contract
+menu:
+  docs:
+    parent: reference
+    weight: 22
+---
+
+This page records the current Test Kitchen provisioner contract. It describes
+how Kitchen uses provisioners today, including behavior that exists because of
+the Ruby base classes and current transport integration.
+
+This is not a redesign of the provisioner API. It is a snapshot of the current
+state so future work can make the contract clearer.
+
+## How Kitchen loads provisioners
+
+Provisioners are Ruby plugins. Kitchen loads a provisioner by calling
+`Kitchen::Provisioner.for_plugin(name, config)`, which delegates to the shared
+plugin loader.
+
+For a provisioner named `example`, Kitchen expects to be able to require:
+
+```text
+kitchen/provisioner/example
+```
+
+and find a class under `Kitchen::Provisioner`, such as:
+
+```ruby
+module Kitchen
+  module Provisioner
+    class Example < Kitchen::Provisioner::Base
+    end
+  end
+end
+```
+
+Kitchen initializes the provisioner with a config hash and then finalizes it
+with the instance before convergence.
+
+## Methods Kitchen calls
+
+The current provisioner methods Kitchen depends on are:
+
+```ruby
+check_license
+call(state)
+doctor(state)
+```
+
+Kitchen calls `check_license` immediately before `call(state)` during converge.
+`doctor(state)` is called by `kitchen doctor`.
+
+`state` is the mutable instance state hash. Kitchen reads it before converge and
+writes it after the action.
+
+## Using the base workflow
+
+A provisioner can subclass `Kitchen::Provisioner::Base` and use the default
+remote execution workflow.
+
+In that workflow, a provisioner can implement these command hooks:
+
+```ruby
+install_command
+init_command
+prepare_command
+run_command
+```
+
+The base workflow:
+
+* creates a local sandbox
+* uploads configured `uploads`
+* opens `instance.transport.connection(state)`
+* runs install and init commands
+* uploads sandbox contents to `root_path`
+* runs prepare
+* runs the main command with `execute_with_retry`
+* downloads configured `downloads`
+* cleans up the local sandbox
+
+Each command hook may return `nil`. Current transports are expected to no-op
+for `execute(nil)`.
+
+## Overriding the workflow
+
+A provisioner may override `call(state)` entirely. In that case it owns its
+transport usage, local execution, logging, state updates, and failure behavior.
+
+The built-in dummy provisioner demonstrates this minimal pattern: it does not
+use the base transport workflow and raises `Kitchen::ActionFailed` when
+configured to fail.
+
+## What the base class provides
+
+Provisioners normally get these shared helpers from the base class and
+configuration mixin:
+
+* `finalize_config!(instance)`
+* access to `instance`, `instance.platform`, `instance.suite`, and
+  `instance.transport`
+* hash-like config lookup with `[]`
+* path and shell helpers for Unix, Windows, Bourne shell, and PowerShell
+* proxy and environment wrapping helpers
+* sandbox helpers such as `create_sandbox`, `sandbox_path`, `sandbox_dirs`, and
+  `cleanup_sandbox`
+* diagnostics and plugin metadata
+* logging helpers
+* `no_parallel_for :converge`
+
+## Failure behavior
+
+Provisioners should raise `Kitchen::ActionFailed` for expected converge
+failures.
+
+The base workflow rescues `Kitchen::Transport::TransportFailed` and re-raises
+`Kitchen::ActionFailed`. Kitchen then records the failure in state, logs details,
+preserves the previous successful lifecycle state, and raises
+`Kitchen::InstanceFailure`.
+
+## Current rough edges
+
+The current provisioner contract includes several implicit behaviors:
+
+* The base workflow depends heavily on the transport command and file APIs.
+* Provisioner state is shared mutable instance state with no namespace.
+* Windows over SSH has special behavior that inspects transport config details.
+* Secret handling and redaction are not expressed as a formal provisioner
+  contract.
+* A provisioner can either use the base workflow or replace it completely, which
+  makes the true minimum contract smaller than the base class suggests.
+
+Future work should define a clearer provisioner contract, including serialized
+configuration, state ownership, events, failure reporting, transport boundaries,
+and secret handling.

--- a/docs/content/docs/reference/current-transport-contract.md
+++ b/docs/content/docs/reference/current-transport-contract.md
@@ -1,0 +1,136 @@
+---
+title: Current Transport Contract
+menu:
+  docs:
+    parent: reference
+    weight: 21
+---
+
+This page records the current Test Kitchen transport contract. It describes how
+Kitchen uses transports today, including behavior that exists because of the
+Ruby base classes, built-in SSH and WinRM transports, and current call sites.
+
+This is not a redesign of the transport API. It is a snapshot of the current
+state so future work can make the contract clearer.
+
+## How Kitchen loads transports
+
+Transports are Ruby plugins. Kitchen loads a transport by calling
+`Kitchen::Transport.for_plugin(name, config)`, which delegates to the shared
+plugin loader.
+
+For a transport named `example`, Kitchen expects to be able to require:
+
+```text
+kitchen/transport/example
+```
+
+and find a class under `Kitchen::Transport`, such as:
+
+```ruby
+module Kitchen
+  module Transport
+    class Example < Kitchen::Transport::Base
+    end
+  end
+end
+```
+
+Kitchen initializes the transport with a config hash and then finalizes it with
+the instance before use.
+
+## Methods Kitchen calls
+
+The required transport method is:
+
+```ruby
+connection(state)
+```
+
+Kitchen call sites normally use block form:
+
+```ruby
+transport.connection(state) do |connection|
+  connection.execute(command)
+end
+```
+
+Kitchen does not automatically close the connection after the block. Transports
+own connection caching, reuse, closing, and cleanup.
+
+Transports may also implement:
+
+```ruby
+doctor(state)
+cleanup!
+```
+
+`cleanup!` is called when the instance cleans up per-instance resources.
+
+## Connection object
+
+A transport connection should provide these methods:
+
+```ruby
+execute(command)
+execute_with_retry(command, retryable_exit_codes, max_retries, wait_time)
+upload(locals, remote)
+download(remotes, local)
+login_command
+close
+wait_until_ready
+```
+
+`Kitchen::Transport::Base::Connection` provides a default
+`execute_with_retry` implementation. It retries only transport failures whose
+`exit_code` appears in the retryable exit code list.
+
+In practice, built-in transports treat `execute(nil)` as a silent no-op. Base
+provisioner and verifier implementations rely on that behavior because command
+hooks may return `nil`.
+
+## State and config
+
+Every call to `connection` receives the mutable instance state hash. Built-in
+SSH and WinRM transports merge transport config and state, with state values
+overriding config values for connection details such as hostname, port,
+username, password, and similar fields.
+
+That state-over-config behavior is part of the current practical contract.
+Drivers often write connection details into state during `create`, and
+transports read them later.
+
+## File and command behavior
+
+Provisioners, verifiers, and remote lifecycle hooks use transports for command
+execution and file movement.
+
+`upload` should accept a single local path or an array-like collection of local
+paths plus a remote destination.
+
+`download` should accept a single remote path or an array-like collection of
+remote paths plus a local destination.
+
+Non-zero command exits should raise `Kitchen::Transport::TransportFailed` or a
+subclass. When possible, the exception should expose an `exit_code` so retry
+logic and callers can make decisions.
+
+`login_command` should return a `Kitchen::LoginCommand` when interactive login
+is supported. The base implementation raises `Kitchen::ActionFailed` when it is
+not supported.
+
+## Current rough edges
+
+The current transport contract includes several implicit behaviors:
+
+* Connection block support is expected by core consumers, but block completion
+  does not imply connection close.
+* State overrides config for built-in transports.
+* `execute(nil)` is expected to be a no-op.
+* Some remote lifecycle hook skippability is coupled to SSH-style error text.
+* `wait_until_ready` exists on the connection API but is not broadly used by
+  core call sites.
+
+Future work should define an explicit command, file, connection, login, retry,
+and error contract so transports and external providers do not have to infer
+behavior from built-in implementations.

--- a/docs/content/docs/reference/current-verifier-contract.md
+++ b/docs/content/docs/reference/current-verifier-contract.md
@@ -1,0 +1,139 @@
+---
+title: Current Verifier Contract
+menu:
+  docs:
+    parent: reference
+    weight: 23
+---
+
+This page records the current Test Kitchen verifier contract. It describes how
+Kitchen uses verifiers today, including behavior that exists because of the Ruby
+base classes, local shell execution, and current transport integration.
+
+This is not a redesign of the verifier API. It is a snapshot of the current
+state so future work can make the contract clearer.
+
+## How Kitchen loads verifiers
+
+Verifiers are Ruby plugins. Kitchen loads a verifier by calling
+`Kitchen::Verifier.for_plugin(name, config)`, which delegates to the shared
+plugin loader.
+
+For a verifier named `example`, Kitchen expects to be able to require:
+
+```text
+kitchen/verifier/example
+```
+
+and find a class under `Kitchen::Verifier`, such as:
+
+```ruby
+module Kitchen
+  module Verifier
+    class Example < Kitchen::Verifier::Base
+    end
+  end
+end
+```
+
+Kitchen initializes the verifier with a config hash and then finalizes it with
+the instance before verification.
+
+## Methods Kitchen calls
+
+The current verifier method Kitchen depends on is:
+
+```ruby
+call(state)
+```
+
+Verifiers may also implement:
+
+```ruby
+doctor(state)
+```
+
+`state` is the mutable instance state hash. Kitchen reads it before verification
+and writes it after the action.
+
+## Using the base workflow
+
+A verifier can subclass `Kitchen::Verifier::Base` and use the default remote
+execution workflow.
+
+In that workflow, a verifier can implement these command hooks:
+
+```ruby
+install_command
+init_command
+prepare_command
+run_command
+```
+
+The base workflow:
+
+* creates a local sandbox
+* opens `instance.transport.connection(state)`
+* runs install and init commands
+* uploads sandbox contents to `root_path`
+* runs prepare
+* runs the main command
+* downloads configured `downloads`
+* cleans up the local sandbox
+
+Downloads are attempted in an ensure block, so configured downloads may run even
+after the verifier command fails.
+
+Each command hook may return `nil`. Current transports are expected to no-op
+for `execute(nil)`.
+
+## Overriding the workflow
+
+A verifier may override `call(state)` entirely. In that case it owns its
+transport usage, local execution, logging, state updates, and failure behavior.
+
+The shell verifier demonstrates this broader current contract. It runs locally
+by default through shell-out and only returns a remote command when configured
+with remote execution.
+
+## What the base class provides
+
+Verifiers normally get these shared helpers from the base class and
+configuration mixin:
+
+* `finalize_config!(instance)`
+* access to `instance`, `instance.platform`, `instance.suite`, and
+  `instance.transport`
+* hash-like config lookup with `[]`
+* path and shell helpers for Unix, Windows, Bourne shell, and PowerShell
+* proxy and environment wrapping helpers
+* sandbox helpers such as `create_sandbox`, `sandbox_path`, `sandbox_dirs`, and
+  `cleanup_sandbox`
+* diagnostics and plugin metadata
+* logging helpers
+* `no_parallel_for :verify`
+
+## Failure behavior
+
+Verifiers should raise `Kitchen::ActionFailed` for expected verification
+failures.
+
+The base workflow rescues `Kitchen::Transport::TransportFailed` and re-raises
+`Kitchen::ActionFailed`. Kitchen then records the failure in state, logs details,
+preserves the previous successful lifecycle state, and raises
+`Kitchen::InstanceFailure`.
+
+## Current rough edges
+
+The current verifier contract includes several implicit behaviors:
+
+* The base workflow depends on the transport command and file APIs.
+* Local and remote execution are both valid verifier patterns.
+* Downloads can run after a verifier command failure.
+* Verifier state is shared mutable instance state with no namespace.
+* A verifier can either use the base workflow or replace it completely, which
+  makes the true minimum contract smaller than the base class suggests.
+
+Future work should define a clearer verifier contract, including local versus
+remote execution, serialized context, state ownership, event output, and failure
+reporting.


### PR DESCRIPTION
## Summary
- Initialize ADR tracking under docs/adr and add ADRs for the current driver, transport, provisioner, and verifier contracts.
- Add reference documentation for the current driver, transport, provisioner, and verifier plugin surfaces.
- Preserve the current messy behavior as documented baseline for future contract improvements.

## Test Plan
- adr list
- git diff --cached --check
- rg -n "[ 	]+$" docs/adr docs/content/docs/reference
- hugo not run: hugo is not installed locally