### PR TITLE
feat: add external provider protocol

### DIFF
--- a/lib/kitchen/provisioner/external.rb
+++ b/lib/kitchen/provisioner/external.rb
@@ -13,25 +13,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'json'
-require 'open3'
-require 'rbconfig'
-require 'shellwords'
+require "json" unless defined?(JSON)
+require "open3"
+require "rbconfig" unless defined?(RbConfig)
+require "shellwords" unless defined?(Shellwords)
 
-require_relative 'base'
-require_relative '../version'
+require_relative "base"
+require_relative "../version"
 
 module Kitchen
   module Provisioner
     # Executes an external provisioner provider over the v1 stdio protocol.
     class External < Base
-      PROTOCOL_VERSION = '1.0'.freeze
-      RESULT_STATUSES = %w(passed failed skipped).freeze
-      LOG_LEVELS = %w(debug info warn error).freeze
-      INTERNAL_CONFIG_KEYS = %i(
+      PROTOCOL_VERSION = "1.0".freeze
+      RESULT_STATUSES = %w{passed failed skipped}.freeze
+      LOG_LEVELS = %w{debug info warn error}.freeze
+      INTERNAL_CONFIG_KEYS = %i{
         command provider pass_env kitchen_root test_base_path
-      ).freeze
-      REDACTED_KEYS = %w(password ssh_http_proxy_password).freeze
+      }.freeze
+      REDACTED_KEYS = %w{password ssh_http_proxy_password}.freeze
 
       kitchen_provisioner_api_version 2
 
@@ -52,29 +52,29 @@ module Kitchen
 
       def provider_name_from_command
         first_part = Shellwords.split(config[:command].to_s).first.to_s
-        File.basename(first_part).sub(/^kitchen-provider-/, '')
+        File.basename(first_part).sub(/^kitchen-provider-/, "")
       end
 
       private
 
       def verify_capabilities
-        response = invoke_json('capabilities', {})
-        protocol_version = response.fetch('protocol_version', nil)
+        response = invoke_json("capabilities", {})
+        protocol_version = response.fetch("protocol_version", nil)
         unless protocol_version == PROTOCOL_VERSION
           raise_protocol_error(
             "Unsupported external provider protocol version #{protocol_version.inspect}"
           )
         end
 
-        commands = Array(response['commands'])
-        missing_commands = %w(validate run) - commands
+        commands = Array(response["commands"])
+        missing_commands = %w{validate run} - commands
         unless missing_commands.empty?
           raise_protocol_error(
-            "External provider does not support required command(s): #{missing_commands.join(', ')}"
+            "External provider does not support required command(s): #{missing_commands.join(", ")}"
           )
         end
 
-        transports = Array(response['supported_transports'])
+        transports = Array(response["supported_transports"])
         transport_type = transport_component({}).fetch(:type)
         return if transports.include?(transport_type)
 
@@ -84,74 +84,74 @@ module Kitchen
       end
 
       def validate_provider(state)
-        response = invoke_json('validate', request_envelope('validate', state))
-        require_protocol_version(response, 'validation result')
+        response = invoke_json("validate", request_envelope("validate", state))
+        require_protocol_version(response, "validation result")
 
-        return if response['status'] == 'ok'
+        return if response["status"] == "ok"
 
-        messages = Array(response['errors']).map { |error| error['message'] }.compact
-        message = messages.empty? ? 'external provider validation failed' : messages.join('; ')
+        messages = Array(response["errors"]).map { |error| error["message"] }.compact
+        message = messages.empty? ? "external provider validation failed" : messages.join("; ")
         raise ActionFailed, redact(message)
       end
 
       def run_provider(state)
-        stdout, stderr, status = invoke('run', request_envelope('run', state))
+        stdout, stderr, status = invoke("run", request_envelope("run", state))
         result = nil
 
         stdout.each_line.with_index(1) do |line, index|
           next if line.strip.empty?
 
           event = parse_event(line, index)
-          require_protocol_version(event, 'event')
+          require_protocol_version(event, "event")
 
-          case event['type']
-          when 'log'
+          case event["type"]
+          when "log"
             handle_log_event(event)
-          when 'progress'
+          when "progress"
             handle_progress_event(event)
-          when 'result'
+          when "result"
             result = event
           else
-            raise_protocol_error("unknown external provider event type #{event['type'].inspect}")
+            raise_protocol_error("unknown external provider event type #{event["type"].inspect}")
           end
         end
 
         unless status.success?
           raise_protocol_error("external provider exited with #{status.exitstatus}", stderr)
         end
-        raise_protocol_error('external provider did not emit a final result') if result.nil?
+        raise_protocol_error("external provider did not emit a final result") if result.nil?
 
         handle_result_event(result)
         result
       end
 
       def handle_log_event(event)
-        level = event['level']
+        level = event["level"]
         raise_protocol_error("external provider log event has invalid level #{level.inspect}") unless LOG_LEVELS.include?(level)
 
-        logger.public_send(level, redact(event.fetch('message', '')))
+        logger.public_send(level, redact(event.fetch("message", "")))
       end
 
       def handle_progress_event(event)
-        stage = event.fetch('stage', 'provider')
-        message = event.fetch('message', '')
+        stage = event.fetch("stage", "provider")
+        message = event.fetch("message", "")
         info(redact("[#{stage}] #{message}"))
       end
 
       def handle_result_event(event)
-        status = event['status']
+        status = event["status"]
         unless RESULT_STATUSES.include?(status)
           raise_protocol_error("external provider result has invalid status #{status.inspect}")
         end
 
-        return if %w(passed skipped).include?(status)
+        return if %w{passed skipped}.include?(status)
 
-        message = event['message'] || "external provider reported #{status}"
+        message = event["message"] || "external provider reported #{status}"
         raise ActionFailed, redact(message)
       end
 
       def persist_provider_state(state, result)
-        provider_state = result.dig('state', 'provider')
+        provider_state = result.dig("state", "provider")
         return if provider_state.nil?
 
         state[:providers] ||= {}
@@ -182,7 +182,7 @@ module Kitchen
 
       def provider_command_parts
         parts = Shellwords.split(config[:command].to_s)
-        raise ActionFailed, 'external provider command cannot be blank' if parts.empty?
+        raise ActionFailed, "external provider command cannot be blank" if parts.empty?
 
         parts
       end
@@ -240,7 +240,7 @@ module Kitchen
           driver: resolved_component(instance.driver, {}),
           transport: transport_component(state),
           provisioner: {
-            name: 'external',
+            name: "external",
             provider: config[:provider],
             command: config[:command],
             config: provider_config,
@@ -267,19 +267,19 @@ module Kitchen
         }
 
         case type
-        when 'exec'
+        when "exec"
           base.merge(
-            target: { kind: 'local', platform: component_attr(instance.platform, :name) },
+            target: { kind: "local", platform: component_attr(instance.platform, :name) },
             config: {
               kitchen_root: File.expand_path(config[:kitchen_root] || Dir.pwd),
-              host_os: RbConfig::CONFIG['host_os'],
+              host_os: RbConfig::CONFIG["host_os"],
             }
           )
-        when 'ssh'
+        when "ssh"
           base.merge(
             target: machine_target(state),
             config: compact_hash(
-              username: component_config(:username, state, 'root'),
+              username: component_config(:username, state, "root"),
               port: component_config(:port, state, 22),
               connection_timeout: component_config(:connection_timeout, state),
               connection_retries: component_config(:connection_retries, state),
@@ -290,14 +290,14 @@ module Kitchen
               gateway_username: component_config(:ssh_gateway_username, state)
             )
           )
-        when 'winrm'
+        when "winrm"
           base.merge(
             target: machine_target(state),
             config: compact_hash(
-              username: component_config(:username, state, 'administrator'),
+              username: component_config(:username, state, "administrator"),
               port: component_config(:port, state, 5985),
-              scheme: component_config(:scheme, state, 'http'),
-              transport: component_config(:winrm_transport, state, 'negotiate').to_s,
+              scheme: component_config(:scheme, state, "http"),
+              transport: component_config(:winrm_transport, state, "negotiate").to_s,
               elevated: component_config(:elevated, state),
               operation_timeout: component_config(:operation_timeout, state),
               receive_timeout: component_config(:receive_timeout, state),
@@ -306,26 +306,26 @@ module Kitchen
             )
           )
         else
-          base.merge(target: { kind: 'custom' })
+          base.merge(target: { kind: "custom" })
         end
       end
 
       def transport_type(name)
         case name.to_s
-        when 'ssh', 'winrm', 'exec', 'docker_exec'
+        when "ssh", "winrm", "exec", "docker_exec"
           name.to_s
         else
-          'custom'
+          "custom"
         end
       end
 
       def executor_context
         {
-          model: 'exec',
+          model: "exec",
           command: config[:command],
-          input: 'stdin',
+          input: "stdin",
           request_file_argument: nil,
-          event_stream: 'ndjson',
+          event_stream: "ndjson",
         }
       end
 
@@ -345,8 +345,8 @@ module Kitchen
 
       def machine_target(state)
         {
-          kind: 'machine',
-          hostname: state.fetch(:hostname, state.fetch('hostname', 'unknown')),
+          kind: "machine",
+          hostname: state.fetch(:hostname, state.fetch("hostname", "unknown")),
           platform: component_attr(instance.platform, :name),
         }
       end
@@ -378,7 +378,7 @@ module Kitchen
       def component_name(component)
         return component.name if component.respond_to?(:name)
 
-        component.class.name.split('::').last.downcase
+        component.class.name.split("::").last.downcase
       end
 
       def component_attr(component, attr)
@@ -394,24 +394,24 @@ module Kitchen
       end
 
       def require_protocol_version(payload, payload_type)
-        return if payload['protocol_version'] == PROTOCOL_VERSION
+        return if payload["protocol_version"] == PROTOCOL_VERSION
 
         raise_protocol_error(
-          "external provider #{payload_type} used unsupported protocol version #{payload['protocol_version'].inspect}"
+          "external provider #{payload_type} used unsupported protocol version #{payload["protocol_version"].inspect}"
         )
       end
 
       def raise_protocol_error(message, stderr = nil)
         details = [message]
         details << stderr.to_s.strip unless stderr.to_s.strip.empty?
-        raise ActionFailed, redact(details.join(': '))
+        raise ActionFailed, redact(details.join(": "))
       end
 
       def redact(message)
         redacted = Util.mask_values(message.to_s.dup, REDACTED_KEYS)
         pass_env.each do |name|
           value = ENV[name].to_s
