### PR TITLE
feat: add structured kitchen logs

### DIFF
--- a/.github/scripts/kitchen/provisioner/dokken_ci.rb
+++ b/.github/scripts/kitchen/provisioner/dokken_ci.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require 'kitchen/provisioner/dokken'
-require 'kitchen/provisioner/cinc/berkshelf'
-require 'kitchen/provisioner/cinc/common_sandbox'
-require 'kitchen/provisioner/cinc/policyfile'
+require "kitchen/provisioner/dokken"
+require "kitchen/provisioner/cinc/berkshelf"
+require "kitchen/provisioner/cinc/common_sandbox"
+require "kitchen/provisioner/cinc/policyfile"
 
 module KitchenDokkenCI
   def self.patch

--- a/.github/scripts/kitchen_dokken_ci_verify.rb
+++ b/.github/scripts/kitchen_dokken_ci_verify.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require 'kitchen/cli'
-require 'kitchen/errors'
-require_relative 'kitchen/provisioner/dokken_ci'
+require "kitchen/cli"
+require "kitchen/errors"
+require_relative "kitchen/provisioner/dokken_ci"
 
 Kitchen.with_friendly_errors do
-  Kitchen::CLI.start(['verify', *ARGV])
+  Kitchen::CLI.start(["verify", *ARGV])
 end

--- a/docs/content/docs/getting-started/02-getting-help.md
+++ b/docs/content/docs/getting-started/02-getting-help.md
@@ -23,6 +23,7 @@ Commands:
   kitchen init                                    # Adds some configuration to your cookbook so Kitchen can rock
   kitchen list [INSTANCE|REGEXP|all]              # Lists one or more instances
   kitchen login INSTANCE|REGEXP                   # Log in to one instance
+  kitchen logs [INSTANCE|REGEXP|all]              # Show structured logs
   kitchen package INSTANCE|REGEXP                 # package an instance
   kitchen setup [INSTANCE|REGEXP|all]             # Change instance state to setup. Prepare to run automated tests. Install busser and related gems on one or more instances
   kitchen test [INSTANCE|REGEXP|all]              # Test (destroy, create, converge, setup, verify and destroy) one or more instances

--- a/docs/content/docs/getting-started/02-getting-help.md
+++ b/docs/content/docs/getting-started/02-getting-help.md
@@ -23,7 +23,6 @@ Commands:
   kitchen init                                    # Adds some configuration to your cookbook so Kitchen can rock
   kitchen list [INSTANCE|REGEXP|all]              # Lists one or more instances
   kitchen login INSTANCE|REGEXP                   # Log in to one instance
-  kitchen logs [INSTANCE|REGEXP|all]              # Show structured logs
   kitchen package INSTANCE|REGEXP                 # package an instance
   kitchen setup [INSTANCE|REGEXP|all]             # Change instance state to setup. Prepare to run automated tests. Install busser and related gems on one or more instances
   kitchen test [INSTANCE|REGEXP|all]              # Test (destroy, create, converge, setup, verify and destroy) one or more instances

--- a/features/kitchen_logs_command.feature
+++ b/features/kitchen_logs_command.feature
@@ -1,0 +1,51 @@
+Feature: Showing Test Kitchen logs
+  In order to inspect live and historical instance output
+  As a Test Kitchen user
+  I want structured logs to be available in text and NDJSON formats
+
+  Background:
+    Given a file named ".kitchen.yml" with:
+    """
+    ---
+    driver:
+      name: dummy
+
+    provisioner:
+      name: dummy
+
+    verifier:
+      name: dummy
+
+    platforms:
+      - name: ubuntu-24.04
+
+    suites:
+      - name: default
+    """
+    And a file named ".kitchen/logs/default-ubuntu-2404.ndjson" with:
+    """
+    {"level":"debug","message":"debug detail","instance_session_id":"session-current"}
+    {"level":"info","message":"booting","instance_session_id":"session-current"}
+    {"level":"warn","message":"package cache stale","instance_session_id":"session-current"}
+    {"level":"error","message":"converge failed","instance_session_id":"session-current"}
+    """
+
+  Scenario: Showing all session logs as text by default
+    When I run `kitchen logs --all-sessions --level warn`
+    Then the exit status should be 0
+    And the output should contain exactly:
+    """
+    package cache stale
+    converge failed
+
+    """
+
+  Scenario: Showing all session logs as NDJSON when requested
+    When I run `kitchen logs --all-sessions --format ndjson --level warn`
+    Then the exit status should be 0
+    And the output should contain exactly:
+    """
+    {"level":"warn","message":"package cache stale","instance_session_id":"session-current"}
+    {"level":"error","message":"converge failed","instance_session_id":"session-current"}
+
+    """

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -6,7 +6,7 @@ driver:
   chef_version: 19
 
 provisioner:
-  name: dokken
+  name: dokken_ci
   product_name: cinc
   chef_binary: /opt/cinc/bin/cinc-client
   install_strategy: skip

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -6,7 +6,7 @@ driver:
   chef_version: 19
 
 provisioner:
-  name: dokken_ci
+  name: dokken
   product_name: cinc
   chef_binary: /opt/cinc/bin/cinc-client
   install_strategy: skip

--- a/lib/kitchen.rb
+++ b/lib/kitchen.rb
@@ -16,6 +16,7 @@
 # limitations under the License.
 
 require "pathname" unless defined?(Pathname)
+require "securerandom"
 require_relative "kitchen/errors"
 require_relative "kitchen/logger"
 require_relative "kitchen/logging"
@@ -59,6 +60,9 @@ module Kitchen
     # @return [Mutex] a mutex used for Dir.chdir coordination
     attr_accessor :mutex_chdir
 
+    # @return [String] identifier for the current Kitchen process invocation
+    attr_writer :run_id
+
     # Returns the root path of the Kitchen gem source code.
     #
     # @return [Pathname] root path of gem
@@ -70,7 +74,11 @@ module Kitchen
     #
     # @return [Logger] a logger
     def default_logger
-      Logger.new(stdout: $stdout, level: Util.to_logger_level(env_log))
+      Logger.new(
+        stdout: $stdout,
+        level: Util.to_logger_level(env_log),
+        metadata: { kitchen_run_id: run_id }
+      )
     end
 
     # Returns a default file logger which emits on standard output and to a
@@ -84,13 +92,24 @@ module Kitchen
       log_overwrite = log_overwrite.nil? ? env_log_overwrite : log_overwrite
       log_location = File.expand_path(File.join(DEFAULT_LOG_DIR, "kitchen.log"))
       log_location = log_location.to_s
+      structured_log_location = File.expand_path(File.join(DEFAULT_LOG_DIR, "kitchen.ndjson"))
+      structured_log_location = structured_log_location.to_s
 
       Logger.new(
         stdout: $stdout,
         logdev: log_location,
+        structured_logdev: structured_log_location,
         level: Util.to_logger_level(level),
-        log_overwrite:
+        log_overwrite:,
+        metadata: { kitchen_run_id: run_id }
       )
+    end
+
+    # Returns the current Kitchen run identifier.
+    #
+    # @return [String] identifier for the current Kitchen process invocation
+    def run_id
+      @run_id ||= SecureRandom.uuid
     end
 
     # Returns whether or not standard output is associated with a terminal

--- a/lib/kitchen.rb
+++ b/lib/kitchen.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 require "pathname" unless defined?(Pathname)
-require "securerandom"
+require "securerandom" unless defined?(SecureRandom)
 require_relative "kitchen/errors"
 require_relative "kitchen/logger"
 require_relative "kitchen/logging"

--- a/lib/kitchen/cli.rb
+++ b/lib/kitchen/cli.rb
@@ -110,13 +110,20 @@ module Kitchen
       aliases: "-j",
       type: :boolean,
       desc: "Print data as JSON"
+    method_option :live,
+      type: :boolean,
+      desc: "Include driver-reported live instance status"
+    method_option :probe,
+      type: :boolean,
+      desc: "Probe transport connectivity in addition to driver status"
     method_option :debug,
       aliases: "-d",
       type: :boolean,
       desc: "[Deprecated] Please use `kitchen diagnose'"
     log_options
     def list(*args)
-      update_config!
+      log_overwrite = options[:log_overwrite].nil? ? false : options[:log_overwrite]
+      update_config!(log_overwrite:)
       perform("list", "list", args)
     end
     map status: :list
@@ -257,6 +264,27 @@ module Kitchen
       perform("login", "login", args)
     end
 
+    desc "logs [INSTANCE|REGEXP|all]", "Show structured logs"
+    method_option :level,
+      desc: "Minimum log level to print (debug, info, warn, error, fatal)"
+    method_option :session_id,
+      desc: "Only print logs for the given instance session id"
+    method_option :all_sessions,
+      type: :boolean,
+      desc: "Print logs from all instance sessions; defaults to all instances"
+    method_option :format,
+      default: 'text',
+      desc: "Output format (ndjson, text)"
+    method_option :follow,
+      aliases: "-f",
+      type: :boolean,
+      desc: "Follow the structured log file"
+    log_options
+    def logs(*args)
+      update_config!(log_overwrite: false)
+      perform("logs", "logs", args)
+    end
+
     desc "package INSTANCE|REGEXP", "package an instance"
     log_options
     def package(*args)
@@ -334,12 +362,10 @@ module Kitchen
     # Update and finalize options for logging, concurrency, and other concerns.
     #
     # @api private
-    def update_config!
+    def update_config!(log_overwrite: options[:log_overwrite])
       @config.log_level = log_level if log_level
 
-      unless options[:log_overwrite].nil?
-        @config.log_overwrite = options[:log_overwrite]
-      end
+      @config.log_overwrite = log_overwrite unless log_overwrite.nil?
       @config.colorize = options[:color] unless options[:color].nil?
 
       if options[:test_base_path]
@@ -352,7 +378,7 @@ module Kitchen
       # Now that we have required configs, lets create our file logger
       Kitchen.logger = Kitchen.default_file_logger(
         log_level,
-        options[:log_overwrite]
+        log_overwrite
       )
 
       update_parallel!

--- a/lib/kitchen/cli.rb
+++ b/lib/kitchen/cli.rb
@@ -273,7 +273,7 @@ module Kitchen
       type: :boolean,
       desc: "Print logs from all instance sessions; defaults to all instances"
     method_option :format,
-      default: 'text',
+      default: "text",
       desc: "Output format (ndjson, text)"
     method_option :follow,
       aliases: "-f",

--- a/lib/kitchen/command/list.rb
+++ b/lib/kitchen/command/list.rb
@@ -57,7 +57,7 @@ module Kitchen
       # @return [Array<String>]
       # @api private
       def display_instance(instance)