-          redacted.gsub!(value, '******') unless value.empty?
+          redacted.gsub!(value, "******") unless value.empty?
         end
         redacted
       end

--- a/lib/kitchen/provisioner/external.rb
+++ b/lib/kitchen/provisioner/external.rb
@@ -1,0 +1,420 @@
+#
+# Copyright:: (C) 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'json'
+require 'open3'
+require 'rbconfig'
+require 'shellwords'
+
+require_relative 'base'
+require_relative '../version'
+
+module Kitchen
+  module Provisioner
+    # Executes an external provisioner provider over the v1 stdio protocol.
+    class External < Base
+      PROTOCOL_VERSION = '1.0'.freeze
+      RESULT_STATUSES = %w(passed failed skipped).freeze
+      LOG_LEVELS = %w(debug info warn error).freeze
+      INTERNAL_CONFIG_KEYS = %i(
+        command provider pass_env kitchen_root test_base_path
+      ).freeze
+      REDACTED_KEYS = %w(password ssh_http_proxy_password).freeze
+
+      kitchen_provisioner_api_version 2
+
+      plugin_version Kitchen::VERSION
+
+      required_config :command
+
+      default_config :provider, &:provider_name_from_command
+      default_config :pass_env, []
+
+      # (see Base#call)
+      def call(state)
+        verify_capabilities
+        validate_provider(state)
+        result = run_provider(state)
+        persist_provider_state(state, result)
+      end
+
+      def provider_name_from_command
+        first_part = Shellwords.split(config[:command].to_s).first.to_s
+        File.basename(first_part).sub(/^kitchen-provider-/, '')
+      end
+
+      private
+
+      def verify_capabilities
+        response = invoke_json('capabilities', {})
+        protocol_version = response.fetch('protocol_version', nil)
+        unless protocol_version == PROTOCOL_VERSION
+          raise_protocol_error(
+            "Unsupported external provider protocol version #{protocol_version.inspect}"
+          )
+        end
+
+        commands = Array(response['commands'])
+        missing_commands = %w(validate run) - commands
+        unless missing_commands.empty?
+          raise_protocol_error(
+            "External provider does not support required command(s): #{missing_commands.join(', ')}"
+          )
+        end
+
+        transports = Array(response['supported_transports'])
+        transport_type = transport_component({}).fetch(:type)
+        return if transports.include?(transport_type)
+
+        raise_protocol_error(
+          "External provider does not support #{transport_type.inspect} transport"
+        )
+      end
+
+      def validate_provider(state)
+        response = invoke_json('validate', request_envelope('validate', state))
+        require_protocol_version(response, 'validation result')
+
+        return if response['status'] == 'ok'
+
+        messages = Array(response['errors']).map { |error| error['message'] }.compact
+        message = messages.empty? ? 'external provider validation failed' : messages.join('; ')
+        raise ActionFailed, redact(message)
+      end
+
+      def run_provider(state)
+        stdout, stderr, status = invoke('run', request_envelope('run', state))
+        result = nil
+
+        stdout.each_line.with_index(1) do |line, index|
+          next if line.strip.empty?
+
+          event = parse_event(line, index)
+          require_protocol_version(event, 'event')
+
+          case event['type']
+          when 'log'
+            handle_log_event(event)
+          when 'progress'
+            handle_progress_event(event)
+          when 'result'
+            result = event
+          else
+            raise_protocol_error("unknown external provider event type #{event['type'].inspect}")
+          end
+        end
+
+        unless status.success?
+          raise_protocol_error("external provider exited with #{status.exitstatus}", stderr)
+        end
+        raise_protocol_error('external provider did not emit a final result') if result.nil?
+
+        handle_result_event(result)
+        result
+      end
+
+      def handle_log_event(event)
+        level = event['level']
+        raise_protocol_error("external provider log event has invalid level #{level.inspect}") unless LOG_LEVELS.include?(level)
+
+        logger.public_send(level, redact(event.fetch('message', '')))
+      end
+
+      def handle_progress_event(event)
+        stage = event.fetch('stage', 'provider')
+        message = event.fetch('message', '')
+        info(redact("[#{stage}] #{message}"))
+      end
+
+      def handle_result_event(event)
+        status = event['status']
+        unless RESULT_STATUSES.include?(status)
+          raise_protocol_error("external provider result has invalid status #{status.inspect}")
+        end
+
+        return if %w(passed skipped).include?(status)
+
+        message = event['message'] || "external provider reported #{status}"
+        raise ActionFailed, redact(message)
+      end
+
+      def persist_provider_state(state, result)
+        provider_state = result.dig('state', 'provider')
+        return if provider_state.nil?
+
+        state[:providers] ||= {}
+        state[:providers][config[:provider]] = provider_state
+      end
+
+      def invoke_json(operation, request)
+        stdout, stderr, status = invoke(operation, request)
+        unless status.success?
+          raise_protocol_error("external provider #{operation} exited with #{status.exitstatus}", stderr)
+        end
+
+        JSON.parse(stdout)
+      rescue JSON::ParserError => error
+        raise_protocol_error("malformed external provider #{operation} response: #{error.message}")
+      end
+
+      def invoke(operation, request)
+        Open3.capture3(
+          provider_environment,
+          *provider_command_parts,
+          operation,
+          stdin_data: JSON.generate(request)
+        )
+      rescue Errno::ENOENT => error
+        raise ActionFailed, redact("external provider command failed: #{error.message}")
+      end
+
+      def provider_command_parts
+        parts = Shellwords.split(config[:command].to_s)
+        raise ActionFailed, 'external provider command cannot be blank' if parts.empty?
+
+        parts
+      end
+
+      def provider_environment
+        pass_env.each_with_object({}) do |name, env|
+          env[name] = ENV[name] if ENV.key?(name)
+        end
+      end
+
+      def request_envelope(operation, state)
+        {
+          protocol_version: PROTOCOL_VERSION,
+          operation: operation,
+          kitchen: kitchen_context,
+          instance: instance_context(state),
+          platform: platform_context,
+          suite: suite_context,
+          components: components_context(state),
+          executor: executor_context,
+          environment: environment_context,
+          state: state_context(state),
+        }
+      end
+
+      def kitchen_context
+        {
+          version: Kitchen::VERSION,
+          root_path: File.expand_path(config[:kitchen_root] || Dir.pwd),
+        }
+      end
+
+      def instance_context(state)
+        {
+          name: instance.name,
+          last_action: state[:last_action],
+          last_attempted_action: state[:last_attempted_action],
+        }
+      end
+
+      def platform_context
+        {
+          name: component_name(instance.platform),
+          os_type: component_attr(instance.platform, :os_type),
+          shell_type: component_attr(instance.platform, :shell_type),
+        }
+      end
+
+      def suite_context
+        { name: instance.suite.name }
+      end
+
+      def components_context(state)
+        {
+          driver: resolved_component(instance.driver, {}),
+          transport: transport_component(state),
+          provisioner: {
+            name: 'external',
+            provider: config[:provider],
+            command: config[:command],
+            config: provider_config,
+          },
+          verifier: resolved_component(instance.verifier, {}),
+        }
+      end
+
+      def resolved_component(component, state)
+        {
+          name: component_name(component),
+          config: {},
+          state: state,
+        }
+      end
+
+      def transport_component(state)
+        name = component_name(instance.transport)
+        type = transport_type(name)
+        base = {
+          name: name,
+          type: type,
+          config: {},
+        }
+
+        case type
+        when 'exec'
+          base.merge(
+            target: { kind: 'local', platform: component_attr(instance.platform, :name) },
+            config: {
+              kitchen_root: File.expand_path(config[:kitchen_root] || Dir.pwd),
+              host_os: RbConfig::CONFIG['host_os'],
+            }
+          )
+        when 'ssh'
+          base.merge(
+            target: machine_target(state),
+            config: compact_hash(
+              username: component_config(:username, state, 'root'),
+              port: component_config(:port, state, 22),
+              connection_timeout: component_config(:connection_timeout, state),
+              connection_retries: component_config(:connection_retries, state),
+              connection_retry_sleep: component_config(:connection_retry_sleep, state),
+              proxy_command: component_config(:ssh_proxy_command, state),
+              gateway: component_config(:ssh_gateway, state),
+              gateway_port: component_config(:ssh_gateway_port, state),
+              gateway_username: component_config(:ssh_gateway_username, state)
+            )
+          )
+        when 'winrm'
+          base.merge(
+            target: machine_target(state),
+            config: compact_hash(
+              username: component_config(:username, state, 'administrator'),
+              port: component_config(:port, state, 5985),
+              scheme: component_config(:scheme, state, 'http'),
+              transport: component_config(:winrm_transport, state, 'negotiate').to_s,
+              elevated: component_config(:elevated, state),
+              operation_timeout: component_config(:operation_timeout, state),
+              receive_timeout: component_config(:receive_timeout, state),
+              connection_retries: component_config(:connection_retries, state),
+              connection_retry_sleep: component_config(:connection_retry_sleep, state)
+            )
+          )
+        else
+          base.merge(target: { kind: 'custom' })
+        end
+      end
+
+      def transport_type(name)
+        case name.to_s
+        when 'ssh', 'winrm', 'exec', 'docker_exec'
+          name.to_s
+        else
+          'custom'
+        end
+      end
+
+      def executor_context
+        {
+          model: 'exec',
+          command: config[:command],
+          input: 'stdin',
+          request_file_argument: nil,
+          event_stream: 'ndjson',
+        }
+      end
+
+      def environment_context
+        passed = pass_env.select { |name| ENV.key?(name) }
+        {
+          passed: passed,
+          user_allowed: pass_env,
+          kitchen_reserved: [],
+        }
+      end
+
+      def state_context(state)
+        providers = state.fetch(:providers, {})
+        { provider: providers.fetch(config[:provider], {}) }
+      end
+
+      def machine_target(state)
+        {
+          kind: 'machine',
+          hostname: state.fetch(:hostname, state.fetch('hostname', 'unknown')),
+          platform: component_attr(instance.platform, :name),
+        }
+      end
+
+      def component_config(key, state, default = nil)
+        return state[key] if state.key?(key)
+        return state[key.to_s] if state.key?(key.to_s)
+        return instance.transport[key] if instance.transport.respond_to?(:[]) && !instance.transport[key].nil?
+
+        default
+      end
+
+      def compact_hash(hash)
+        hash.compact
+      end
+
+      def provider_config
+        config.each_with_object({}) do |(key, value), result|
+          next if INTERNAL_CONFIG_KEYS.include?(key)
+
+          result[key.to_s] = value
+        end
+      end
+
+      def pass_env
+        Array(config[:pass_env]).map(&:to_s)
+      end
+
+      def component_name(component)
+        return component.name if component.respond_to?(:name)
+
+        component.class.name.split('::').last.downcase
+      end
+
+      def component_attr(component, attr)
+        component.public_send(attr) if component.respond_to?(attr)
+      end
+
+      def parse_event(line, index)
+        JSON.parse(line)
+      rescue JSON::ParserError => error
+        raise_protocol_error(
+          "malformed external provider event at line #{index}: #{error.message}"
+        )
+      end
+
+      def require_protocol_version(payload, payload_type)
+        return if payload['protocol_version'] == PROTOCOL_VERSION
+
+        raise_protocol_error(
+          "external provider #{payload_type} used unsupported protocol version #{payload['protocol_version'].inspect}"
+        )
+      end
+
+      def raise_protocol_error(message, stderr = nil)
+        details = [message]
+        details << stderr.to_s.strip unless stderr.to_s.strip.empty?
+        raise ActionFailed, redact(details.join(': '))
+      end
+
+      def redact(message)
+        redacted = Util.mask_values(message.to_s.dup, REDACTED_KEYS)
+        pass_env.each do |name|
+          value = ENV[name].to_s
+          redacted.gsub!(value, '******') unless value.empty?
+        end
+        redacted
+      end
+    end
+  end
+end

--- a/schemas/external-provider-protocol.v1.openapi.yaml
+++ b/schemas/external-provider-protocol.v1.openapi.yaml
@@ -1,0 +1,1375 @@
+openapi: 3.1.0
+jsonSchemaDialect: https://json-schema.org/draft/2020-12/schema
+info:
+  title: Test Kitchen External Provider Protocol
+  version: "1.0.0"
+  summary: Logical OpenAPI description for the Test Kitchen external provider exec protocol.
+  description: |
+    This document describes version 1.0 of the Test Kitchen external provider
+    protocol. The protocol is not an HTTP API. Test Kitchen invokes a short-lived
+    provider executable and exchanges JSON over stdin/stdout.
+
+    The `paths` in this document are logical command names so OpenAPI tooling can
+    validate the request, response, and event schemas. The real command mapping is:
+
+    - `GET /capabilities` -> `<command> capabilities`
+    - `POST /validate` -> `<command> validate`
+    - `POST /run` -> `<command> run`
+
+    `validate` and `run` receive one JSON request on stdin. `capabilities` returns
+    one JSON document on stdout. `validate` returns one JSON document on stdout.
+    `run` emits newline-delimited JSON events on stdout and must finish with one
+    `result` event.
+
+    Raw secret values MUST NOT be serialized into JSON request documents, JSON
+    responses, NDJSON events, schema validation errors, logs, or persisted provider
+    state. Kitchen may pass a constrained allowlist of environment variables to the
+    provider process. JSON may reference environment variable names.
+  license:
+    name: Apache-2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0
+x-kitchen-protocol:
+  name: external-provider
+  protocol_version: "1.0"
+  execution_model: exec
+  channel: stdio
+  event_stream: ndjson
+  rpc: false
+  secret_policy:
+    json_contains_secret_values: false
+    secret_delivery: environment
+    environment_variables: allowlist
+  conformance:
+    provider_must_implement_commands:
+      - capabilities
+      - validate
+      - run
+    provider_must_accept_request_schemas:
+      - ProviderRequest
+    provider_must_emit_event_schemas:
+      - LogEvent
+      - ProgressEvent
+      - ResultEvent
+    provider_must_emit_exactly_one_final_result_event: true
+    provider_must_not_emit_json_secret_values: true
+servers:
+  - url: stdio://external-provider/v1
+    description: Logical endpoint for OpenAPI tooling; actual transport is process stdio.
+security: []
+tags:
+  - name: Commands
+    description: Logical operations implemented by external provider subcommands.
+paths:
+  /capabilities:
+    get:
+      tags:
+        - Commands
+      operationId: getExternalProviderCapabilities
+      summary: Discover provider protocol support.
+      description: |
+        Logical form of `<command> capabilities`. The provider writes one JSON
+        capabilities document to stdout and exits zero when discovery succeeds.
+      x-kitchen-command:
+        argv_suffix:
+          - capabilities
+        stdin: none
+        stdout: application/json
+        stderr: diagnostics
+        exit_status:
+          zero: capabilities document was written to stdout
+          non_zero: provider process or protocol failure
+      responses:
+        "200":
+          description: Provider capabilities.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Capabilities"
+              examples:
+                cinc:
+                  value:
+                    protocol_version: "1.0"
+                    provider:
+                      name: cinc
+                      type: provisioner
+                      version: 0.1.0
+                    execution_model: exec
+                    channel: stdio
+                    commands:
+                      - validate
+                      - run
+                    event_stream: ndjson
+                    supported_transports:
+                      - ssh
+                      - winrm
+                      - exec
+                      - docker_exec
+                    secret_policy:
+                      json_contains_secret_values: false
+                      secret_delivery: environment
+                      environment_variables: allowlist
+        "400":
+          description: Malformed capabilities output or unsupported protocol response.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProtocolError"
+        default:
+          description: Capabilities could not be discovered.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProtocolError"
+  /validate:
+    post:
+      tags:
+        - Commands
+      operationId: validateExternalProviderRequest
+      summary: Validate provider configuration and runtime compatibility.
+      description: |
+        Logical form of `<command> validate`. Kitchen sends a normalized
+        per-instance request on stdin. The provider validates that it can handle
+        the provisioner configuration, platform, target, transport descriptor, and
+        environment references.
+      x-kitchen-command:
+        argv_suffix:
+          - validate
+        stdin: application/json
+        stdout: application/json
+        stderr: diagnostics
+        exit_status:
+          zero: validation response was written to stdout
+          non_zero: provider process or protocol failure
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ValidateProviderRequest"
+            examples:
+              ssh:
+                $ref: "#/components/examples/SshValidateProviderRequest"
+      responses:
+        "200":
+          description: Validation result.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ValidationResult"
+        "400":
+          description: Malformed request or validation output.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProtocolError"
+        default:
+          description: Protocol or provider process failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProtocolError"
+  /run:
+    post:
+      tags:
+        - Commands
+      operationId: runExternalProvider
+      summary: Execute the external provider.
+      description: |
+        Logical form of `<command> run`. Kitchen sends a normalized per-instance
+        request on stdin. The provider owns execution against the target using the
+        supplied target and transport descriptors. The provider writes NDJSON
+        events to stdout and must emit exactly one final `result` event.
+
+        A normal provisioner failure is represented by a final `result` event with
+        `status: failed`. Provider protocol or process failures use non-zero exit
+        status, malformed output, or missing final result and are reported by
+        Kitchen as protocol failures.
+      x-kitchen-command:
+        argv_suffix:
+          - run
+        stdin: application/json
+        stdout: application/x-ndjson
+        stderr: diagnostics
+        final_event: result
+        exit_status:
+          zero: provider emitted a final result event; the result event status determines provisioner success or failure
+          non_zero: provider process or protocol failure
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RunProviderRequest"
+            examples:
+              ssh:
+                $ref: "#/components/examples/SshProviderRequest"
+              winrm:
+                $ref: "#/components/examples/WinrmProviderRequest"
+              exec:
+                $ref: "#/components/examples/ExecProviderRequest"
+              dockerExec:
+                $ref: "#/components/examples/DockerExecProviderRequest"
+      responses:
+        "200":
+          description: NDJSON runtime event stream.
+          content:
+            application/x-ndjson:
+              schema:
+                $ref: "#/components/schemas/ProviderEvent"
+              examples:
+                successfulRun:
+                  value: |
+                    {"protocol_version":"1.0","type":"log","level":"info","message":"Installing Cinc Client"}
+                    {"protocol_version":"1.0","type":"progress","stage":"converge","message":"Cinc Client run started"}
+                    {"protocol_version":"1.0","type":"result","status":"passed","state":{"provider":{"client_version":"18.6.2"}}}
+        "400":
+          description: Malformed request, malformed event stream, or missing final result event.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProtocolError"
+        default:
+          description: Protocol or provider process failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProtocolError"
+components:
+  schemas:
+    ProtocolVersion:
+      type: string
+      const: "1.0"
+
+    ProviderIdentity:
+      type: object
+      additionalProperties: false
+      required:
+        - name
+        - type
+      properties:
+        name:
+          type: string
+          minLength: 1
+          description: Provider implementation name, such as `cinc`.
+        type:
+          type: string
+          enum:
+            - provisioner
+          description: V1 supports external provisioners only.
+        version:
+          type: string
+          minLength: 1
+          description: Provider implementation version.
+
+    Capabilities:
+      type: object
+      additionalProperties: false
+      required:
+        - protocol_version
+        - provider
+        - execution_model
+        - channel
+        - commands
+        - event_stream
+        - supported_transports
+        - secret_policy
+      properties:
+        protocol_version:
+          $ref: "#/components/schemas/ProtocolVersion"
+        provider:
+          $ref: "#/components/schemas/ProviderIdentity"
+        execution_model:
+          type: string
+          const: exec
+          description: V1 providers are short-lived executables, not RPC services.
+        channel:
+          type: string
+          const: stdio
+        commands:
+          type: array
+          minItems: 2
+          uniqueItems: true
+          items:
+            type: string
+            enum:
+              - validate
+              - run
+        event_stream:
+          type: string
+          const: ndjson
+        supported_transports:
+          type: array
+          minItems: 1
+          uniqueItems: true
+          items:
+            $ref: "#/components/schemas/KnownTransportType"
+          description: Transport descriptor types the provider knows how to execute through.
+        secret_policy:
+          $ref: "#/components/schemas/SecretPolicy"
+
+    KnownTransportType:
+      type: string
+      enum:
+        - ssh
+        - winrm
+        - exec
+        - docker_exec
+        - custom
+
+    SecretPolicy:
+      type: object
+      additionalProperties: false
+      required:
+        - json_contains_secret_values
+        - secret_delivery
+        - environment_variables
+      properties:
+        json_contains_secret_values:
+          type: boolean
+          const: false
+        secret_delivery:
+          type: string
+          const: environment
+        environment_variables:
+          type: string
+          const: allowlist
+
+    ProviderRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - protocol_version
+        - operation
+        - kitchen
+        - instance
+        - platform
+        - suite
+        - components
+        - executor
+        - environment
+      properties:
+        protocol_version:
+          $ref: "#/components/schemas/ProtocolVersion"
+        operation:
+          type: string
+          enum:
+            - validate
+            - run
+        kitchen:
+          $ref: "#/components/schemas/KitchenContext"
+        instance:
+          $ref: "#/components/schemas/InstanceContext"
+        platform:
+          $ref: "#/components/schemas/PlatformContext"
+        suite:
+          $ref: "#/components/schemas/SuiteContext"
+        components:
+          $ref: "#/components/schemas/ResolvedComponents"
+        executor:
+          $ref: "#/components/schemas/ExecutorContext"
+        environment:
+          $ref: "#/components/schemas/EnvironmentDescriptor"
+        state:
+          $ref: "#/components/schemas/ProviderStateContext"
+
+    ValidateProviderRequest:
+      allOf:
+        - $ref: "#/components/schemas/ProviderRequest"
+        - type: object
+          required:
+            - operation
+          properties:
+            operation:
+              type: string
+              const: validate
+
+    RunProviderRequest:
+      allOf:
+        - $ref: "#/components/schemas/ProviderRequest"
+        - type: object
+          required:
+            - operation
+          properties:
+            operation:
+              type: string
+              const: run
+
+    KitchenContext:
+      type: object
+      additionalProperties: false
+      required:
+        - version
+        - root_path
+      properties:
+        version:
+          type: string
+          minLength: 1
+        root_path:
+          type: string
+          minLength: 1
+          description: Absolute path to the Kitchen project root.
+        log_path:
+          type: string
+          minLength: 1
+        state_path:
+          type: string
+          minLength: 1
+
+    InstanceContext:
+      type: object
+      additionalProperties: false
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          minLength: 1
+        last_action:
+          type:
+            - string
+            - "null"
+        last_attempted_action:
+          type:
+            - string
+            - "null"
+
+    PlatformContext:
+      type: object
+      additionalProperties: true
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          minLength: 1
+        os_type:
+          type:
+            - string
+            - "null"
+          enum:
+            - unix
+            - windows
+            - null
+        shell_type:
+          type:
+            - string
+            - "null"
+          enum:
+            - bourne
+            - powershell
+            - null
+
+    SuiteContext:
+      type: object
+      additionalProperties: true
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          minLength: 1
+
+    ResolvedComponents:
+      type: object
+      additionalProperties: false
+      required:
+        - driver
+        - transport
+        - provisioner
+      properties:
+        driver:
+          $ref: "#/components/schemas/ResolvedComponent"
+        transport:
+          $ref: "#/components/schemas/TransportComponent"
+        provisioner:
+          $ref: "#/components/schemas/ExternalProvisionerComponent"
+        verifier:
+          $ref: "#/components/schemas/ResolvedComponent"
+
+    ResolvedComponent:
+      type: object
+      additionalProperties: false
+      required:
+        - name
+        - config
+      properties:
+        name:
+          type: string
+          minLength: 1
+        config:
+          $ref: "#/components/schemas/JsonObject"
+        state:
+          $ref: "#/components/schemas/JsonObject"
+
+    ExternalProvisionerComponent:
+      type: object
+      additionalProperties: false
+      required:
+        - name
+        - provider
+        - command
+        - config
+      properties:
+        name:
+          type: string
+          const: external
+        provider:
+          type: string
+          minLength: 1
+          description: External provider implementation name.
+        command:
+          type: string
+          minLength: 1
+          description: Provider executable configured in kitchen.yml.
+        config:
+          $ref: "#/components/schemas/JsonObject"
+
+    ExecutorContext:
+      type: object
+      additionalProperties: false
+      required:
+        - model
+        - command
+        - input
+        - event_stream
+      properties:
+        model:
+          type: string
+          const: exec
+        command:
+          type: string
+          minLength: 1
+          description: External provider executable configured in kitchen.yml.
+        input:
+          type: string
+          const: stdin
+        request_file_argument:
+          type:
+            - string
+            - "null"
+          description: Optional provider-supported debug argument for reading request JSON from a file.
+        event_stream:
+          type: string
+          const: ndjson
+
+    TransportComponent:
+      oneOf:
+        - $ref: "#/components/schemas/SshTransportComponent"
+        - $ref: "#/components/schemas/WinrmTransportComponent"
+        - $ref: "#/components/schemas/ExecTransportComponent"
+        - $ref: "#/components/schemas/DockerExecTransportComponent"
+        - $ref: "#/components/schemas/CustomTransportComponent"
+      discriminator:
+        propertyName: type
+        mapping:
+          ssh: "#/components/schemas/SshTransportComponent"
+          winrm: "#/components/schemas/WinrmTransportComponent"
+          exec: "#/components/schemas/ExecTransportComponent"
+          docker_exec: "#/components/schemas/DockerExecTransportComponent"
+          custom: "#/components/schemas/CustomTransportComponent"
+
+    SshTransportComponent:
+      type: object
+      additionalProperties: false
+      required:
+        - name
+        - type
+        - target
+        - config
+      properties:
+        name:
+          type: string
+          const: ssh
+        type:
+          type: string
+          const: ssh
+        target:
+          $ref: "#/components/schemas/MachineTarget"
+        config:
+          $ref: "#/components/schemas/SshTransportConfig"
+        secrets:
+          $ref: "#/components/schemas/TransportSecretEnvironmentReferences"
+
+    WinrmTransportComponent:
+      type: object
+      additionalProperties: false
+      required:
+        - name
+        - type
+        - target
+        - config
+      properties:
+        name:
+          type: string
+          const: winrm
+        type:
+          type: string
+          const: winrm
+        target:
+          $ref: "#/components/schemas/MachineTarget"
+        config:
+          $ref: "#/components/schemas/WinrmTransportConfig"
+        secrets:
+          $ref: "#/components/schemas/TransportSecretEnvironmentReferences"
+
+    ExecTransportComponent:
+      type: object
+      additionalProperties: false
+      required:
+        - name
+        - type
+        - target
+        - config
+      properties:
+        name:
+          type: string
+          const: exec
+        type:
+          type: string
+          const: exec
+        target:
+          $ref: "#/components/schemas/LocalTarget"
+        config:
+          $ref: "#/components/schemas/ExecTransportConfig"
+
+    DockerExecTransportComponent:
+      type: object
+      additionalProperties: false
+      required:
+        - name
+        - type
+        - target
+        - config
+      properties:
+        name:
+          type: string
+          description: Resolved Kitchen transport plugin name.
+        type:
+          type: string
+          const: docker_exec
+        target:
+          $ref: "#/components/schemas/ContainerTarget"
+        config:
+          $ref: "#/components/schemas/DockerExecTransportConfig"
+
+    CustomTransportComponent:
+      type: object
+      additionalProperties: false
+      required:
+        - name
+        - type
+        - target
+        - config
+      properties:
+        name:
+          type: string
+          minLength: 1
+        type:
+          type: string
+          const: custom
+        target:
+          $ref: "#/components/schemas/CustomTarget"
+        config:
+          $ref: "#/components/schemas/JsonObject"
+        secrets:
+          $ref: "#/components/schemas/TransportSecretEnvironmentReferences"
+
+    SshTransportConfig:
+      type: object
+      additionalProperties: false
+      required:
+        - username
+        - port
+      properties:
+        username:
+          type: string
+          minLength: 1
+        port:
+          type: integer
+          minimum: 1
+          maximum: 65535
+          default: 22
+        connection_timeout:
+          type: integer
+          minimum: 0
+        connection_retries:
+          type: integer
+          minimum: 0
+        connection_retry_sleep:
+          type: integer
+          minimum: 0
+        proxy_command:
+          type:
+            - string
+            - "null"
+        gateway:
+          type:
+            - string
+            - "null"
+        gateway_port:
+          type:
+            - integer
+            - "null"
+          minimum: 1
+          maximum: 65535
+        gateway_username:
+          type:
+            - string
+            - "null"
+
+    WinrmTransportConfig:
+      type: object
+      additionalProperties: false
+      required:
+        - username
+        - port
+        - scheme
+        - transport
+      properties:
+        username:
+          type: string
+          minLength: 1
+        port:
+          type: integer
+          minimum: 1
+          maximum: 65535
+        scheme:
+          type: string
+          enum:
+            - http
+            - https
+        transport:
+          type: string
+          minLength: 1
+          description: WinRM authentication transport, such as negotiate, ssl, plaintext, or kerberos.
+        elevated:
+          type: boolean
+          default: false
+        operation_timeout:
+          type: integer
+          minimum: 1
+        receive_timeout:
+          type: integer
+          minimum: 1
+        connection_retries:
+          type: integer
+          minimum: 0
+        connection_retry_sleep:
+          type: integer
+          minimum: 0
+
+    ExecTransportConfig:
+      type: object
+      additionalProperties: false
+      properties:
+        kitchen_root:
+          type: string
+          minLength: 1
+        host_os:
+          type:
+            - string
+            - "null"
+
+    DockerExecTransportConfig:
+      type: object
+      additionalProperties: false
+      required:
+        - executable
+      properties:
+        executable:
+          type: string
+          enum:
+            - docker
+            - podman
+        shell:
+          type:
+            - string
+            - "null"
+        user:
+          type:
+            - string
+            - "null"
+
+    MachineTarget:
+      type: object
+      additionalProperties: false
+      required:
+        - kind
+        - hostname
+      properties:
+        kind:
+          type: string
+          const: machine
+        hostname:
+          type: string
+          minLength: 1
+        platform:
+          type:
+            - string
+            - "null"
+
+    ContainerTarget:
+      type: object
+      additionalProperties: false
+      required:
+        - kind
+        - container_id
+      properties:
+        kind:
+          type: string
+          const: container
+        container_id:
+          type: string
+          minLength: 1
+        image:
+          type:
+            - string
+            - "null"
+        platform:
+          type:
+            - string
+            - "null"
+
+    LocalTarget:
+      type: object
+      additionalProperties: false
+      required:
+        - kind
+      properties:
+        kind:
+          type: string
+          const: local
+        platform:
+          type:
+            - string
+            - "null"
+
+    CustomTarget:
+      type: object
+      additionalProperties: true
+      required:
+        - kind
+      properties:
+        kind:
+          type: string
+          const: custom
+
+    TransportSecretEnvironmentReferences:
+      type: object
+      additionalProperties: false
+      description: |
+        Environment variable names for transport secrets. Values are environment
+        variable names, never secret values.
+      properties:
+        password:
+          $ref: "#/components/schemas/EnvVarName"
+        private_key:
+          $ref: "#/components/schemas/EnvVarName"
+        passphrase:
+          $ref: "#/components/schemas/EnvVarName"
+        sudo_password:
+          $ref: "#/components/schemas/EnvVarName"
+        proxy_password:
+          $ref: "#/components/schemas/EnvVarName"
+        client_cert:
+          $ref: "#/components/schemas/EnvVarName"
+        client_key:
+          $ref: "#/components/schemas/EnvVarName"
+      examples:
+        - password: KITCHEN_TRANSPORT_PASSWORD
+          private_key: KITCHEN_TRANSPORT_SSH_KEY
+
+    EnvironmentDescriptor:
+      type: object
+      additionalProperties: false
+      required:
+        - passed
+      properties:
+        passed:
+          type: array
+          uniqueItems: true
+          items:
+            $ref: "#/components/schemas/EnvVarName"
+          description: Environment variable names Kitchen made available to the provider process.
+        user_allowed:
+          type: array
+          uniqueItems: true
+          items:
+            $ref: "#/components/schemas/EnvVarName"
+          description: Environment variable names explicitly allowed by user configuration.
+        kitchen_reserved:
+          type: array
+          uniqueItems: true
+          items:
+            $ref: "#/components/schemas/EnvVarName"
+          description: Environment variable names injected by Kitchen for protocol operation.
+
+    EnvVarName:
+      type: string
+      pattern: "^[A-Za-z_][A-Za-z0-9_]*$"
+      minLength: 1
+
+    ProviderStateContext:
+      type: object
+      additionalProperties: false
+      properties:
+        provider:
+          $ref: "#/components/schemas/JsonObject"
+          description: Previously persisted state for this provider namespace only.
+
+    ValidationResult:
+      type: object
+      additionalProperties: false
+      required:
+        - protocol_version
+        - status
+      properties:
+        protocol_version:
+          $ref: "#/components/schemas/ProtocolVersion"
+        status:
+          type: string
+          enum:
+            - ok
+            - error
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ValidationMessage"
+        warnings:
+          type: array
+          items:
+            $ref: "#/components/schemas/ValidationMessage"
+
+    ValidationMessage:
+      type: object
+      additionalProperties: false
+      required:
+        - message
+      properties:
+        code:
+          type: string
+          minLength: 1
+        path:
+          type: string
+          description: JSON Pointer to the relevant request field, when available.
+        message:
+          type: string
+          minLength: 1
+
+    ProviderEvent:
+      oneOf:
+        - $ref: "#/components/schemas/LogEvent"
+        - $ref: "#/components/schemas/ProgressEvent"
+        - $ref: "#/components/schemas/ResultEvent"
+      discriminator:
+        propertyName: type
+        mapping:
+          log: "#/components/schemas/LogEvent"
+          progress: "#/components/schemas/ProgressEvent"
+          result: "#/components/schemas/ResultEvent"
+
+    LogEvent:
+      type: object
+      additionalProperties: false
+      required:
+        - protocol_version
+        - type
+        - level
+        - message
+      properties:
+        protocol_version:
+          $ref: "#/components/schemas/ProtocolVersion"
+        type:
+          type: string
+          const: log
+        timestamp:
+          type: string
+          format: date-time
+        level:
+          type: string
+          enum:
+            - debug
+            - info
+            - warn
+            - error
+        message:
+          type: string
+        fields:
+          $ref: "#/components/schemas/JsonObject"
+
+    ProgressEvent:
+      type: object
+      additionalProperties: false
+      required:
+        - protocol_version
+        - type
+        - stage
+        - message
+      properties:
+        protocol_version:
+          $ref: "#/components/schemas/ProtocolVersion"
+        type:
+          type: string
+          const: progress
+        timestamp:
+          type: string
+          format: date-time
+        stage:
+          type: string
+          minLength: 1
+        message:
+          type: string
+
+    ResultEvent:
+      type: object
+      additionalProperties: false
+      required:
+        - protocol_version
+        - type
+        - status
+      properties:
+        protocol_version:
+          $ref: "#/components/schemas/ProtocolVersion"
+        type:
+          type: string
+          const: result
+        timestamp:
+          type: string
+          format: date-time
+        status:
+          type: string
+          enum:
+            - passed
+            - failed
+            - skipped
+        message:
+          type: string
+        exit_code:
+          type: integer
+        state:
+          $ref: "#/components/schemas/ResultState"
+
+    ResultState:
+      type: object
+      additionalProperties: false
+      properties:
+        provider:
+          $ref: "#/components/schemas/JsonObject"
+          description: State to persist under this provider's namespace.
+
+    ProtocolError:
+      type: object
+      additionalProperties: false
+      required:
+        - error
+      properties:
+        error:
+          type: string
+          minLength: 1
+        message:
+          type: string
+        details:
+          $ref: "#/components/schemas/JsonObject"
+
+    JsonObject:
+      type: object
+      additionalProperties: true
+
+  examples:
+    SshValidateProviderRequest:
+      summary: Validate an external provisioner against an SSH target.
+      value:
+        protocol_version: "1.0"
+        operation: validate
+        kitchen:
+          version: 3.7.0
+          root_path: /work/cookbook
+        instance:
+          name: default-ubuntu-2404
+          last_action: create
+          last_attempted_action: create
+        platform:
+          name: ubuntu-24.04
+          os_type: unix
+          shell_type: bourne
+        suite:
+          name: default
+        components:
+          driver:
+            name: vagrant
+            config: {}
+            state:
+              hostname: 127.0.0.1
+              port: 2222
+          transport:
+            name: ssh
+            type: ssh
+            target:
+              kind: machine
+              hostname: 127.0.0.1
+              platform: ubuntu-24.04
+            config:
+              username: vagrant
+              port: 2222
+            secrets:
+              private_key: KITCHEN_TRANSPORT_SSH_KEY
+          provisioner:
+            name: external
+            provider: cinc
+            command: kitchen-provider-cinc
+            config:
+              product_name: cinc
+              channel: stable
+        executor:
+          model: exec
+          command: kitchen-provider-cinc
+          input: stdin
+          request_file_argument: --request
+          event_stream: ndjson
+        environment:
+          passed:
+            - KITCHEN_TRANSPORT_SSH_KEY
+          kitchen_reserved:
+            - KITCHEN_TRANSPORT_SSH_KEY
+        state:
+          provider: {}
+
+    SshProviderRequest:
+      summary: Run an external provisioner against an SSH target.
+      value:
+        protocol_version: "1.0"
+        operation: run
+        kitchen:
+          version: 3.7.0
+          root_path: /work/cookbook
+          log_path: /work/cookbook/.kitchen/logs/default-ubuntu-2404.log
+          state_path: /work/cookbook/.kitchen/default-ubuntu-2404.yml
+        instance:
+          name: default-ubuntu-2404
+          last_action: create
+          last_attempted_action: create
+        platform:
+          name: ubuntu-24.04
+          os_type: unix
+          shell_type: bourne
+        suite:
+          name: default
+        components:
+          driver:
+            name: vagrant
+            config: {}
+            state:
+              hostname: 127.0.0.1
+              port: 2222
+          transport:
+            name: ssh
+            type: ssh
+            target:
+              kind: machine
+              hostname: 127.0.0.1
+              platform: ubuntu-24.04
+            config:
+              username: vagrant
+              port: 2222
+              connection_timeout: 15
+              connection_retries: 5
+              connection_retry_sleep: 1
+            secrets:
+              private_key: KITCHEN_TRANSPORT_SSH_KEY
+          provisioner:
+            name: external
+            provider: cinc
+            command: kitchen-provider-cinc
+            config:
+              product_name: cinc
+              channel: stable
+        executor:
+          model: exec
+          command: kitchen-provider-cinc
+          input: stdin
+          request_file_argument: --request
+          event_stream: ndjson
+        environment:
+          passed:
+            - KITCHEN_TRANSPORT_SSH_KEY
+            - CHEF_LICENSE
+          user_allowed:
+            - CHEF_LICENSE
+          kitchen_reserved:
+            - KITCHEN_TRANSPORT_SSH_KEY
+        state:
+          provider: {}
+
+    WinrmProviderRequest:
+      summary: Run an external provisioner against a WinRM target.
+      value:
+        protocol_version: "1.0"
+        operation: run
+        kitchen:
+          version: 3.7.0
+          root_path: /work/cookbook
+        instance:
+          name: default-windows-2022
+          last_action: create
+          last_attempted_action: create
+        platform:
+          name: windows-2022
+          os_type: windows
+          shell_type: powershell
+        suite:
+          name: default
+        components:
+          driver:
+            name: vagrant
+            config: {}
+            state:
+              hostname: 127.0.0.1
+              port: 55985
+          transport:
+            name: winrm
+            type: winrm
+            target:
+              kind: machine
+              hostname: 127.0.0.1
+              platform: windows-2022
+            config:
+              username: Administrator
+              port: 55985
+              scheme: http
+              transport: negotiate
+              elevated: true
+              operation_timeout: 60
+              receive_timeout: 70
+              connection_retries: 5
+              connection_retry_sleep: 1
+            secrets:
+              password: KITCHEN_TRANSPORT_PASSWORD
+          provisioner:
+            name: external
+            provider: cinc
+            command: kitchen-provider-cinc
+            config:
+              product_name: cinc
+              channel: stable
+        executor:
+          model: exec
+          command: kitchen-provider-cinc
+          input: stdin
+          request_file_argument: --request
+          event_stream: ndjson
+        environment:
+          passed:
+            - KITCHEN_TRANSPORT_PASSWORD
+          kitchen_reserved:
+            - KITCHEN_TRANSPORT_PASSWORD
+        state:
+          provider: {}
+
+    ExecProviderRequest:
+      summary: Run an external provisioner locally through the exec transport.
+      value:
+        protocol_version: "1.0"
+        operation: run
+        kitchen:
+          version: 3.7.0
+          root_path: /work/cookbook
+        instance:
+          name: default-local
+          last_action: create
+          last_attempted_action: create
+        platform:
+          name: local
+          os_type: unix
+          shell_type: bourne
+        suite:
+          name: default
+        components:
+          driver:
+            name: exec
+            config: {}
+            state: {}
+          transport:
+            name: exec
+            type: exec
+            target:
+              kind: local
+              platform: local
+            config:
+              kitchen_root: /work/cookbook
+              host_os: darwin
+          provisioner:
+            name: external
+            provider: cinc
+            command: kitchen-provider-cinc
+            config:
+              product_name: cinc
+              channel: stable
+        executor:
+          model: exec
+          command: kitchen-provider-cinc
+          input: stdin
+          request_file_argument: --request
+          event_stream: ndjson
+        environment:
+          passed:
+            - CHEF_LICENSE
+          user_allowed:
+            - CHEF_LICENSE
+          kitchen_reserved: []
+        state:
+          provider: {}
+
+    DockerExecProviderRequest:
+      summary: Run an external provisioner inside a container.
+      value:
+        protocol_version: "1.0"
+        operation: run
+        kitchen:
+          version: 3.7.0
+          root_path: /work/cookbook
+        instance:
+          name: default-ubuntu-container
+          last_action: create
+          last_attempted_action: create
+        platform:
+          name: ubuntu-24.04
+          os_type: unix
+          shell_type: bourne
+        suite:
+          name: default
+        components:
+          driver:
+            name: dokken
+            config: {}
+            state:
+              container_id: 8f4c2a1b3d5e
+          transport:
+            name: docker
+            type: docker_exec
+            target:
+              kind: container
+              container_id: 8f4c2a1b3d5e
+              image: ubuntu:24.04
+              platform: ubuntu-24.04
+            config:
+              executable: docker
+              shell: /bin/sh
+              user: root
+          provisioner:
+            name: external
+            provider: cinc
+            command: kitchen-provider-cinc
+            config:
+              product_name: cinc
+              channel: stable
+        executor:
+          model: exec
+          command: kitchen-provider-cinc
+          input: stdin
+          request_file_argument: --request
+          event_stream: ndjson
+        environment:
+          passed: []
+          kitchen_reserved: []
+        state:
+          provider: {}