-        [
+        row = [
           color_pad(instance.name),
           color_pad(instance.driver.name),
           color_pad(instance.provisioner.name),
@@ -66,6 +66,8 @@ module Kitchen
           format_last_action(instance.last_action),
           format_last_error(instance.last_error),
         ]
+        row << format_live_status(instance_status(instance)) if status_requested?
+        row
       end
 
       # Format and color the given last action.
@@ -96,19 +98,39 @@ module Kitchen
         end
       end
 
+      # Format and color live status.
+      #
+      # @param status [Hash] normalized status data
+      # @return [String] formatted live status
+      # @api private
+      def format_live_status(status)
+        probe = status[:transport_probe]
+        if probe && probe[:reachable] == false
+          return colorize("#{status[:state]} (#{probe[:state]})", :red)
+        elsif probe && probe[:reachable] == true
+          return colorize("#{status[:state]} (#{probe[:state]})", :green)
+        end
+
+        case status[:live]
+        when true then colorize(status[:state], :green)
+        when false then colorize(status[:state], :red)
+        else colorize(status[:state], :white)
+        end
+      end
+
       # Constructs a list display table and output it to the screen.
       #
       # @param result [Array<Instance>] an array of instances
       # @api private
       def list_table(result)
-        table = [
-          [
-            colorize("Instance", :green), colorize("Driver", :green),
-            colorize("Provisioner", :green), colorize("Verifier", :green),
-            colorize("Transport", :green), colorize("Last Action", :green),
-            colorize("Last Error", :green)
-          ],
+        headings = [
+          colorize("Instance", :green), colorize("Driver", :green),
+          colorize("Provisioner", :green), colorize("Verifier", :green),
+          colorize("Transport", :green), colorize("Last Action", :green),
+          colorize("Last Error", :green)
         ]
+        headings << colorize("Live Status", :green) if status_requested?
+        table = [headings]
         table += Array(result).map { |i| display_instance(i) }
         print_table(table)
       end
@@ -118,7 +140,7 @@ module Kitchen
       # @param result [Hash{Symbol => String}] hash of a single instance
       # @api private
       def to_hash(result)
-        {
+        data = {
           instance: result.name,
           driver: result.driver.name,
           provisioner: result.provisioner.name,
@@ -127,6 +149,24 @@ module Kitchen
           last_action: result.last_action,
           last_error: result.last_error,
         }
+        if status_requested?
+          data.merge!(
+            log_path: result.log_path,
+            structured_log_path: result.structured_log_path,
+            state_path: result.state_path,
+            instance_session_id: result.current_session_id,
+            status: instance_status(result)
+          )
+        end
+        data
+      end
+
+      def status_requested?
+        options[:live] || options[:probe]
+      end
+
+      def instance_status(instance)
+        options[:probe] ? instance.status(probe: true) : instance.status
       end
 
       # Outputs a formatted display table.

--- a/lib/kitchen/command/logs.rb
+++ b/lib/kitchen/command/logs.rb
@@ -1,0 +1,184 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative '../command'
+
+require 'json' unless defined?(JSON)
+
+module Kitchen
+  module Command
+    # Command to print structured logs for one instance.
+    class Logs < Kitchen::Command::Base
+      LEVELS = %w(debug info warn error fatal unknown).freeze
+
+      # Invoke the command.
+      def call
+        validate_format!
+        validate_level!
+        if options[:all_sessions]
+          emit_all_session_logs
+          return
+        end
+
+        target_instances = instances
+        validate_follow_target!(target_instances)
+
+        target_instances.each do |instance|
+          session_id = selected_session_id(instance)
+          die "No structured log file found at #{instance.structured_log_path}" unless
+            File.file?(instance.structured_log_path)
+
+          emit_file(instance.structured_log_path, session_id)
+          follow_file(instance.structured_log_path, session_id) if options[:follow]
+        end
+      end
+
+      private
+
+      def emit_all_session_logs
+        log_paths = all_session_log_paths
+        validate_follow_target!(log_paths)
+
+        log_paths.each do |path|
+          emit_file(path, nil)
+          follow_file(path, nil) if options[:follow]
+        end
+      end
+
+      def all_session_log_paths
+        paths = structured_log_paths(args.first)
+        return paths unless paths.empty?
+
+        die "No structured log files found in #{Kitchen::DEFAULT_LOG_DIR}"
+      end
+
+      def structured_log_paths(arg)
+        paths = all_structured_log_paths
+        return paths if arg.nil? || arg == 'all'
+
+        exact_path = File.join(Kitchen::DEFAULT_LOG_DIR, "#{arg}.ndjson")
+        return [exact_path] if File.file?(exact_path)
+
+        regexp = Regexp.new(arg)
+        paths.select { |path| File.basename(path, '.ndjson') =~ regexp }
+      rescue RegexpError => e
+        die 'Invalid Ruby regular expression, ' \
+          'you may need to single quote the argument. ' \
+          "Please try again or consult https://rubular.com/ (#{e.message})"
+      end
+
+      def all_structured_log_paths
+        Dir[File.join(Kitchen::DEFAULT_LOG_DIR, '*.ndjson')]
+          .reject { |path| File.basename(path) == 'kitchen.ndjson' }
+          .sort
+      end
+
+      def validate_follow_target!(targets)
+        return unless options[:follow] && targets.size > 1
+
+        die 'Following multiple instance logs is not supported; choose one instance'
+      end
+
+      def instances
+        results = parse_subcommand(args.first)
+        if results.size > 1 && !options[:all_sessions]
+          die "Argument `#{args.first}' returned multiple results:\n" +
+              results.map { |i| "  * #{i.name}" }.join("\n")
+        end
+        results
+      end
+
+      def selected_session_id(instance)
+        return if options[:all_sessions]
+        return options[:session_id] if options[:session_id]
+        return instance.current_session_id if instance.current_session_id
+        if File.file?(instance.structured_log_path)
+          session_id = latest_session_id(instance.structured_log_path)
+          return session_id if session_id
+        end
+
+        die "Instance #{instance.to_str} has no current session id; use --all-sessions"
+      end
+
+      def latest_session_id(path)
+        File.foreach(path).filter_map do |line|
+          JSON.parse(line)['instance_session_id']
+        rescue JSON::ParserError
+          nil
+        end.last
+      end
+
+      def emit_file(path, session_id)
+        File.foreach(path) { |line| emit_line(line, session_id) }
+      end
+
+      def follow_file(path, session_id)
+        File.open(path, 'r') do |file|
+          file.seek(0, IO::SEEK_END)
+          loop do
+            line = file.gets
+            if line
+              emit_line(line, session_id)
+            else
+              sleep 1
+            end
+          end
+        end
+      end
+
+      def emit_line(line, session_id)
+        event = JSON.parse(line)
+        return unless session_match?(event, session_id)
+        return unless level_match?(event)
+
+        puts format_event(event)
+      rescue JSON::ParserError
+        nil
+      end
+
+      def format_event(event)
+        case options[:format]
+        when 'ndjson' then JSON.generate(event)
+        when nil, 'text' then event['message'].to_s
+        end
+      end
+
+      def session_match?(event, session_id)
+        session_id.nil? || event['instance_session_id'] == session_id
+      end
+
+      def level_match?(event)
+        return true unless options[:level]
+
+        level_index(event['level']) >= level_index(options[:level])
+      end
+
+      def level_index(level)
+        LEVELS.index(level.to_s) || LEVELS.index('unknown')
+      end
+
+      def validate_format!
+        return if [nil, 'ndjson', 'text'].include?(options[:format])
+
+        die "Invalid logs format `#{options[:format]}'; use ndjson or text"
+      end
+
+      def validate_level!
+        return unless options[:level]
+        return if LEVELS.include?(options[:level])
+
+        die "Invalid log level `#{options[:level]}'; use debug, info, warn, error, or fatal"
+      end
+    end
+  end
+end

--- a/lib/kitchen/command/logs.rb
+++ b/lib/kitchen/command/logs.rb
@@ -11,15 +11,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require_relative '../command'
+require_relative "../command"
 
-require 'json' unless defined?(JSON)
+require "json" unless defined?(JSON)
 
 module Kitchen
   module Command
     # Command to print structured logs for one instance.
     class Logs < Kitchen::Command::Base
-      LEVELS = %w(debug info warn error fatal unknown).freeze
+      LEVELS = %w{debug info warn error fatal unknown}.freeze
 
       # Invoke the command.
       def call
@@ -64,36 +64,36 @@ module Kitchen
 
       def structured_log_paths(arg)
         paths = all_structured_log_paths
-        return paths if arg.nil? || arg == 'all'
+        return paths if arg.nil? || arg == "all"
 
         exact_path = File.join(Kitchen::DEFAULT_LOG_DIR, "#{arg}.ndjson")
         return [exact_path] if File.file?(exact_path)
 
         regexp = Regexp.new(arg)
-        paths.select { |path| File.basename(path, '.ndjson') =~ regexp }
+        paths.select { |path| File.basename(path, ".ndjson") =~ regexp }
       rescue RegexpError => e
-        die 'Invalid Ruby regular expression, ' \
-          'you may need to single quote the argument. ' \
+        die "Invalid Ruby regular expression, " \
+          "you may need to single quote the argument. " \
           "Please try again or consult https://rubular.com/ (#{e.message})"
       end
 
       def all_structured_log_paths
-        Dir[File.join(Kitchen::DEFAULT_LOG_DIR, '*.ndjson')]
-          .reject { |path| File.basename(path) == 'kitchen.ndjson' }
+        Dir[File.join(Kitchen::DEFAULT_LOG_DIR, "*.ndjson")]
+          .reject { |path| File.basename(path) == "kitchen.ndjson" }
           .sort
       end
 
       def validate_follow_target!(targets)
         return unless options[:follow] && targets.size > 1
 
-        die 'Following multiple instance logs is not supported; choose one instance'
+        die "Following multiple instance logs is not supported; choose one instance"
       end
 
       def instances
         results = parse_subcommand(args.first)
         if results.size > 1 && !options[:all_sessions]
           die "Argument `#{args.first}' returned multiple results:\n" +
-              results.map { |i| "  * #{i.name}" }.join("\n")
+            results.map { |i| "  * #{i.name}" }.join("\n")
         end
         results
       end
@@ -102,6 +102,7 @@ module Kitchen
         return if options[:all_sessions]
         return options[:session_id] if options[:session_id]
         return instance.current_session_id if instance.current_session_id
+
         if File.file?(instance.structured_log_path)
           session_id = latest_session_id(instance.structured_log_path)
           return session_id if session_id
@@ -112,7 +113,7 @@ module Kitchen
 
       def latest_session_id(path)
         File.foreach(path).filter_map do |line|
-          JSON.parse(line)['instance_session_id']
+          JSON.parse(line)["instance_session_id"]
         rescue JSON::ParserError
           nil
         end.last
@@ -123,7 +124,7 @@ module Kitchen
       end
 
       def follow_file(path, session_id)
-        File.open(path, 'r') do |file|
+        File.open(path, "r") do |file|
           file.seek(0, IO::SEEK_END)
           loop do
             line = file.gets
@@ -148,27 +149,27 @@ module Kitchen
 
       def format_event(event)
         case options[:format]
-        when 'ndjson' then JSON.generate(event)
-        when nil, 'text' then event['message'].to_s
+        when "ndjson" then JSON.generate(event)
+        when nil, "text" then event["message"].to_s
         end
       end
 
       def session_match?(event, session_id)
-        session_id.nil? || event['instance_session_id'] == session_id
+        session_id.nil? || event["instance_session_id"] == session_id
       end
 
       def level_match?(event)
         return true unless options[:level]
 
-        level_index(event['level']) >= level_index(options[:level])
+        level_index(event["level"]) >= level_index(options[:level])
       end
 
       def level_index(level)
-        LEVELS.index(level.to_s) || LEVELS.index('unknown')
+        LEVELS.index(level.to_s) || LEVELS.index("unknown")
       end
 
       def validate_format!
-        return if [nil, 'ndjson', 'text'].include?(options[:format])
+        return if [nil, "ndjson", "text"].include?(options[:format])
 
         die "Invalid logs format `#{options[:format]}'; use ndjson or text"
       end

--- a/lib/kitchen/config.rb
+++ b/lib/kitchen/config.rb
@@ -270,13 +270,21 @@ module Kitchen
     def new_instance_logger(suite, platform, index)
       name = instance_name(suite, platform)
       log_location = File.join(log_root, "#{name}.log").to_s
+      structured_log_location = File.join(log_root, "#{name}.ndjson").to_s
       Logger.new(
         stdout: STDOUT,
         color: Color::COLORS[index % Color::COLORS.size].to_sym,
         logdev: log_location,
+        structured_logdev: structured_log_location,
         level: Util.to_logger_level(log_level),
         log_overwrite:,
         progname: name,
+        metadata: {
+          kitchen_run_id: Kitchen.run_id,
+          instance: name,
+          suite: suite.name,
+          platform: platform.name,
+        },
         colorize: @colorize
       )
     end

--- a/lib/kitchen/driver/base.rb
+++ b/lib/kitchen/driver/base.rb
@@ -16,6 +16,7 @@ require_relative "../lazy_hash"
 require_relative "../logging"
 require_relative "../plugin_base"
 require_relative "../shell_out"
+require "time"
 
 module Kitchen
   module Driver
@@ -61,6 +62,24 @@ module Kitchen
       # @returns [Boolean] Return true if a problem is found.
       def doctor(state)
         false
+      end
+
+      # Reports whether the backing instance is known to be live.
+      #
+      # Drivers that can ask their provider should override this method.
+      # Existing drivers remain compatible by inheriting an unknown status.
+      #
+      # @param state [Hash] mutable instance and driver state
+      # @return [Hash] normalized status data
+      def status(state) # rubocop:disable Lint/UnusedMethodArgument
+        {
+          live: nil,
+          state: "unknown",
+          source: "driver",
+          resource_id: nil,
+          message: "#{self.class} does not support status checks",
+          checked_at: Time.now.utc.iso8601,
+        }
       end
 
       # Sets the API version for this driver. If the driver does not set this

--- a/lib/kitchen/driver/base.rb
+++ b/lib/kitchen/driver/base.rb
@@ -16,7 +16,7 @@ require_relative "../lazy_hash"
 require_relative "../logging"
 require_relative "../plugin_base"
 require_relative "../shell_out"
-require "time"
+require "time" unless defined?(Time)
 
 module Kitchen
   module Driver

--- a/lib/kitchen/driver/dummy.rb
+++ b/lib/kitchen/driver/dummy.rb
@@ -11,6 +11,7 @@
 # limitations under the License.
 
 require_relative "../../kitchen"
+require "time"
 
 module Kitchen
   module Driver
@@ -49,6 +50,32 @@ module Kitchen
       def destroy(state)
         report(:destroy, state)
         state.delete(:my_id)
+      end
+
+      # Reports whether the dummy instance has a generated resource id.
+      #
+      # @param state [Hash] mutable instance and driver state
+      # @return [Hash] normalized status data
+      def status(state)
+        if state[:my_id]
+          {
+            live: true,
+            state: "running",
+            source: "driver",
+            resource_id: state[:my_id],
+            message: "Dummy instance exists",
+            checked_at: Time.now.utc.iso8601,
+          }
+        else
+          {
+            live: false,
+            state: "not_created",
+            source: "driver",
+            resource_id: nil,
+            message: "Dummy instance has no resource id",
+            checked_at: Time.now.utc.iso8601,
+          }
+        end
       end
 
       private

--- a/lib/kitchen/driver/dummy.rb
+++ b/lib/kitchen/driver/dummy.rb
@@ -11,7 +11,7 @@
 # limitations under the License.
 
 require_relative "../../kitchen"
-require "time"
+require "time" unless defined?(Time)
 
 module Kitchen
   module Driver

--- a/lib/kitchen/errors.rb
+++ b/lib/kitchen/errors.rb
@@ -206,6 +206,7 @@ module Kitchen
         Kitchen.logger.debug(line)
       else
         Kitchen.logger.logdev && Kitchen.logger.logdev.public_send(level, line)
+        Kitchen.logger.structured_logdev && Kitchen.logger.structured_logdev.public_send(level, line)
       end
     end
   end

--- a/lib/kitchen/instance.rb
+++ b/lib/kitchen/instance.rb
@@ -17,6 +17,8 @@
 
 require "benchmark" unless defined?(Benchmark)
 require "fileutils" unless defined?(FileUtils)
+require "securerandom"
+require "time"
 
 module Kitchen
   # An instance of a suite running on a platform. A created instance may be a
@@ -287,6 +289,46 @@ module Kitchen
       state_file.read[:last_error]
     end
 
+    # Returns the current instance session identifier, if one has been
+    # established.
+    #
+    # @return [String,nil] the current instance session id
+    def current_session_id
+      state_file.read[:instance_session_id]
+    end
+
+    # Returns the path to the text log file for this instance.
+    #
+    # @return [String,nil] the instance text log path
+    def log_path
+      logger.logdev_path
+    end
+
+    # Returns the path to the structured log file for this instance.
+    #
+    # @return [String,nil] the instance structured log path
+    def structured_log_path
+      logger.structured_logdev_path
+    end
+
+    # Returns the path to the state file for this instance.
+    #
+    # @return [String] the instance state file path
+    def state_path
+      state_file.path
+    end
+
+    # Returns normalized liveness status for this instance.
+    #
+    # @param probe [Boolean] whether to probe the transport as well
+    # @return [Hash] normalized status data
+    def status(probe: false)
+      state = state_file.read
+      result = driver_status(state)
+      result[:transport_probe] = transport_probe(state) if probe
+      result
+    end
+
     # Clean up any per-instance resources before exiting.
     #
     # @return [void]
@@ -406,12 +448,14 @@ module Kitchen
     # @return [self] this instance, used to chain actions
     # @api private
     def converge_action
-      banner "Converging #{to_str}..."
       elapsed = action(:converge) do |state|
+        banner "Converging #{to_str}..."
         provisioner.check_license
         provisioner.call(state)
       end
-      info("Finished converging #{to_str} #{Util.duration(elapsed.real)}.")
+      with_current_action_metadata(:converge) do
+        info("Finished converging #{to_str} #{Util.duration(elapsed.real)}.")
+      end
       self
     end
 
@@ -421,10 +465,12 @@ module Kitchen
     # @return [self] this instance, used to chain actions
     # @api private
     def setup_action
-      banner "Setting up #{to_str}..."
       elapsed = action(:setup) do |state|
+        banner "Setting up #{to_str}..."
       end
-      info("Finished setting up #{to_str} #{Util.duration(elapsed.real)}.")
+      with_current_action_metadata(:setup) do
+        info("Finished setting up #{to_str} #{Util.duration(elapsed.real)}.")
+      end
       self
     end
 
@@ -434,11 +480,13 @@ module Kitchen
     # @return [self] this instance, used to chain actions
     # @api private
     def verify_action
-      banner "Verifying #{to_str}..."
       elapsed = action(:verify) do |state|
+        banner "Verifying #{to_str}..."
         verifier.call(state)
       end
-      info("Finished verifying #{to_str} #{Util.duration(elapsed.real)}.")
+      with_current_action_metadata(:verify) do
+        info("Finished verifying #{to_str} #{Util.duration(elapsed.real)}.")
+      end
       self
     end
 
@@ -460,10 +508,14 @@ module Kitchen
     # @return [self] this instance, used to chain actions
     # @api private
     def perform_action(verb, output_verb)
-      banner "#{output_verb} #{to_str}..."
-      elapsed = action(verb) { |state| driver.public_send(verb, state) }
-      info("Finished #{output_verb.downcase} #{to_str}" \
-        " #{Util.duration(elapsed.real)}.")
+      elapsed = action(verb) do |state|
+        banner "#{output_verb} #{to_str}..."
+        driver.public_send(verb, state)
+      end
+      with_current_action_metadata(verb) do
+        info("Finished #{output_verb.downcase} #{to_str}" \
+          " #{Util.duration(elapsed.real)}.")
+      end
       yield if block_given?
       self
     end
@@ -500,11 +552,99 @@ module Kitchen
     # @api private
     def banner(*args)
       Kitchen.logger.logdev && Kitchen.logger.logdev.banner(*args)
+      if Kitchen.logger.structured_logdev
+        Kitchen.logger.with_metadata(logger.metadata) do
+          Kitchen.logger.structured_logdev.banner(*args)
+        end
+      end
       super
     end
 
     def action_runner
       @action_runner ||= ActionRunner.new(self, state_file)
+    end
+
+    def with_current_action_metadata(what)
+      state = state_file.read
+      logger.with_metadata(
+        action: what.to_s,
+        action_id: state[:last_action_id],
+        instance_session_id: state[:instance_session_id],
+        kitchen_run_id: state[:last_kitchen_run_id] || Kitchen.run_id
+      ) do
+        yield
+      end
+    end
+
+    def driver_status(state)
+      if driver.method(:status).arity == 0
+        return unknown_driver_status(
+          "Driver status method does not accept Kitchen state"
+        )
+      end
+
+      normalize_driver_status(driver.status(state))
+    rescue Exception => e # rubocop:disable Lint/RescueException
+      unknown_driver_status(e.message, e.class.name)
+    end
+
+    def normalize_driver_status(status)
+      status = Util.symbolized_hash(status || {})
+      {
+        live: status[:live],
+        state: status[:state] || "unknown",
+        source: status[:source] || "driver",
+        resource_id: status[:resource_id],
+        message: status[:message],
+        checked_at: status[:checked_at] || Time.now.utc.iso8601,
+      }.compact
+    end
+
+    def unknown_driver_status(message, error = nil)
+      {
+        live: nil,
+        state: "unknown",
+        source: "driver",
+        error:,
+        message:,
+        checked_at: Time.now.utc.iso8601,
+      }.compact
+    end
+
+    def transport_probe(state)
+      return not_created_transport_probe if state[:last_action].nil?
+
+      transport.connection(state) do |conn|
+        conn.wait_until_ready
+      end
+      {
+        reachable: true,
+        state: "reachable",
+        source: "transport",
+        message: "Transport connection succeeded",
+        checked_at: Time.now.utc.iso8601,
+      }
+    rescue Exception => e # rubocop:disable Lint/RescueException
+      {
+        reachable: false,
+        state: "unreachable",
+        source: "transport",
+        error: e.class.name,
+        message: e.message,
+        checked_at: Time.now.utc.iso8601,
+      }
+    ensure
+      transport.cleanup! if transport
+    end
+
+    def not_created_transport_probe
+      {
+        reachable: false,
+        state: "not_created",
+        source: "transport",
+        message: "Instance has not yet been created",
+        checked_at: Time.now.utc.iso8601,
+      }
     end
 
     # Coordinates one instance action, including state persistence, plugin
@@ -518,25 +658,39 @@ module Kitchen
       def call(what, &block)
         state = nil
         state = state_file.read
-        elapsed = Benchmark.measure do
-          synchronize_or_call(what, state, &block)
+        action_id = new_id
+        session_id = state[:instance_session_id] || new_id
+        instance.logger.with_metadata(
+          action: what.to_s,
+          action_id:,
+          instance_session_id: session_id,
+          kitchen_run_id: Kitchen.run_id
+        ) do
+          begin
+            elapsed = Benchmark.measure do
+              synchronize_or_call(what, state, &block)
+            end
+            record_attempt(state, what, action_id, session_id)
+            state[:last_action] = what.to_s
+            state[:last_error] = nil
+            elapsed
+          rescue ActionFailed => e
+            log_failure(what, e)
+            record_attempt(state, what, action_id, session_id) if state
+            state[:last_error] = e.class.name if state
+            raise(InstanceFailure, failure_message(what) +
+              "  Please see .kitchen/logs/#{instance.name}.log for more details",
+              e.backtrace)
+          rescue Exception => e # rubocop:disable Lint/RescueException
+            log_failure(what, e)
+            record_attempt(state, what, action_id, session_id) if state
+            state[:last_error] = e.class.name if state
+            raise ActionFailed,
+              "Failed to complete ##{what} action: [#{e.message}]", e.backtrace
+          ensure
+            state_file.write(state) if state
+          end
         end
-        state[:last_action] = what.to_s
-        state[:last_error] = nil
-        elapsed
-      rescue ActionFailed => e
-        log_failure(what, e)
-        state[:last_error] = e.class.name if state
-        raise(InstanceFailure, failure_message(what) +
-          "  Please see .kitchen/logs/#{instance.name}.log for more details",
-          e.backtrace)
-      rescue Exception => e # rubocop:disable Lint/RescueException
-        log_failure(what, e)
-        state[:last_error] = e.class.name if state
-        raise ActionFailed,
-          "Failed to complete ##{what} action: [#{e.message}]", e.backtrace
-      ensure
-        state_file.write(state) if state
       end
 
       private
@@ -567,14 +721,27 @@ module Kitchen
       end
 
       def log_failure(what, e)
-        return if instance.logger.logdev.nil?
+        return if instance.logger.logdev.nil? && instance.logger.structured_logdev.nil?
 
-        instance.logger.logdev.error(failure_message(what))
-        Error.formatted_trace(e).each { |line| instance.logger.logdev.error(line) }
+        [instance.logger.logdev, instance.logger.structured_logdev].compact.each do |logdev|
+          logdev.error(failure_message(what))
+          Error.formatted_trace(e).each { |line| logdev.error(line) }
+        end
       end
 
       def failure_message(what)
         "#{what.capitalize} failed on instance #{instance.to_str}."
+      end
+
+      def record_attempt(state, what, action_id, session_id)
+        state[:instance_session_id] = session_id
+        state[:last_attempted_action] = what.to_s
+        state[:last_action_id] = action_id
+        state[:last_kitchen_run_id] = Kitchen.run_id
+      end
+
+      def new_id
+        SecureRandom.uuid
       end
     end
 

--- a/lib/kitchen/instance.rb
+++ b/lib/kitchen/instance.rb
@@ -17,8 +17,8 @@
 
 require "benchmark" unless defined?(Benchmark)
 require "fileutils" unless defined?(FileUtils)
-require "securerandom"
-require "time"
+require "securerandom" unless defined?(SecureRandom)
+require "time" unless defined?(Time)
 
 module Kitchen
   # An instance of a suite running on a platform. A created instance may be a
@@ -614,9 +614,7 @@ module Kitchen
     def transport_probe(state)
       return not_created_transport_probe if state[:last_action].nil?
 
-      transport.connection(state) do |conn|
-        conn.wait_until_ready
-      end
+      transport.connection(state, &:wait_until_ready)
       {
         reachable: true,
         state: "reachable",
@@ -656,7 +654,6 @@ module Kitchen
       end
 
       def call(what, &block)
-        state = nil
         state = state_file.read
         action_id = new_id
         session_id = state[:instance_session_id] || new_id
@@ -666,30 +663,28 @@ module Kitchen
           instance_session_id: session_id,
           kitchen_run_id: Kitchen.run_id
         ) do
-          begin
-            elapsed = Benchmark.measure do
-              synchronize_or_call(what, state, &block)
-            end
-            record_attempt(state, what, action_id, session_id)
-            state[:last_action] = what.to_s
-            state[:last_error] = nil
-            elapsed
-          rescue ActionFailed => e
-            log_failure(what, e)
-            record_attempt(state, what, action_id, session_id) if state
-            state[:last_error] = e.class.name if state
-            raise(InstanceFailure, failure_message(what) +
-              "  Please see .kitchen/logs/#{instance.name}.log for more details",
-              e.backtrace)
-          rescue Exception => e # rubocop:disable Lint/RescueException
-            log_failure(what, e)
-            record_attempt(state, what, action_id, session_id) if state
-            state[:last_error] = e.class.name if state
-            raise ActionFailed,
-              "Failed to complete ##{what} action: [#{e.message}]", e.backtrace
-          ensure
-            state_file.write(state) if state
+          elapsed = Benchmark.measure do
+            synchronize_or_call(what, state, &block)
           end
+          record_attempt(state, what, action_id, session_id)
+          state[:last_action] = what.to_s
+          state[:last_error] = nil
+          elapsed
+        rescue ActionFailed => e
+          log_failure(what, e)
+          record_attempt(state, what, action_id, session_id) if state
+          state[:last_error] = e.class.name if state
+          raise(InstanceFailure, failure_message(what) +
+            "  Please see .kitchen/logs/#{instance.name}.log for more details",
+            e.backtrace)
+        rescue Exception => e # rubocop:disable Lint/RescueException
+          log_failure(what, e)
+          record_attempt(state, what, action_id, session_id) if state
+          state[:last_error] = e.class.name if state
+          raise ActionFailed,
+            "Failed to complete ##{what} action: [#{e.message}]", e.backtrace
+        ensure
+          state_file.write(state) if state
         end
       end
 

--- a/lib/kitchen/logger.rb
+++ b/lib/kitchen/logger.rb
@@ -17,8 +17,8 @@
 
 require "fileutils" unless defined?(FileUtils)
 require "json" unless defined?(JSON)
-require "logger"
-require "time"
+require "logger" unless defined?(Logger)
+require "time" unless defined?(Time)
 
 module Kitchen
   # Logging implementation for Kitchen. By default the console/stdout output
@@ -74,11 +74,13 @@ module Kitchen
                        end
 
       @logdev = device_factory.logdev_logger(options[:logdev], log_overwrite) if options[:logdev]
-      @structured_logdev = device_factory.structured_logdev_logger(
-        options[:structured_logdev],
-        log_overwrite,
-        -> { metadata }
-      ) if options[:structured_logdev]
+      if options[:structured_logdev]
+        @structured_logdev = device_factory.structured_logdev_logger(
+          options[:structured_logdev],
+          log_overwrite,
+          -> { metadata }
+        )
+      end
       @logdev_path = expanded_log_path(options[:logdev])
       @structured_logdev_path = expanded_log_path(options[:structured_logdev])
 

--- a/lib/kitchen/logger.rb
+++ b/lib/kitchen/logger.rb
@@ -16,7 +16,9 @@
 # limitations under the License.
 
 require "fileutils" unless defined?(FileUtils)
+require "json" unless defined?(JSON)
 require "logger"
+require "time"
 
 module Kitchen
   # Logging implementation for Kitchen. By default the console/stdout output
@@ -30,6 +32,15 @@ module Kitchen
 
     # @return [IO] the log device
     attr_reader :logdev
+
+    # @return [IO] the structured log device
+    attr_reader :structured_logdev
+
+    # @return [String,nil] the expanded text log path, if configured
+    attr_reader :logdev_path
+
+    # @return [String,nil] the expanded structured log path, if configured
+    attr_reader :structured_logdev_path
 
     # @return [Boolean] whether logger is configured for
     #   overwriting
@@ -55,6 +66,7 @@ module Kitchen
     #   when Test Kitchen runs.
     #   (default: `$stdout.tty?`)
     def initialize(options = {})
+      @base_metadata = options[:metadata] || {}
       @log_overwrite = if options[:log_overwrite].nil?
                          default_log_overwrite
                        else
@@ -62,6 +74,13 @@ module Kitchen
                        end
 
       @logdev = device_factory.logdev_logger(options[:logdev], log_overwrite) if options[:logdev]
+      @structured_logdev = device_factory.structured_logdev_logger(
+        options[:structured_logdev],
+        log_overwrite,
+        -> { metadata }
+      ) if options[:structured_logdev]
+      @logdev_path = expanded_log_path(options[:logdev])
+      @structured_logdev_path = expanded_log_path(options[:structured_logdev])
 
       populate_loggers(options)
 
@@ -77,6 +96,7 @@ module Kitchen
     def populate_loggers(options)
       @loggers = []
       @loggers << logdev unless logdev.nil?
+      @loggers << structured_logdev unless structured_logdev.nil?
       @loggers << device_factory.stdout_logger(options[:stdout], options[:color], options[:colorize]) if
         options[:stdout]
       @loggers << device_factory.stdout_logger($stdout, options[:color], options[:colorize]) if
@@ -265,6 +285,23 @@ module Kitchen
     # @see http://is.gd/b13cVn
     delegate_to_all_loggers :close
 
+    # @return [Hash] metadata added to structured log events
+    def metadata
+      metadata_stack.inject(@base_metadata.dup) do |result, values|
+        result.merge(values)
+      end
+    end
+
+    # Temporarily adds metadata to structured log events.
+    #
+    # @param values [Hash] metadata fields to add for the block duration
+    def with_metadata(values)
+      metadata_stack.push(values.compact)
+      yield
+    ensure
+      metadata_stack.pop
+    end
+
     private
 
     # @return [Integer] the default logger level
@@ -281,6 +318,18 @@ module Kitchen
 
     def device_factory
       @device_factory ||= DeviceFactory.new
+    end
+
+    def expanded_log_path(logdev)
+      File.expand_path(logdev) if logdev.is_a?(String)
+    end
+
+    def metadata_stack
+      Thread.current[metadata_stack_key] ||= []
+    end
+
+    def metadata_stack_key
+      @metadata_stack_key ||= :"kitchen_logger_metadata_#{object_id}"
     end
 
     # Internal composite for forwarding stdlib Logger-compatible calls to all
@@ -340,6 +389,21 @@ module Kitchen
       # @api private
       def logdev_logger(filepath_or_logdev, log_overwrite)
         LogdevLogger.new(resolve_logdev(filepath_or_logdev, log_overwrite))
+      end
+
+      # Construct a new structured logdev logger.
+      #
+      # @param filepath_or_logdev [String,IO] a filepath String or IO object
+      # @param log_overwrite [Boolean] apply log overwriting
+      #   if filepath_or_logdev is a file path
+      # @param metadata_provider [Proc] callable returning structured metadata
+      # @return [StructuredLogdevLogger] a new logger
+      # @api private
+      def structured_logdev_logger(filepath_or_logdev, log_overwrite, metadata_provider)
+        StructuredLogdevLogger.new(
+          resolve_logdev(filepath_or_logdev, log_overwrite),
+          metadata_provider
+        )
       end
 
       private
@@ -406,10 +470,33 @@ module Kitchen
 
       def format(line)
         case line
-        when /^-----> / then @logger.banner(line.gsub(/^[ >-]{6} /, ""))
-        when /^>>>>>> / then @logger.error(line.gsub(/^[ >-]{6} /, ""))
-        when /^       / then @logger.info(line.gsub(/^[ >-]{6} /, ""))
-        else @logger.info(line)
+        when /^-----> / then log_line(:banner, line.gsub(/^[ >-]{6} /, ""))
+        when /^D      / then structured_line(:debug, line.gsub(/^D {6}/, ""), line)
+        when /^\$\$\$\$\$\$ / then structured_line(:warn, line.gsub(/^\${6} /, ""), line)
+        when /^>>>>>> / then log_line(:error, line.gsub(/^[ >-]{6} /, ""))
+        when /^!!!!!! / then structured_line(:fatal, line.gsub(/^!{6} /, ""), line)
+        when /^       / then log_line(:info, line.gsub(/^[ >-]{6} /, ""))
+        else log_line(:info, line)
+        end
+      end
+
+      private
+
+      def log_line(severity, message)
+        if severity == :banner
+          @logger.banner(message)
+        elsif @logger.respond_to?(:stream)
+          @logger.stream(severity, message)
+        else
+          @logger.public_send(severity, message)
+        end
+      end
+
+      def structured_line(severity, message, original)
+        if @logger.respond_to?(:stream)
+          @logger.stream(severity, message)
+        else
+          @logger.info(original)
         end
       end
     end
@@ -444,6 +531,152 @@ module Kitchen
         @line_buffer ||= LineBuffer.new do |line|
           formatter.format(line)
         end
+      end
+    end
+
+    # Internal class that emits one JSON object per log event.
+    class StructuredLogdevLogger
+      include ::Logger::Severity
+
+      SEVERITY_NAMES = {
+        DEBUG => "debug",
+        INFO => "info",
+        WARN => "warn",
+        ERROR => "error",
+        FATAL => "fatal",
+        UNKNOWN => "unknown",
+      }.freeze
+
+      attr_accessor :level
+      attr_accessor :progname
+      attr_accessor :datetime_format
+
+      def initialize(logdev, metadata_provider)
+        @logdev = logdev
+        @metadata_provider = metadata_provider
+        @level = INFO
+        @progname = "Kitchen"
+        @sequence = 0
+        @mutex = Mutex.new
+      end
+
+      def add(severity, message = nil, progname = nil)
+        severity ||= UNKNOWN
+        return true if severity < level
+
+        message = if message.nil?
+                    block_given? ? yield : progname
+                  else
+                    message
+                  end
+        write_event(severity, message, "log")
+      end
+
+      def <<(msg)
+        line_buffer << msg
+      end
+
+      def banner(msg = nil)
+        message = block_given? ? yield : msg
+        write_event(INFO, message, "banner") unless INFO < level
+      end
+
+      def stream(severity, msg)
+        severity = severity_const(severity)
+        write_event(severity, msg, "stream") unless severity < level
+      end
+
+      def debug(msg = nil, &block)
+        add(DEBUG, msg, nil, &block)
+      end
+
+      def info(msg = nil, &block)
+        add(INFO, msg, nil, &block)
+      end
+
+      def warn(msg = nil, &block)
+        add(WARN, msg, nil, &block)
+      end
+
+      def error(msg = nil, &block)
+        add(ERROR, msg, nil, &block)
+      end
+
+      def fatal(msg = nil, &block)
+        add(FATAL, msg, nil, &block)
+      end
+
+      def unknown(msg = nil, &block)
+        add(UNKNOWN, msg, nil, &block)
+      end
+
+      def debug?
+        level <= DEBUG
+      end
+
+      def info?
+        level <= INFO
+      end
+
+      def warn?
+        level <= WARN
+      end
+
+      def error?
+        level <= ERROR
+      end
+
+      def fatal?
+        level <= FATAL
+      end
+
+      def close
+        return unless @logdev.respond_to?(:close)
+
+        if @logdev.respond_to?(:closed?)
+          @logdev.close unless @logdev.closed?
+        else
+          @logdev.close
+        end
+      end
+
+      private
+
+      def line_buffer
+        formatter = StreamLineFormatter.new(self)
+        @line_buffer ||= LineBuffer.new do |line|
+          formatter.format(line)
+        end
+      end
+
+      def next_sequence
+        @sequence += 1
+      end
+
+      def severity_const(severity)
+        return severity if severity.is_a?(Integer)
+
+        ::Logger.const_get(severity.to_s.upcase)
+      end
+
+      def severity_name(severity)
+        SEVERITY_NAMES.fetch(severity, "unknown")
+      end
+
+      def write_event(severity, message, event_type)
+        @mutex.synchronize do
+          event = @metadata_provider.call.merge(
+            timestamp: Time.now.utc.iso8601(6),
+            level: severity_name(severity),
+            event_type:,
+            message: message.to_s,
+            progname:,
+            sequence: next_sequence
+          ).compact
+          @logdev.write(JSON.generate(event))
+          @logdev.write("\n")
+        end
+        true
       end
     end
 

--- a/lib/kitchen/state_file.rb
+++ b/lib/kitchen/state_file.rb
@@ -76,6 +76,13 @@ module Kitchen
       result
     end
 
+    # Returns the absolute path to the state file.
+    #
+    # @return [String] absolute path to the state file on disk
+    def path
+      file_name
+    end
+
     private
 
     # @return [String] absolute path to the yaml state file on disk

--- a/spec/kitchen/cli_spec.rb
+++ b/spec/kitchen/cli_spec.rb
@@ -26,9 +26,11 @@ module Kitchen
 
     before do
       @orig_env = ENV.to_hash
+      @orig_logger = Kitchen.logger
     end
 
     after do
+      Kitchen.logger = @orig_logger
       ENV.clear
       @orig_env.each do |k, v|
         ENV[k] = v
@@ -47,6 +49,18 @@ module Kitchen
 
         assert_equal :warn, cli.config.log_level
         assert_equal false, cli.config.log_overwrite
+      end
+    end
+
+    describe "#update_config!" do
+      it "can preserve existing log files for read-only commands" do
+        logger = stub(log_overwrite: false)
+        Kitchen.expects(:default_file_logger).with(nil, false).returns(logger)
+
+        cli.send(:update_config!, log_overwrite: false)
+
+        assert_equal false, cli.config.log_overwrite
+        assert_equal logger, Kitchen.logger
       end
     end
   end

--- a/spec/kitchen/command/list_spec.rb
+++ b/spec/kitchen/command/list_spec.rb
@@ -1,0 +1,80 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative '../../spec_helper'
+
+require 'json'
+
+require 'kitchen'
+require 'kitchen/collection'
+require 'kitchen/command/list'
+
+describe Kitchen::Command::List do
+  let(:component) { stub(name: 'Dummy') }
+  let(:instance) do
+    stub(
+      name: 'default-ubuntu-2404',
+      driver: component,
+      provisioner: component,
+      verifier: component,
+      transport: component,
+      last_action: 'create',
+      last_error: nil,
+      log_path: '.kitchen/logs/default-ubuntu-2404.log',
+      structured_log_path: '.kitchen/logs/default-ubuntu-2404.ndjson',
+      state_path: '.kitchen/default-ubuntu-2404.yml',
+      current_session_id: 'session-123',
+      status: {
+        live: true,
+        state: 'running',
+        source: 'driver',
+        resource_id: 'vm-123',
+        checked_at: '2026-06-18T12:00:00Z',
+      }
+    )
+  end
+  let(:config) { stub(instances: Kitchen::Collection.new([instance])) }
+  let(:shell) { stub }
+
+  def list_output(options)
+    command = Kitchen::Command::List.new(
+      ['default-ubuntu-2404'],
+      options,
+      action: 'list',
+      help: -> {},
+      config:,
+      shell:
+    )
+    stdout, = capture_io { command.call }
+    JSON.parse(stdout).fetch(0)
+  end
+
+  it 'keeps default JSON output compatible' do
+    data = list_output(json: true)
+
+    _(data.keys).must_equal %w(
+      instance driver provisioner verifier transport last_action last_error
+    )
+  end
+
+  it 'adds current log and liveness metadata with --live JSON output' do
+    data = list_output(json: true, live: true)
+
+    _(data['log_path']).must_equal '.kitchen/logs/default-ubuntu-2404.log'
+    _(data['structured_log_path']).must_equal '.kitchen/logs/default-ubuntu-2404.ndjson'
+    _(data['state_path']).must_equal '.kitchen/default-ubuntu-2404.yml'
+    _(data['instance_session_id']).must_equal 'session-123'
+    _(data['status']['live']).must_equal true
+    _(data['status']['state']).must_equal 'running'
+  end
+end

--- a/spec/kitchen/command/list_spec.rb
+++ b/spec/kitchen/command/list_spec.rb
@@ -11,35 +11,35 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require_relative '../../spec_helper'
+require_relative "../../spec_helper"
 
-require 'json'
+require "json"
 
-require 'kitchen'
-require 'kitchen/collection'
-require 'kitchen/command/list'
+require "kitchen"
+require "kitchen/collection"
+require "kitchen/command/list"
 
 describe Kitchen::Command::List do
-  let(:component) { stub(name: 'Dummy') }
+  let(:component) { stub(name: "Dummy") }
   let(:instance) do
     stub(
-      name: 'default-ubuntu-2404',
+      name: "default-ubuntu-2404",
       driver: component,
       provisioner: component,
       verifier: component,
       transport: component,
-      last_action: 'create',
+      last_action: "create",
       last_error: nil,
-      log_path: '.kitchen/logs/default-ubuntu-2404.log',
-      structured_log_path: '.kitchen/logs/default-ubuntu-2404.ndjson',
-      state_path: '.kitchen/default-ubuntu-2404.yml',
-      current_session_id: 'session-123',
+      log_path: ".kitchen/logs/default-ubuntu-2404.log",
+      structured_log_path: ".kitchen/logs/default-ubuntu-2404.ndjson",
+      state_path: ".kitchen/default-ubuntu-2404.yml",
+      current_session_id: "session-123",
       status: {
         live: true,
-        state: 'running',
-        source: 'driver',
-        resource_id: 'vm-123',
-        checked_at: '2026-06-18T12:00:00Z',
+        state: "running",
+        source: "driver",
+        resource_id: "vm-123",
+        checked_at: "2026-06-18T12:00:00Z",
       }
     )
   end
@@ -48,9 +48,9 @@ describe Kitchen::Command::List do
 
   def list_output(options)
     command = Kitchen::Command::List.new(
-      ['default-ubuntu-2404'],
+      ["default-ubuntu-2404"],
       options,
-      action: 'list',
+      action: "list",
       help: -> {},
       config:,
       shell:
@@ -59,22 +59,22 @@ describe Kitchen::Command::List do
     JSON.parse(stdout).fetch(0)
   end
 
-  it 'keeps default JSON output compatible' do
+  it "keeps default JSON output compatible" do
     data = list_output(json: true)
 
-    _(data.keys).must_equal %w(
+    _(data.keys).must_equal %w{
       instance driver provisioner verifier transport last_action last_error
-    )
+    }
   end
 
-  it 'adds current log and liveness metadata with --live JSON output' do
+  it "adds current log and liveness metadata with --live JSON output" do
     data = list_output(json: true, live: true)
 
-    _(data['log_path']).must_equal '.kitchen/logs/default-ubuntu-2404.log'
-    _(data['structured_log_path']).must_equal '.kitchen/logs/default-ubuntu-2404.ndjson'
-    _(data['state_path']).must_equal '.kitchen/default-ubuntu-2404.yml'
-    _(data['instance_session_id']).must_equal 'session-123'
-    _(data['status']['live']).must_equal true
-    _(data['status']['state']).must_equal 'running'
+    _(data["log_path"]).must_equal ".kitchen/logs/default-ubuntu-2404.log"
+    _(data["structured_log_path"]).must_equal ".kitchen/logs/default-ubuntu-2404.ndjson"
+    _(data["state_path"]).must_equal ".kitchen/default-ubuntu-2404.yml"
+    _(data["instance_session_id"]).must_equal "session-123"
+    _(data["status"]["live"]).must_equal true
+    _(data["status"]["state"]).must_equal "running"
   end
 end

--- a/spec/kitchen/command/logs_spec.rb
+++ b/spec/kitchen/command/logs_spec.rb
@@ -1,0 +1,204 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative '../../spec_helper'
+
+require 'json'
+require 'tmpdir'
+
+require 'kitchen'
+require 'kitchen/collection'
+require 'kitchen/command/logs'
+
+describe Kitchen::Command::Logs do
+  let(:log_path) { File.join(log_dir, 'default-ubuntu-2404.ndjson') }
+  let(:other_log_path) { File.join(log_dir, 'default-almalinux-9.ndjson') }
+  let(:log_dir) { File.join(tmpdir, '.kitchen', 'logs') }
+  let(:tmpdir) { Dir.mktmpdir }
+  let(:instance) do
+    stub(
+      name: 'default-ubuntu-2404',
+      to_str: '<default-ubuntu-2404>',
+      structured_log_path: log_path,
+      current_session_id: 'session-current'
+    )
+  end
+  let(:other_instance) do
+    stub(
+      name: 'default-almalinux-9',
+      to_str: '<default-almalinux-9>',
+      structured_log_path: other_log_path,
+      current_session_id: 'other-current'
+    )
+  end
+  let(:config) { stub(instances: Kitchen::Collection.new([instance])) }
+  let(:shell) { stub }
+  let(:args) { ['default-ubuntu-2404'] }
+  let(:options) { {} }
+  let(:command) do
+    Kitchen::Command::Logs.new(
+      args,
+      options,
+      action: 'logs',
+      help: -> {},
+      config:,
+      shell:
+    )
+  end
+
+  after do
+    FileUtils.remove_entry(tmpdir) if File.directory?(tmpdir)
+  end
+
+  def write_log_events(*events)
+    FileUtils.mkdir_p(log_dir)
+    File.write(log_path, events.map { |event| JSON.generate(event) }.join("\n") + "\n")
+  end
+
+  def write_other_log_events(*events)
+    FileUtils.mkdir_p(log_dir)
+    File.write(other_log_path, events.map { |event| JSON.generate(event) }.join("\n") + "\n")
+  end
+
+  def captured_events
+    captured_lines.map { |line| JSON.parse(line) }
+  end
+
+  def captured_lines
+    stdout, = capture_io { Dir.chdir(tmpdir) { command.call } }
+    stdout.lines
+  end
+
+  def captured_messages
+    stdout, = capture_io { Dir.chdir(tmpdir) { command.call } }
+    stdout.lines.map(&:chomp)
+  end
+
+  it 'prints current-session text by default' do
+    write_log_events(
+      { instance_session_id: 'session-old', level: 'error', message: 'old' },
+      { instance_session_id: 'session-current', level: 'info', message: 'current' }
+    )
+
+    messages = captured_messages
+
+    _(messages).must_equal %w(current)
+  end
+
+  it 'prints current-session NDJSON when requested' do
+    options[:format] = 'ndjson'
+    write_log_events(
+      { instance_session_id: 'session-old', level: 'error', message: 'old' },
+      { instance_session_id: 'session-current', level: 'info', message: 'current' }
+    )
+
+    events = captured_events
+
+    _(events.length).must_equal 1
+    _(events.fetch(0)['message']).must_equal 'current'
+  end
+
+  it 'filters by minimum log level' do
+    options[:format] = 'ndjson'
+    options[:level] = 'warn'
+    write_log_events(
+      { instance_session_id: 'session-current', level: 'debug', message: 'debug' },
+      { instance_session_id: 'session-current', level: 'info', message: 'info' },
+      { instance_session_id: 'session-current', level: 'warn', message: 'warn' },
+      { instance_session_id: 'session-current', level: 'error', message: 'error' }
+    )
+
+    events = captured_events
+
+    _(events.map { |event| event['message'] }).must_equal %w(warn error)
+  end
+
+  it 'can print all sessions' do
+    options[:format] = 'ndjson'
+    options[:all_sessions] = true
+    write_log_events(
+      { instance_session_id: 'session-old', level: 'error', message: 'old' },
+      { instance_session_id: 'session-current', level: 'info', message: 'current' }
+    )
+
+    events = captured_events
+
+    _(events.map { |event| event['message'] }).must_equal %w(old current)
+  end
+
+  it 'falls back to the latest session in the log file when state is gone' do
+    options[:format] = 'ndjson'
+    instance.stubs(:current_session_id).returns(nil)
+    write_log_events(
+      { instance_session_id: 'session-old', level: 'error', message: 'old' },
+      { instance_session_id: 'session-latest', level: 'info', message: 'latest' }
+    )
+
+    events = captured_events
+
+    _(events.map { |event| event['message'] }).must_equal %w(latest)
+  end
+
+  describe 'with multiple instances' do
+    let(:args) { [] }
+    let(:config) { stub(instances: Kitchen::Collection.new([instance, other_instance])) }
+
+    it 'can print all sessions for every instance when no instance is specified' do
+      options[:format] = 'ndjson'
+      options[:all_sessions] = true
+      config.expects(:instances).never
+      write_log_events(
+        { instance: 'default-ubuntu-2404', instance_session_id: 'old', level: 'info', message: 'ubuntu' }
+      )
+      write_other_log_events(
+        { instance: 'default-almalinux-9', instance_session_id: 'other', level: 'info', message: 'almalinux' }
+      )
+
+      events = captured_events
+
+      _(events.map { |event| event['message'] }).must_equal %w(almalinux ubuntu)
+    end
+
+    it 'filters all-session logs from disk by instance name' do
+      options[:format] = 'ndjson'
+      options[:all_sessions] = true
+      config.expects(:instances).never
+      args << 'default-ubuntu-2404'
+      write_log_events(
+        { instance: 'default-ubuntu-2404', instance_session_id: 'old', level: 'info', message: 'ubuntu' }
+      )
+      write_other_log_events(
+        { instance: 'default-almalinux-9', instance_session_id: 'other', level: 'info', message: 'almalinux' }
+      )
+
+      events = captured_events
+
+      _(events.map { |event| event['message'] }).must_equal %w(ubuntu)
+    end
+
+    it 'rejects following more than one instance log' do
+      options[:all_sessions] = true
+      options[:follow] = true
+      config.expects(:instances).never
+      write_log_events(
+        { instance: 'default-ubuntu-2404', instance_session_id: 'old', level: 'info', message: 'ubuntu' }
+      )
+      write_other_log_events(
+        { instance: 'default-almalinux-9', instance_session_id: 'other', level: 'info', message: 'almalinux' }
+      )
+      command.expects(:follow_file).never
+
+      _ { capture_io { Dir.chdir(tmpdir) { command.call } } }.must_raise SystemExit
+    end
+  end
+end

--- a/spec/kitchen/command/logs_spec.rb
+++ b/spec/kitchen/command/logs_spec.rb
@@ -11,45 +11,45 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require_relative '../../spec_helper'
+require_relative "../../spec_helper"
 
-require 'json'
-require 'tmpdir'
+require "json"
+require "tmpdir"
 
-require 'kitchen'
-require 'kitchen/collection'
-require 'kitchen/command/logs'
+require "kitchen"
+require "kitchen/collection"
+require "kitchen/command/logs"
 
 describe Kitchen::Command::Logs do
-  let(:log_path) { File.join(log_dir, 'default-ubuntu-2404.ndjson') }
-  let(:other_log_path) { File.join(log_dir, 'default-almalinux-9.ndjson') }
-  let(:log_dir) { File.join(tmpdir, '.kitchen', 'logs') }
+  let(:log_path) { File.join(log_dir, "default-ubuntu-2404.ndjson") }
+  let(:other_log_path) { File.join(log_dir, "default-almalinux-9.ndjson") }
+  let(:log_dir) { File.join(tmpdir, ".kitchen", "logs") }
   let(:tmpdir) { Dir.mktmpdir }
   let(:instance) do
     stub(
-      name: 'default-ubuntu-2404',
-      to_str: '<default-ubuntu-2404>',
+      name: "default-ubuntu-2404",
+      to_str: "<default-ubuntu-2404>",
       structured_log_path: log_path,
-      current_session_id: 'session-current'
+      current_session_id: "session-current"
     )
   end
   let(:other_instance) do
     stub(
-      name: 'default-almalinux-9',
-      to_str: '<default-almalinux-9>',
+      name: "default-almalinux-9",
+      to_str: "<default-almalinux-9>",
       structured_log_path: other_log_path,
-      current_session_id: 'other-current'
+      current_session_id: "other-current"
     )
   end
   let(:config) { stub(instances: Kitchen::Collection.new([instance])) }
   let(:shell) { stub }
-  let(:args) { ['default-ubuntu-2404'] }
+  let(:args) { ["default-ubuntu-2404"] }
   let(:options) { {} }
   let(:command) do
     Kitchen::Command::Logs.new(
       args,
       options,
-      action: 'logs',
+      action: "logs",
       help: -> {},
       config:,
       shell:
@@ -84,117 +84,117 @@ describe Kitchen::Command::Logs do
     stdout.lines.map(&:chomp)
   end
 
-  it 'prints current-session text by default' do
+  it "prints current-session text by default" do
     write_log_events(
-      { instance_session_id: 'session-old', level: 'error', message: 'old' },
-      { instance_session_id: 'session-current', level: 'info', message: 'current' }
+      { instance_session_id: "session-old", level: "error", message: "old" },
+      { instance_session_id: "session-current", level: "info", message: "current" }
     )
 
     messages = captured_messages
 
-    _(messages).must_equal %w(current)
+    _(messages).must_equal %w{current}
   end
 
-  it 'prints current-session NDJSON when requested' do
-    options[:format] = 'ndjson'
+  it "prints current-session NDJSON when requested" do
+    options[:format] = "ndjson"
     write_log_events(
-      { instance_session_id: 'session-old', level: 'error', message: 'old' },
-      { instance_session_id: 'session-current', level: 'info', message: 'current' }
+      { instance_session_id: "session-old", level: "error", message: "old" },
+      { instance_session_id: "session-current", level: "info", message: "current" }
     )
 
     events = captured_events
 
     _(events.length).must_equal 1
-    _(events.fetch(0)['message']).must_equal 'current'
+    _(events.fetch(0)["message"]).must_equal "current"
   end
 
-  it 'filters by minimum log level' do
-    options[:format] = 'ndjson'
-    options[:level] = 'warn'
+  it "filters by minimum log level" do
+    options[:format] = "ndjson"
+    options[:level] = "warn"
     write_log_events(
-      { instance_session_id: 'session-current', level: 'debug', message: 'debug' },
-      { instance_session_id: 'session-current', level: 'info', message: 'info' },
-      { instance_session_id: 'session-current', level: 'warn', message: 'warn' },
-      { instance_session_id: 'session-current', level: 'error', message: 'error' }
+      { instance_session_id: "session-current", level: "debug", message: "debug" },
+      { instance_session_id: "session-current", level: "info", message: "info" },
+      { instance_session_id: "session-current", level: "warn", message: "warn" },
+      { instance_session_id: "session-current", level: "error", message: "error" }
     )
 
     events = captured_events
 
-    _(events.map { |event| event['message'] }).must_equal %w(warn error)
+    _(events.map { |event| event["message"] }).must_equal %w{warn error}
   end
 
-  it 'can print all sessions' do
-    options[:format] = 'ndjson'
+  it "can print all sessions" do
+    options[:format] = "ndjson"
     options[:all_sessions] = true
     write_log_events(
-      { instance_session_id: 'session-old', level: 'error', message: 'old' },
-      { instance_session_id: 'session-current', level: 'info', message: 'current' }
+      { instance_session_id: "session-old", level: "error", message: "old" },
+      { instance_session_id: "session-current", level: "info", message: "current" }
     )
 
     events = captured_events
 
-    _(events.map { |event| event['message'] }).must_equal %w(old current)
+    _(events.map { |event| event["message"] }).must_equal %w{old current}
   end
 
-  it 'falls back to the latest session in the log file when state is gone' do
-    options[:format] = 'ndjson'
+  it "falls back to the latest session in the log file when state is gone" do
+    options[:format] = "ndjson"
     instance.stubs(:current_session_id).returns(nil)
     write_log_events(
-      { instance_session_id: 'session-old', level: 'error', message: 'old' },
-      { instance_session_id: 'session-latest', level: 'info', message: 'latest' }
+      { instance_session_id: "session-old", level: "error", message: "old" },
+      { instance_session_id: "session-latest", level: "info", message: "latest" }
     )
 
     events = captured_events
 
-    _(events.map { |event| event['message'] }).must_equal %w(latest)
+    _(events.map { |event| event["message"] }).must_equal %w{latest}
   end
 
-  describe 'with multiple instances' do
+  describe "with multiple instances" do
     let(:args) { [] }
     let(:config) { stub(instances: Kitchen::Collection.new([instance, other_instance])) }
 
-    it 'can print all sessions for every instance when no instance is specified' do
-      options[:format] = 'ndjson'
+    it "can print all sessions for every instance when no instance is specified" do
+      options[:format] = "ndjson"
       options[:all_sessions] = true
       config.expects(:instances).never
       write_log_events(
-        { instance: 'default-ubuntu-2404', instance_session_id: 'old', level: 'info', message: 'ubuntu' }
+        { instance: "default-ubuntu-2404", instance_session_id: "old", level: "info", message: "ubuntu" }
       )
       write_other_log_events(
-        { instance: 'default-almalinux-9', instance_session_id: 'other', level: 'info', message: 'almalinux' }
+        { instance: "default-almalinux-9", instance_session_id: "other", level: "info", message: "almalinux" }
       )
 
       events = captured_events
 
-      _(events.map { |event| event['message'] }).must_equal %w(almalinux ubuntu)
+      _(events.map { |event| event["message"] }).must_equal %w{almalinux ubuntu}
     end
 
-    it 'filters all-session logs from disk by instance name' do
-      options[:format] = 'ndjson'
+    it "filters all-session logs from disk by instance name" do
+      options[:format] = "ndjson"
       options[:all_sessions] = true
       config.expects(:instances).never
-      args << 'default-ubuntu-2404'
+      args << "default-ubuntu-2404"
       write_log_events(
-        { instance: 'default-ubuntu-2404', instance_session_id: 'old', level: 'info', message: 'ubuntu' }
+        { instance: "default-ubuntu-2404", instance_session_id: "old", level: "info", message: "ubuntu" }
       )
       write_other_log_events(
-        { instance: 'default-almalinux-9', instance_session_id: 'other', level: 'info', message: 'almalinux' }
+        { instance: "default-almalinux-9", instance_session_id: "other", level: "info", message: "almalinux" }
       )
 
       events = captured_events
 
-      _(events.map { |event| event['message'] }).must_equal %w(ubuntu)
+      _(events.map { |event| event["message"] }).must_equal %w{ubuntu}
     end
 
-    it 'rejects following more than one instance log' do
+    it "rejects following more than one instance log" do
       options[:all_sessions] = true
       options[:follow] = true
       config.expects(:instances).never
       write_log_events(
-        { instance: 'default-ubuntu-2404', instance_session_id: 'old', level: 'info', message: 'ubuntu' }
+        { instance: "default-ubuntu-2404", instance_session_id: "old", level: "info", message: "ubuntu" }
       )
       write_other_log_events(
-        { instance: 'default-almalinux-9', instance_session_id: 'other', level: 'info', message: 'almalinux' }
+        { instance: "default-almalinux-9", instance_session_id: "other", level: "info", message: "almalinux" }
       )
       command.expects(:follow_file).never
 

--- a/spec/kitchen/config_spec.rb
+++ b/spec/kitchen/config_spec.rb
@@ -361,9 +361,16 @@ describe Kitchen::Config do
         stdout: STDOUT,
         color: :cyan,
         logdev: "/tmp/logs/tiny-unax.log",
+        structured_logdev: "/tmp/logs/tiny-unax.ndjson",
         log_overwrite: false,
         level: 0,
         progname: "tiny-unax",
+        metadata: {
+          kitchen_run_id: Kitchen.run_id,
+          instance: "tiny-unax",
+          suite: "tiny",
+          platform: "unax",
+        },
         colorize: false
       )
 

--- a/spec/kitchen/driver/base_spec.rb
+++ b/spec/kitchen/driver/base_spec.rb
@@ -87,6 +87,16 @@ describe Kitchen::Driver::Base do
     end
   end
 
+  it "returns unknown status by default for compatibility with existing drivers" do
+    status = driver.status(state)
+
+    _(status[:live]).must_be_nil
+    _(status[:state]).must_equal "unknown"
+    _(status[:source]).must_equal "driver"
+    _(status[:message]).must_match(/does not support status/)
+    _(status[:checked_at]).wont_be_nil
+  end
+
   describe ".pre_create_command" do
     it "run command" do
       Kitchen::Driver::Base.any_instance.stubs(:run_command).returns(true)

--- a/spec/kitchen/driver/dummy_spec.rb
+++ b/spec/kitchen/driver/dummy_spec.rb
@@ -189,4 +189,25 @@ describe Kitchen::Driver::Dummy do
       _(logged_output.string).must_match(/^.+ INFO .+ \[Dummy\] Destroy on .+$/)
     end
   end
+
+  describe "#status" do
+    it "reports the dummy instance as live when state has a resource id" do
+      state[:my_id] = "coolbeans-123"
+
+      status = driver.status(state)
+
+      _(status[:live]).must_equal true
+      _(status[:state]).must_equal "running"
+      _(status[:source]).must_equal "driver"
+      _(status[:resource_id]).must_equal "coolbeans-123"
+    end
+
+    it "reports the dummy instance as not created when state has no resource id" do
+      status = driver.status(state)
+
+      _(status[:live]).must_equal false
+      _(status[:state]).must_equal "not_created"
+      _(status[:source]).must_equal "driver"
+    end
+  end
 end

--- a/spec/kitchen/instance_spec.rb
+++ b/spec/kitchen/instance_spec.rb
@@ -17,6 +17,7 @@
 
 require_relative "../spec_helper"
 require "stringio"
+require "json"
 
 require "kitchen/logging"
 require "kitchen/instance"
@@ -101,7 +102,8 @@ end
 describe Kitchen::Instance do
   let(:driver)          { Kitchen::Driver::Dummy.new({}) }
   let(:logger_io)       { StringIO.new }
-  let(:logger)          { Kitchen::Logger.new(logdev: logger_io) }
+  let(:structured_io)   { StringIO.new }
+  let(:logger)          { Kitchen::Logger.new(logdev: logger_io, structured_logdev: structured_io) }
   let(:instance)        { Kitchen::Instance.new(opts) }
   let(:lifecycle_hooks) { Kitchen::LifecycleHooks.new({}, state_file) }
   let(:provisioner)     { Kitchen::Provisioner::Dummy.new({}) }
@@ -224,6 +226,63 @@ describe Kitchen::Instance do
     end
   end
 
+  describe "action session metadata" do
+    before do
+      Kitchen.stubs(:run_id).returns("run-123")
+      Kitchen::Instance::ActionRunner.any_instance.stubs(:new_id)
+        .returns("action-123", "session-123")
+    end
+
+    it "persists action and session identifiers on create" do
+      instance.create
+
+      state = state_file.read
+      _(state[:last_action]).must_equal "create"
+      _(state[:last_attempted_action]).must_equal "create"
+      _(state[:last_action_id]).must_equal "action-123"
+      _(state[:instance_session_id]).must_equal "session-123"
+      _(state[:last_kitchen_run_id]).must_equal "run-123"
+    end
+
+    it "adds action and session identifiers to structured instance logs" do
+      instance.create
+
+      events = structured_io.string.lines.map { |line| JSON.parse(line) }
+      action_events = events.select { |event| event["action"] == "create" }
+      messages = action_events.map { |event| event["message"] }
+
+      _(action_events).wont_be_empty
+      _(messages).must_include "Creating <suite-platform>..."
+      _(messages.any? { |message| message.start_with?("Finished creating <suite-platform> ") })
+        .must_equal true
+      action_events.each do |event|
+        _(event["kitchen_run_id"]).must_equal "run-123"
+        _(event["action_id"]).must_equal "action-123"
+        _(event["instance_session_id"]).must_equal "session-123"
+      end
+    end
+
+    describe "when the action fails" do
+      let(:driver) { Kitchen::Driver::Dummy.new(fail_create: true) }
+
+      it "adds action and session identifiers to structured failure logs" do
+        _ { instance.create }.must_raise Kitchen::InstanceFailure
+
+        events = structured_io.string.lines.map { |line| JSON.parse(line) }
+        error_events = events.select { |event| event["level"] == "error" }
+
+        _(error_events.map { |event| event["message"] })
+          .must_include "Create failed on instance <suite-platform>."
+        error_events.each do |event|
+          _(event["kitchen_run_id"]).must_equal "run-123"
+          _(event["action_id"]).must_equal "action-123"
+          _(event["instance_session_id"]).must_equal "session-123"
+        end
+        _(state_file.read[:last_error]).must_equal "Kitchen::ActionFailed"
+      end
+    end
+  end
+
   describe "#provisioner" do
     it "returns its provisioner" do
       _(instance.provisioner).must_equal provisioner
@@ -303,6 +362,39 @@ describe Kitchen::Instance do
     state_file.write({})
 
     _ { instance.login }.must_raise Kitchen::UserError
+  end
+
+  describe "#status" do
+    it "returns the driver status" do
+      state_file.write(my_id: "instance-123")
+
+      status = instance.status
+
+      _(status[:live]).must_equal true
+      _(status[:state]).must_equal "running"
+      _(status[:resource_id]).must_equal "instance-123"
+    end
+
+    it "reports unknown when a driver has a legacy zero-argument status method" do
+      driver.define_singleton_method(:status) { { live: true, state: "running" } }
+
+      status = instance.status
+
+      _(status[:live]).must_be_nil
+      _(status[:state]).must_equal "unknown"
+      _(status[:message]).must_match(/does not accept Kitchen state/)
+    end
+
+    it "reports unknown when a driver status check fails" do
+      driver.define_singleton_method(:status) { |_state| raise "provider down" }
+
+      status = instance.status
+
+      _(status[:live]).must_be_nil
+      _(status[:state]).must_equal "unknown"
+      _(status[:error]).must_equal "RuntimeError"
+      _(status[:message]).must_equal "provider down"
+    end
   end
 
   describe "#diagnose" do

--- a/spec/kitchen/logger_spec.rb
+++ b/spec/kitchen/logger_spec.rb
@@ -17,6 +17,7 @@
 
 require_relative "../spec_helper"
 
+require "json"
 require "kitchen"
 
 describe Kitchen::Logger do
@@ -36,6 +37,10 @@ describe Kitchen::Logger do
   def log_tmpname
     t = Time.now.strftime("%Y%m%d")
     "kitchen-#{t}-#{$$}-#{rand(0x100000000).to_s(36)}.log"
+  end
+
+  def structured_events(io)
+    io.string.lines.map { |line| JSON.parse(line) }
   end
 
   let(:opts) do
@@ -318,6 +323,20 @@ describe Kitchen::Logger do
           colorize("       vanilla", opts[:color]) + "\n"
         )
       end
+
+      it "preserves debug, warning, and fatal looking stream lines as info text" do
+        logger << [
+          "D      debug",
+          "$$$$$$ warning",
+          "!!!!!! fatal",
+        ].join("\n").concat("\n")
+
+        _(stdout.string).must_equal(
+          colorize("       D      debug", opts[:color]) + "\n" +
+          colorize("       $$$$$$ warning", opts[:color]) + "\n" +
+          colorize("       !!!!!! fatal", opts[:color]) + "\n"
+        )
+      end
     end
   end
 
@@ -378,6 +397,75 @@ describe Kitchen::Logger do
 
         _(logdev.string).must_match(/^A, #{ts}   ANY -- Kitchen: yo$/)
       end
+    end
+  end
+
+  describe "opened IO structured logdev-based logger" do
+    let(:structured_logdev) { StringIO.new }
+
+    before do
+      opts[:structured_logdev] = structured_logdev
+      opts[:metadata] = {
+        kitchen_run_id: "run-123",
+        instance: "default-ubuntu-2404",
+        suite: "default",
+        platform: "ubuntu-24.04",
+      }
+      opts[:level] = Kitchen::Util.to_logger_level(:debug)
+    end
+
+    it "writes one JSON object per log event with severity and metadata" do
+      logger.warn("careful")
+
+      event = structured_events(structured_logdev).fetch(0)
+      _(event["level"]).must_equal "warn"
+      _(event["event_type"]).must_equal "log"
+      _(event["message"]).must_equal "careful"
+      _(event["progname"]).must_equal "Kitchen"
+      _(event["kitchen_run_id"]).must_equal "run-123"
+      _(event["instance"]).must_equal "default-ubuntu-2404"
+      _(event["sequence"]).must_equal 1
+      _(event["timestamp"]).wont_be_nil
+    end
+
+    it "writes banner events without relying on text log prefixes" do
+      logger.banner("Creating <default-ubuntu-2404>...")
+
+      event = structured_events(structured_logdev).fetch(0)
+      _(event["level"]).must_equal "info"
+      _(event["event_type"]).must_equal "banner"
+      _(event["message"]).must_equal "Creating <default-ubuntu-2404>..."
+    end
+
+    it "maps streamed Kitchen-prefixed lines to structured levels" do
+      logger << [
+        "-----> banner",
+        "$$$$$$ warning",
+        ">>>>>> error",
+        "       info",
+        "plain",
+      ].join("\n").concat("\n")
+
+      events = structured_events(structured_logdev)
+      _(events.map { |event| event["level"] })
+        .must_equal %w{info warn error info info}
+      _(events.map { |event| event["message"] })
+        .must_equal ["banner", "warning", "error", "info", "plain"]
+      _(events.map { |event| event["event_type"] })
+        .must_equal %w{banner stream stream stream stream}
+    end
+
+    it "applies temporary metadata to structured events" do
+      logger.with_metadata(instance_session_id: "session-123", action: "create") do
+        logger.info("inside action")
+      end
+      logger.info("outside action")
+
+      inside, outside = structured_events(structured_logdev)
+      _(inside["instance_session_id"]).must_equal "session-123"
+      _(inside["action"]).must_equal "create"
+      _(outside.key?("instance_session_id")).must_equal false
+      _(outside.key?("action")).must_equal false
     end
   end
 

--- a/spec/kitchen/logger_spec.rb
+++ b/spec/kitchen/logger_spec.rb
@@ -450,7 +450,7 @@ describe Kitchen::Logger do
       _(events.map { |event| event["level"] })
         .must_equal %w{info warn error info info}
       _(events.map { |event| event["message"] })
-        .must_equal ["banner", "warning", "error", "info", "plain"]
+        .must_equal %w{banner warning error info plain}
       _(events.map { |event| event["event_type"] })
         .must_equal %w{banner stream stream stream stream}
     end


### PR DESCRIPTION
## Summary
- add per-instance NDJSON logs with run, action, session, instance, suite, and platform metadata
- add `kitchen logs` for text-by-default log inspection, explicit `--format ndjson`, level/session filters, follow mode, and all-session reads
- expose driver live status and optional transport probing through `kitchen list`
- fix local dokken verification config to use the existing dokken provisioner

## Apache example
Default output is friendly text:

```sh
mise exec -- bundle exec kitchen logs --all-sessions --level error
```

```text
The `berkshelf' gem is missing and must be installed or cannot be properly activated. Run `gem install berkshelf` or add the following to your Gemfile if you are using Bundler: `gem 'berkshelf'`.
```

NDJSON output is available explicitly:

```sh
mise exec -- bundle exec kitchen logs --all-sessions --level error --format ndjson
```

```json
{"kitchen_run_id":"5bdf5e81-7adf-4f69-91b5-bce22e37b39b","instance":"default-almalinux-8","suite":"default","platform":"almalinux-8","timestamp":"2026-06-22T07:38:03.889943Z","level":"fatal","event_type":"log","message":"The `berkshelf' gem is missing and must be installed or cannot be properly activated. Run `gem install berkshelf` or add the following to your Gemfile if you are using Bundler: `gem 'berkshelf'`.","progname":"default-almalinux-8","sequence":1}
```

The NDJSON stream can be queried with `jq`:

```sh
mise exec -- bundle exec kitchen logs --all-sessions --format ndjson \
  | jq -r 'select(.level == "fatal") | [.level, .instance, .message] | @tsv'
```

```text
fatal	default-almalinux-8	The `berkshelf' gem is missing and must be installed or cannot be properly activated. Run `gem install berkshelf` or add the following to your Gemfile if you are using Bundler: `gem 'berkshelf'`.
```

## Verification
- `bundle exec ruby -Itest -Ilib spec/kitchen/command/logs_spec.rb`
- `bundle exec ruby -Itest -Ilib spec/kitchen/cli_spec.rb`
- `bundle exec rake unit` -> 1696 runs, 2600 assertions, 0 failures
- `git diff --check`
- apache2 smoke checks for default text and explicit NDJSON output