--- a/spec/fixtures/external_provider/fake_provider.rb
+++ b/spec/fixtures/external_provider/fake_provider.rb
@@ -1,0 +1,113 @@
+#
+# Copyright:: (C) 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'json'
+
+MODE = ARGV.fetch(0)
+OPERATION = ARGV.fetch(1)
+
+def read_request
+  input = $stdin.read
+  request = input.empty? ? {} : JSON.parse(input)
+
+  if ENV['FAKE_EXTERNAL_PROVIDER_REQUEST_LOG']
+    File.open(ENV.fetch('FAKE_EXTERNAL_PROVIDER_REQUEST_LOG'), 'a') do |file|
+      file.puts(JSON.generate(request))
+    end
+  end
+
+  request
+end
+
+def capabilities(protocol_version: '1.0')
+  supported_transports = if MODE == 'all_transports'
+                           %w(ssh winrm exec docker_exec custom)
+                         else
+                           %w(exec)
+                         end
+
+  {
+    protocol_version: protocol_version,
+    provider: {
+      name: 'fake',
+      type: 'provisioner',
+      version: '0.1.0',
+    },
+    execution_model: 'exec',
+    channel: 'stdio',
+    commands: %w(validate run),
+    event_stream: 'ndjson',
+    supported_transports: supported_transports,
+    secret_policy: {
+      json_contains_secret_values: false,
+      secret_delivery: 'environment',
+      environment_variables: 'allowlist',
+    },
+  }
+end
+
+def validation(status, message = nil)
+  response = { protocol_version: '1.0', status: status }
+  response[:errors] = [{ code: 'invalid', message: message }] if message
+  response
+end
+
+def event(payload)
+  $stdout.puts(JSON.generate({ protocol_version: '1.0' }.merge(payload)))
+end
+
+case OPERATION
+when 'capabilities'
+  read_request
+  if MODE == 'unsupported_protocol'
+    puts JSON.generate(capabilities(protocol_version: '2.0'))
+  else
+    puts JSON.generate(capabilities)
+  end
+when 'validate'
+  read_request
+  if MODE == 'validation_error'
+    puts JSON.generate(validation('error', 'suite is not valid for fake provider'))
+  else
+    puts JSON.generate(validation('ok'))
+  end
+when 'run'
+  read_request
+
+  case MODE
+  when 'converge_failure'
+    event(type: 'result', status: 'failed', message: 'fake converge failed', exit_code: 42)
+  when 'malformed_json'
+    puts('{not-json')
+  when 'missing_result'
+    event(type: 'log', level: 'info', message: 'started without finishing')
+  when 'non_zero'
+    warn('provider process exploded')
+    exit 17
+  when 'noisy_stderr'
+    warn('debug detail on stderr')
+    event(type: 'result', status: 'passed', state: { provider: { instance_id: 'abc-123' } })
+  when 'secret_echo'
+    event(type: 'log', level: 'info', message: "secret is #{ENV.fetch('TK_FAKE_SECRET', '')}")
+    event(type: 'result', status: 'failed', message: "failed with #{ENV.fetch('TK_FAKE_SECRET', '')}")
+  else
+    event(type: 'log', level: 'info', message: 'installing fake provider')
+    event(type: 'progress', stage: 'converge', message: 'halfway through fake run')
+    event(type: 'result', status: 'passed', state: { provider: { instance_id: 'abc-123' } })
+  end
+else
+  warn("unknown operation: #{OPERATION}")
+  exit 64
+end

--- a/spec/fixtures/external_provider/fake_provider.rb
+++ b/spec/fixtures/external_provider/fake_provider.rb
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'json'
+require "json"
 
 MODE = ARGV.fetch(0)
 OPERATION = ARGV.fetch(1)
@@ -22,8 +22,8 @@ def read_request
   input = $stdin.read
   request = input.empty? ? {} : JSON.parse(input)
 
-  if ENV['FAKE_EXTERNAL_PROVIDER_REQUEST_LOG']
-    File.open(ENV.fetch('FAKE_EXTERNAL_PROVIDER_REQUEST_LOG'), 'a') do |file|
+  if ENV["FAKE_EXTERNAL_PROVIDER_REQUEST_LOG"]
+    File.open(ENV.fetch("FAKE_EXTERNAL_PROVIDER_REQUEST_LOG"), "a") do |file|
       file.puts(JSON.generate(request))
     end
   end
@@ -31,81 +31,81 @@ def read_request
   request
 end
 
-def capabilities(protocol_version: '1.0')
-  supported_transports = if MODE == 'all_transports'
-                           %w(ssh winrm exec docker_exec custom)
+def capabilities(protocol_version: "1.0")
+  supported_transports = if MODE == "all_transports"
+                           %w{ssh winrm exec docker_exec custom}
                          else
-                           %w(exec)
+                           %w{exec}
                          end
 
   {
     protocol_version: protocol_version,
     provider: {
-      name: 'fake',
-      type: 'provisioner',
-      version: '0.1.0',
+      name: "fake",
+      type: "provisioner",
+      version: "0.1.0",
     },
-    execution_model: 'exec',
-    channel: 'stdio',
-    commands: %w(validate run),
-    event_stream: 'ndjson',
+    execution_model: "exec",
+    channel: "stdio",
+    commands: %w{validate run},
+    event_stream: "ndjson",
     supported_transports: supported_transports,
     secret_policy: {
       json_contains_secret_values: false,
-      secret_delivery: 'environment',
-      environment_variables: 'allowlist',
+      secret_delivery: "environment",
+      environment_variables: "allowlist",
     },
   }
 end
 
 def validation(status, message = nil)
-  response = { protocol_version: '1.0', status: status }
-  response[:errors] = [{ code: 'invalid', message: message }] if message
+  response = { protocol_version: "1.0", status: status }
+  response[:errors] = [{ code: "invalid", message: message }] if message
   response
 end
 
 def event(payload)
-  $stdout.puts(JSON.generate({ protocol_version: '1.0' }.merge(payload)))
+  $stdout.puts(JSON.generate({ protocol_version: "1.0" }.merge(payload)))
 end
 
 case OPERATION
-when 'capabilities'
+when "capabilities"
   read_request
-  if MODE == 'unsupported_protocol'
-    puts JSON.generate(capabilities(protocol_version: '2.0'))
+  if MODE == "unsupported_protocol"
+    puts JSON.generate(capabilities(protocol_version: "2.0"))
   else
     puts JSON.generate(capabilities)
   end
-when 'validate'
+when "validate"
   read_request
-  if MODE == 'validation_error'
-    puts JSON.generate(validation('error', 'suite is not valid for fake provider'))
+  if MODE == "validation_error"
+    puts JSON.generate(validation("error", "suite is not valid for fake provider"))
   else
-    puts JSON.generate(validation('ok'))
+    puts JSON.generate(validation("ok"))
   end
-when 'run'
+when "run"
   read_request
 
   case MODE
-  when 'converge_failure'
-    event(type: 'result', status: 'failed', message: 'fake converge failed', exit_code: 42)
-  when 'malformed_json'
-    puts('{not-json')
-  when 'missing_result'
-    event(type: 'log', level: 'info', message: 'started without finishing')
-  when 'non_zero'
-    warn('provider process exploded')
+  when "converge_failure"
+    event(type: "result", status: "failed", message: "fake converge failed", exit_code: 42)
+  when "malformed_json"
+    puts("{not-json")
+  when "missing_result"
+    event(type: "log", level: "info", message: "started without finishing")
+  when "non_zero"
+    warn("provider process exploded")
     exit 17
-  when 'noisy_stderr'
-    warn('debug detail on stderr')
-    event(type: 'result', status: 'passed', state: { provider: { instance_id: 'abc-123' } })
-  when 'secret_echo'
-    event(type: 'log', level: 'info', message: "secret is #{ENV.fetch('TK_FAKE_SECRET', '')}")
-    event(type: 'result', status: 'failed', message: "failed with #{ENV.fetch('TK_FAKE_SECRET', '')}")
+  when "noisy_stderr"
+    warn("debug detail on stderr")
+    event(type: "result", status: "passed", state: { provider: { instance_id: "abc-123" } })
+  when "secret_echo"
+    event(type: "log", level: "info", message: "secret is #{ENV.fetch("TK_FAKE_SECRET", "")}")
+    event(type: "result", status: "failed", message: "failed with #{ENV.fetch("TK_FAKE_SECRET", "")}")
   else
-    event(type: 'log', level: 'info', message: 'installing fake provider')
-    event(type: 'progress', stage: 'converge', message: 'halfway through fake run')
-    event(type: 'result', status: 'passed', state: { provider: { instance_id: 'abc-123' } })
+    event(type: "log", level: "info", message: "installing fake provider")
+    event(type: "progress", stage: "converge", message: "halfway through fake run")
+    event(type: "result", status: "passed", state: { provider: { instance_id: "abc-123" } })
   end
 else
   warn("unknown operation: #{OPERATION}")

--- a/spec/kitchen/provisioner/external_spec.rb
+++ b/spec/kitchen/provisioner/external_spec.rb
@@ -13,33 +13,33 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require_relative '../../spec_helper'
+require_relative "../../spec_helper"
 
-require 'json'
-require 'logger'
-require 'rbconfig'
-require 'shellwords'
-require 'stringio'
-require 'tempfile'
+require "json"
+require "logger"
+require "rbconfig"
+require "shellwords"
+require "stringio"
+require "tempfile"
 
-require 'kitchen/provisioner'
-require 'kitchen/provisioner/external'
+require "kitchen/provisioner"
+require "kitchen/provisioner/external"
 
 describe Kitchen::Provisioner::External do
   let(:logged_output) { StringIO.new }
   let(:logger)        { Logger.new(logged_output) }
-  let(:platform)      { stub(name: 'ubuntu', os_type: 'unix', shell_type: 'bourne') }
-  let(:suite)         { stub(name: 'default') }
-  let(:driver)        { stub(name: 'exec') }
-  let(:transport_name) { 'exec' }
+  let(:platform)      { stub(name: "ubuntu", os_type: "unix", shell_type: "bourne") }
+  let(:suite)         { stub(name: "default") }
+  let(:driver)        { stub(name: "exec") }
+  let(:transport_name) { "exec" }
   let(:transport)     { stub(name: transport_name) }
-  let(:verifier)      { stub(name: 'inspec') }
+  let(:verifier)      { stub(name: "inspec") }
   let(:state)         { {} }
 
   let(:instance) do
     stub(
-      name: 'default-ubuntu',
-      to_str: 'default-ubuntu',
+      name: "default-ubuntu",
+      to_str: "default-ubuntu",
       logger: logger,
       suite: suite,
       platform: platform,
@@ -50,18 +50,18 @@ describe Kitchen::Provisioner::External do
   end
 
   let(:fixture_path) do
-    File.expand_path('../../fixtures/external_provider/fake_provider.rb', __dir__)
+    File.expand_path("../../fixtures/external_provider/fake_provider.rb", __dir__)
   end
 
-  let(:request_log) { Tempfile.new('fake-provider-requests') }
+  let(:request_log) { Tempfile.new("fake-provider-requests") }
 
   let(:config) do
     {
       command: "#{RbConfig.ruby} #{Shellwords.escape(fixture_path)} success",
-      provider: 'fake',
-      kitchen_root: '/rooty',
-      test_base_path: '/basist',
-      pass_env: ['FAKE_EXTERNAL_PROVIDER_REQUEST_LOG'],
+      provider: "fake",
+      kitchen_root: "/rooty",
+      test_base_path: "/basist",
+      pass_env: ["FAKE_EXTERNAL_PROVIDER_REQUEST_LOG"],
     }
   end
 
@@ -70,146 +70,146 @@ describe Kitchen::Provisioner::External do
   end
 
   before do
-    ENV['FAKE_EXTERNAL_PROVIDER_REQUEST_LOG'] = request_log.path
+    ENV["FAKE_EXTERNAL_PROVIDER_REQUEST_LOG"] = request_log.path
   end
 
   after do
-    ENV.delete('FAKE_EXTERNAL_PROVIDER_REQUEST_LOG')
+    ENV.delete("FAKE_EXTERNAL_PROVIDER_REQUEST_LOG")
     request_log.close!
   end
 
-  it 'provisioner api_version is 2' do
+  it "provisioner api_version is 2" do
     _(provisioner.diagnose_plugin[:api_version]).must_equal 2
   end
 
-  it 'plugin_version is set to Kitchen::VERSION' do
+  it "plugin_version is set to Kitchen::VERSION" do
     _(provisioner.diagnose_plugin[:version]).must_equal Kitchen::VERSION
   end
 
-  it 'can be loaded as the external provisioner plugin' do
+  it "can be loaded as the external provisioner plugin" do
     Kitchen::Plugin.stubs(:require).returns(true)
 
-    loaded = Kitchen::Provisioner.for_plugin('external', command: 'kitchen-provider-fake')
+    loaded = Kitchen::Provisioner.for_plugin("external", command: "kitchen-provider-fake")
 
     _(loaded).must_be_kind_of Kitchen::Provisioner::External
   end
 
-  it 'runs the provider, logs events, and persists provider state' do
+  it "runs the provider, logs events, and persists provider state" do
     provisioner.call(state)
 
-    _(logged_output.string).must_include 'installing fake provider'
-    _(logged_output.string).must_include 'halfway through fake run'
-    _(state[:providers]['fake']).must_equal('instance_id' => 'abc-123')
+    _(logged_output.string).must_include "installing fake provider"
+    _(logged_output.string).must_include "halfway through fake run"
+    _(state[:providers]["fake"]).must_equal("instance_id" => "abc-123")
   end
 
-  it 'sends validate and run request envelopes to the provider' do
+  it "sends validate and run request envelopes to the provider" do
     provisioner.call(state)
 
     requests = request_log.tap(&:rewind).read.lines.map { |line| JSON.parse(line) }
-    operations = requests.map { |request| request['operation'] }
+    operations = requests.map { |request| request["operation"] }
 
-    _(operations).must_equal [nil, 'validate', 'run']
-    _(requests.fetch(1)['protocol_version']).must_equal '1.0'
-    _(requests.fetch(1)['components']['transport']['type']).must_equal 'exec'
-    _(requests.fetch(2)['state']['provider']).must_equal({})
+    _(operations).must_equal [nil, "validate", "run"]
+    _(requests.fetch(1)["protocol_version"]).must_equal "1.0"
+    _(requests.fetch(1)["components"]["transport"]["type"]).must_equal "exec"
+    _(requests.fetch(2)["state"]["provider"]).must_equal({})
   end
 
-  it 'describes existing ssh transport without copying secrets into JSON' do
+  it "describes existing ssh transport without copying secrets into JSON" do
     config[:command] = "#{RbConfig.ruby} #{Shellwords.escape(fixture_path)} all_transports"
-    state[:hostname] = '192.0.2.10'
-    state[:username] = 'ubuntu'
+    state[:hostname] = "192.0.2.10"
+    state[:username] = "ubuntu"
     state[:port] = 2222
-    state[:password] = 'ssh-password'
-    transport.stubs(:name).returns('ssh')
+    state[:password] = "ssh-password"
+    transport.stubs(:name).returns("ssh")
 
     provisioner.call(state)
 
     requests = request_log.tap(&:rewind).read.lines.map { |line| JSON.parse(line) }
-    transport_request = requests.fetch(1).fetch('components').fetch('transport')
+    transport_request = requests.fetch(1).fetch("components").fetch("transport")
 
-    _(transport_request['type']).must_equal 'ssh'
-    _(transport_request['target']).must_equal(
-      'kind' => 'machine',
-      'hostname' => '192.0.2.10',
-      'platform' => 'ubuntu'
+    _(transport_request["type"]).must_equal "ssh"
+    _(transport_request["target"]).must_equal(
+      "kind" => "machine",
+      "hostname" => "192.0.2.10",
+      "platform" => "ubuntu"
     )
-    _(transport_request['config']['username']).must_equal 'ubuntu'
-    _(transport_request['config']['port']).must_equal 2222
-    _(request_log.tap(&:rewind).read).wont_include 'ssh-password'
+    _(transport_request["config"]["username"]).must_equal "ubuntu"
+    _(transport_request["config"]["port"]).must_equal 2222
+    _(request_log.tap(&:rewind).read).wont_include "ssh-password"
   end
 
-  it 'raises ActionFailed when provider validation fails' do
+  it "raises ActionFailed when provider validation fails" do
     config[:command] = "#{RbConfig.ruby} #{Shellwords.escape(fixture_path)} validation_error"
 
     error = _ { provisioner.call(state) }.must_raise Kitchen::ActionFailed
 
-    _(error.message).must_include 'suite is not valid for fake provider'
+    _(error.message).must_include "suite is not valid for fake provider"
   end
 
-  it 'raises ActionFailed for provider-reported converge failure' do
+  it "raises ActionFailed for provider-reported converge failure" do
     config[:command] = "#{RbConfig.ruby} #{Shellwords.escape(fixture_path)} converge_failure"
 
     error = _ { provisioner.call(state) }.must_raise Kitchen::ActionFailed
 
-    _(error.message).must_include 'fake converge failed'
+    _(error.message).must_include "fake converge failed"
   end
 
-  it 'raises ActionFailed for unsupported protocol versions' do
+  it "raises ActionFailed for unsupported protocol versions" do
     config[:command] = "#{RbConfig.ruby} #{Shellwords.escape(fixture_path)} unsupported_protocol"
 
     error = _ { provisioner.call(state) }.must_raise Kitchen::ActionFailed
 
-    _(error.message).must_include 'Unsupported external provider protocol version'
+    _(error.message).must_include "Unsupported external provider protocol version"
   end
 
-  it 'raises ActionFailed when run output is malformed' do
+  it "raises ActionFailed when run output is malformed" do
     config[:command] = "#{RbConfig.ruby} #{Shellwords.escape(fixture_path)} malformed_json"
 
     error = _ { provisioner.call(state) }.must_raise Kitchen::ActionFailed
 
-    _(error.message).must_include 'malformed external provider event'
+    _(error.message).must_include "malformed external provider event"
   end
 
-  it 'raises ActionFailed when run output has no final result' do
+  it "raises ActionFailed when run output has no final result" do
     config[:command] = "#{RbConfig.ruby} #{Shellwords.escape(fixture_path)} missing_result"
 
     error = _ { provisioner.call(state) }.must_raise Kitchen::ActionFailed
 
-    _(error.message).must_include 'did not emit a final result'
+    _(error.message).must_include "did not emit a final result"
   end
 
-  it 'raises ActionFailed when the provider process exits non-zero' do
+  it "raises ActionFailed when the provider process exits non-zero" do
     config[:command] = "#{RbConfig.ruby} #{Shellwords.escape(fixture_path)} non_zero"
 
     error = _ { provisioner.call(state) }.must_raise Kitchen::ActionFailed
 
-    _(error.message).must_include 'provider process exploded'
+    _(error.message).must_include "provider process exploded"
   end
 
-  it 'redacts allowlisted environment values from logs and errors' do
+  it "redacts allowlisted environment values from logs and errors" do
     config[:command] = "#{RbConfig.ruby} #{Shellwords.escape(fixture_path)} secret_echo"
-    config[:pass_env] = ['TK_FAKE_SECRET']
-    ENV['TK_FAKE_SECRET'] = 'super-secret-value'
+    config[:pass_env] = ["TK_FAKE_SECRET"]
+    ENV["TK_FAKE_SECRET"] = "super-secret-value"
 
     error = _ { provisioner.call(state) }.must_raise Kitchen::ActionFailed
 
-    _(logged_output.string).wont_include 'super-secret-value'
-    _(error.message).wont_include 'super-secret-value'
-    _(logged_output.string).must_include '******'
-    _(error.message).must_include '******'
+    _(logged_output.string).wont_include "super-secret-value"
+    _(error.message).wont_include "super-secret-value"
+    _(logged_output.string).must_include "******"
+    _(error.message).must_include "******"
   ensure
-    ENV.delete('TK_FAKE_SECRET')
+    ENV.delete("TK_FAKE_SECRET")
   end
 
-  it 'does not include allowlisted environment values in JSON requests' do
-    config[:pass_env] = ['TK_FAKE_SECRET']
-    ENV['TK_FAKE_SECRET'] = 'super-secret-value'
+  it "does not include allowlisted environment values in JSON requests" do
+    config[:pass_env] = ["TK_FAKE_SECRET"]
+    ENV["TK_FAKE_SECRET"] = "super-secret-value"
 
     provisioner.call(state)
 
     request_log.rewind
-    _(request_log.read).wont_include 'super-secret-value'
+    _(request_log.read).wont_include "super-secret-value"
   ensure
-    ENV.delete('TK_FAKE_SECRET')
+    ENV.delete("TK_FAKE_SECRET")
   end
 end

--- a/spec/kitchen/provisioner/external_spec.rb
+++ b/spec/kitchen/provisioner/external_spec.rb
@@ -1,0 +1,215 @@
+#
+# Copyright:: (C) 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative '../../spec_helper'
+
+require 'json'
+require 'logger'
+require 'rbconfig'
+require 'shellwords'
+require 'stringio'
+require 'tempfile'
+
+require 'kitchen/provisioner'
+require 'kitchen/provisioner/external'
+
+describe Kitchen::Provisioner::External do
+  let(:logged_output) { StringIO.new }
+  let(:logger)        { Logger.new(logged_output) }
+  let(:platform)      { stub(name: 'ubuntu', os_type: 'unix', shell_type: 'bourne') }
+  let(:suite)         { stub(name: 'default') }
+  let(:driver)        { stub(name: 'exec') }
+  let(:transport_name) { 'exec' }
+  let(:transport)     { stub(name: transport_name) }
+  let(:verifier)      { stub(name: 'inspec') }
+  let(:state)         { {} }
+
+  let(:instance) do
+    stub(
+      name: 'default-ubuntu',
+      to_str: 'default-ubuntu',
+      logger: logger,
+      suite: suite,
+      platform: platform,
+      driver: driver,
+      transport: transport,
+      verifier: verifier
+    )
+  end
+
+  let(:fixture_path) do
+    File.expand_path('../../fixtures/external_provider/fake_provider.rb', __dir__)
+  end
+
+  let(:request_log) { Tempfile.new('fake-provider-requests') }
+
+  let(:config) do
+    {
+      command: "#{RbConfig.ruby} #{Shellwords.escape(fixture_path)} success",
+      provider: 'fake',
+      kitchen_root: '/rooty',
+      test_base_path: '/basist',
+      pass_env: ['FAKE_EXTERNAL_PROVIDER_REQUEST_LOG'],
+    }
+  end
+
+  let(:provisioner) do
+    Kitchen::Provisioner::External.new(config).finalize_config!(instance)
+  end
+
+  before do
+    ENV['FAKE_EXTERNAL_PROVIDER_REQUEST_LOG'] = request_log.path
+  end
+
+  after do
+    ENV.delete('FAKE_EXTERNAL_PROVIDER_REQUEST_LOG')
+    request_log.close!
+  end
+
+  it 'provisioner api_version is 2' do
+    _(provisioner.diagnose_plugin[:api_version]).must_equal 2
+  end
+
+  it 'plugin_version is set to Kitchen::VERSION' do
+    _(provisioner.diagnose_plugin[:version]).must_equal Kitchen::VERSION
+  end
+
+  it 'can be loaded as the external provisioner plugin' do
+    Kitchen::Plugin.stubs(:require).returns(true)
+
+    loaded = Kitchen::Provisioner.for_plugin('external', command: 'kitchen-provider-fake')
+
+    _(loaded).must_be_kind_of Kitchen::Provisioner::External
+  end
+
+  it 'runs the provider, logs events, and persists provider state' do
+    provisioner.call(state)
+
+    _(logged_output.string).must_include 'installing fake provider'
+    _(logged_output.string).must_include 'halfway through fake run'
+    _(state[:providers]['fake']).must_equal('instance_id' => 'abc-123')
+  end
+
+  it 'sends validate and run request envelopes to the provider' do
+    provisioner.call(state)
+
+    requests = request_log.tap(&:rewind).read.lines.map { |line| JSON.parse(line) }
+    operations = requests.map { |request| request['operation'] }
+
+    _(operations).must_equal [nil, 'validate', 'run']
+    _(requests.fetch(1)['protocol_version']).must_equal '1.0'
+    _(requests.fetch(1)['components']['transport']['type']).must_equal 'exec'
+    _(requests.fetch(2)['state']['provider']).must_equal({})
+  end
+
+  it 'describes existing ssh transport without copying secrets into JSON' do
+    config[:command] = "#{RbConfig.ruby} #{Shellwords.escape(fixture_path)} all_transports"
+    state[:hostname] = '192.0.2.10'
+    state[:username] = 'ubuntu'
+    state[:port] = 2222
+    state[:password] = 'ssh-password'
+    transport.stubs(:name).returns('ssh')
+
+    provisioner.call(state)
+
+    requests = request_log.tap(&:rewind).read.lines.map { |line| JSON.parse(line) }
+    transport_request = requests.fetch(1).fetch('components').fetch('transport')
+
+    _(transport_request['type']).must_equal 'ssh'
+    _(transport_request['target']).must_equal(
+      'kind' => 'machine',
+      'hostname' => '192.0.2.10',
+      'platform' => 'ubuntu'
+    )
+    _(transport_request['config']['username']).must_equal 'ubuntu'
+    _(transport_request['config']['port']).must_equal 2222
+    _(request_log.tap(&:rewind).read).wont_include 'ssh-password'
+  end
+
+  it 'raises ActionFailed when provider validation fails' do
+    config[:command] = "#{RbConfig.ruby} #{Shellwords.escape(fixture_path)} validation_error"
+
+    error = _ { provisioner.call(state) }.must_raise Kitchen::ActionFailed
+
+    _(error.message).must_include 'suite is not valid for fake provider'
+  end
+
+  it 'raises ActionFailed for provider-reported converge failure' do
+    config[:command] = "#{RbConfig.ruby} #{Shellwords.escape(fixture_path)} converge_failure"
+
+    error = _ { provisioner.call(state) }.must_raise Kitchen::ActionFailed
+
+    _(error.message).must_include 'fake converge failed'
+  end
+
+  it 'raises ActionFailed for unsupported protocol versions' do
+    config[:command] = "#{RbConfig.ruby} #{Shellwords.escape(fixture_path)} unsupported_protocol"
+
+    error = _ { provisioner.call(state) }.must_raise Kitchen::ActionFailed
+
+    _(error.message).must_include 'Unsupported external provider protocol version'
+  end
+
+  it 'raises ActionFailed when run output is malformed' do
+    config[:command] = "#{RbConfig.ruby} #{Shellwords.escape(fixture_path)} malformed_json"
+
+    error = _ { provisioner.call(state) }.must_raise Kitchen::ActionFailed
+
+    _(error.message).must_include 'malformed external provider event'
+  end
+
+  it 'raises ActionFailed when run output has no final result' do
+    config[:command] = "#{RbConfig.ruby} #{Shellwords.escape(fixture_path)} missing_result"
+
+    error = _ { provisioner.call(state) }.must_raise Kitchen::ActionFailed
+
+    _(error.message).must_include 'did not emit a final result'
+  end
+
+  it 'raises ActionFailed when the provider process exits non-zero' do
+    config[:command] = "#{RbConfig.ruby} #{Shellwords.escape(fixture_path)} non_zero"
+
+    error = _ { provisioner.call(state) }.must_raise Kitchen::ActionFailed
+
+    _(error.message).must_include 'provider process exploded'
+  end
+
+  it 'redacts allowlisted environment values from logs and errors' do
+    config[:command] = "#{RbConfig.ruby} #{Shellwords.escape(fixture_path)} secret_echo"
+    config[:pass_env] = ['TK_FAKE_SECRET']
+    ENV['TK_FAKE_SECRET'] = 'super-secret-value'
+
+    error = _ { provisioner.call(state) }.must_raise Kitchen::ActionFailed
+
+    _(logged_output.string).wont_include 'super-secret-value'
+    _(error.message).wont_include 'super-secret-value'
+    _(logged_output.string).must_include '******'
+    _(error.message).must_include '******'
+  ensure
+    ENV.delete('TK_FAKE_SECRET')
+  end
+
+  it 'does not include allowlisted environment values in JSON requests' do
+    config[:pass_env] = ['TK_FAKE_SECRET']
+    ENV['TK_FAKE_SECRET'] = 'super-secret-value'
+
+    provisioner.call(state)
+
+    request_log.rewind
+    _(request_log.read).wont_include 'super-secret-value'
+  ensure
+    ENV.delete('TK_FAKE_SECRET')
+  end
+end


### PR DESCRIPTION
## Summary
- add an OpenAPI 3.1 contract for the v1 external provider exec protocol
- define logical capabilities, validate, and run command schemas
- model provider-owned execution, target/transport descriptors, env-based secret references, NDJSON events, and conformance examples

Refs #2056
