### PR TITLE
docs: update plugin guidance

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,9 +23,9 @@ jobs:
         id: check
         run: |
           if [ -f Gemfile ]; then
-           echo "gemfile=true" >> $GITHUB_OUTPUT
+           echo "gemfile=true" >> "$GITHUB_OUTPUT"
           else
-            echo "gemfile=false" >> $GITHUB_OUTPUT
+            echo "gemfile=false" >> "$GITHUB_OUTPUT"
           fi
       - name: Setup Ruby
         if: steps.check.outputs.gemfile == 'true'
@@ -58,17 +58,6 @@ jobs:
             *.md
             !CHANGELOG.md
 
-  markdown-link-check:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - uses: gaurav-nelson/github-action-markdown-link-check@1.0.17
-        with:
-          use-quiet-mode: "yes"
-          use-verbose-mode: "yes"
-          check-modified-files-only: "yes"
-          base-branch: "main"
-
   test:
     name: Unit Test with Ruby
     runs-on: ubuntu-latest
@@ -84,9 +73,9 @@ jobs:
         id: check
         run: |
           if [ -f Gemfile ]; then
-           echo "gemfile=true" >> $GITHUB_OUTPUT
+           echo "gemfile=true" >> "$GITHUB_OUTPUT"
           else
-            echo "gemfile=false" >> $GITHUB_OUTPUT
+            echo "gemfile=false" >> "$GITHUB_OUTPUT"
           fi
       - name: Setup Ruby
         if: steps.check.outputs.gemfile == 'true'

--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -1,91 +1,83 @@
-# Community and Ecosystem plugins
+# Community and ecosystem plugins
 
-Here is a collection of plugins for extending Test Kitchen functionality:
+Test Kitchen discovers plugins from the Ruby environment that runs `kitchen`.
+That environment might be system Ruby, Bundler, Cinc Workstation, Chef
+Workstation, or another packaged distribution. Check that environment before
+assuming a plugin is available:
 
-The following are in the test-kitchen GitHub organization
+```bash
+gem list kitchen-vagrant
+chef gem list kitchen-vagrant
+```
 
-| [kitchen-ec2][ec2] | [kitchen-digitalocean][do] | [kitchen-openstack][open] | [kitchen-rackspace][rs] | [kitchen-google][google] | [kitchen-vagrant][vagrant] |
-|--------------------|----------------------------|---------------------------|-------------------------|--------------------------|----------------------------|
-| [![Status](https://travis-ci.org/test-kitchen/kitchen-ec2.svg?branch=master)](https://travis-ci.org/test-kitchen/kitchen-ec2) | [![Status](https://travis-ci.org/test-kitchen/kitchen-digitalocean.svg?branch=master)](https://travis-ci.org/test-kitchen/kitchen-digitalocean) | [![Status](https://travis-ci.org/test-kitchen/kitchen-openstack.svg?branch=master)](https://travis-ci.org/test-kitchen/kitchen-openstack) | [![Status](https://travis-ci.org/test-kitchen/kitchen-rackspace.svg?branch=master)](https://travis-ci.org/test-kitchen/kitchen-rackspace) |  [![Status](https://travis-ci.org/test-kitchen/kitchen-google.svg?branch=master)](https://travis-ci.org/test-kitchen/kitchen-google) | [![Status](https://travis-ci.org/test-kitchen/kitchen-vagrant.svg?branch=master)](https://travis-ci.org/test-kitchen/kitchen-vagrant) |
-| [![Gem Version](https://badge.fury.io/rb/kitchen-ec2.svg)](https://badge.fury.io/rb/kitchen-ec2) | [![Gem Version](https://badge.fury.io/rb/kitchen-digitalocean.svg)](https://badge.fury.io/rb/kitchen-digitalocean) | [![Gem Version](https://badge.fury.io/rb/kitchen-openstack.svg)](https://badge.fury.io/rb/kitchen-openstack) | [![Gem Version](https://badge.fury.io/rb/kitchen-rackspace.svg)](https://badge.fury.io/rb/kitchen-rackspace) | [![Gem Version](https://badge.fury.io/rb/kitchen-google.svg)](https://badge.fury.io/rb/kitchen-google) | [![Gem Version](https://badge.fury.io/rb/kitchen-vagrant.svg)](https://badge.fury.io/rb/kitchen-vagrant) |
+Install missing plugins into the same environment that runs `kitchen`.
 
-| [kitchen-dsc][dsc] | [kitchen-pester][pester] | [kitchen-opennebula][opennebula] | [kitchen-hyperv][hyperv] | [kitchen-cloudstack][cloudstack] |
-|--------------------|--------------------------|----------------------------------|--------------------------|----------------------------------|
-| [![Status](https://travis-ci.org/test-kitchen/kitchen-dsc.svg?branch=master)](https://travis-ci.org/test-kitchen/kitchen-dsc) | [![Status](https://travis-ci.org/test-kitchen/kitchen-pester.svg?branch=master)](https://travis-ci.org/test-kitchen/kitchen-pester) | [![Status](https://travis-ci.org/test-kitchen/kitchen-opennebula.svg?branch=master)](https://travis-ci.org/test-kitchen/kitchen-opennebula) |  [![Status](https://travis-ci.org/test-kitchen/kitchen-hyperv.svg?branch=master)](https://travis-ci.org/test-kitchen/kitchen-hyperv) | [![Status](https://travis-ci.org/test-kitchen/kitchen-cloudstack.svg?branch=master)](https://travis-ci.org/test-kitchen/kitchen-cloudstack) |
-| [![Gem Version](https://badge.fury.io/rb/kitchen-dsc.svg)](https://badge.fury.io/rb/kitchen-dsc) | [![Gem Version](https://badge.fury.io/rb/kitchen-pester.svg)](https://badge.fury.io/rb/kitchen-pester) | [![Gem Version](https://badge.fury.io/rb/kitchen-opennebula.svg)](https://badge.fury.io/rb/kitchen-opennebula) | [![Gem Version](https://badge.fury.io/rb/kitchen-hyperv.svg)](https://badge.fury.io/rb/kitchen-hyperv) | [![Gem Version](https://badge.fury.io/rb/kitchen-cloudstack.svg)](https://badge.fury.io/rb/kitchen-cloudstack) |
+This page lists common Test Kitchen ecosystem plugins. It is not an exhaustive
+registry of every historical plugin.
 
-| [kitchen-dokken][dokken] | [kitchen-azurerm][azurerm] | [kitchen-vra][vra] | [kitchen-vro][vro] | [kitchen-vcair][vcair] | [kitchen-sparkleformation][sparkleformation]                                                                              |
-|--------------------------|----------------------------|--------------------|--------------------|------------------------|---------------------------------------------------------------------------------------------------------------------------|
-| [![Status](https://travis-ci.org/test-kitchen/kitchen-dokken.svg?branch=master)](https://travis-ci.org/test-kitchen/kitchen-dokken) | [![Status](https://travis-ci.org/pendrica/kitchen-azurerm.svg?branch=master)](https://travis-ci.org/pendrica/kitchen-azurerm) | [![Status](https://travis-ci.org/test-kitchen/kitchen-vra.svg?branch=master)](https://travis-ci.org/test-kitchen/kitchen-vra)| [![Status](https://travis-ci.org/test-kitchen/kitchen-vro.svg?branch=master)](https://travis-ci.org/test-kitchen/kitchen-vro) | [![Status](https://travis-ci.org/test-kitchen/kitchen-vcair.svg?branch=master)](https://travis-ci.org/test-kitchen/kitchen-vcair) | [![Status](https://travis-ci.org/test-kitchen/kitchen-sparkleformation.svg?branch=master)](https://travis-ci.org/test-kitchen/kitchen-sparkleformation) |
-| [![Gem Version](https://badge.fury.io/rb/kitchen-dokken.svg)](https://badge.fury.io/rb/kitchen-dokken) | [![Gem Version](https://badge.fury.io/rb/kitchen-azurerm.svg)](https://badge.fury.io/rb/kitchen-azurerm) | [![Gem Version](https://badge.fury.io/rb/kitchen-vra.svg)](https://badge.fury.io/rb/kitchen-vra) | [![Gem Version](https://badge.fury.io/rb/kitchen-vro.svg)](https://badge.fury.io/rb/kitchen-vro) | [![Gem Version](https://badge.fury.io/rb/kitchen-vcair.svg)](https://badge.fury.io/rb/kitchen-vcair) | [![Gem Version](https://badge.fury.io/rb/kitchen-sparkleformation.svg)](https://badge.fury.io/rb/kitchen-sparkleformation) |
+## Drivers
 
-| [kitchen-habtiat][habitat] |
-|----------------------------|
-| Unknown |
-| [![Gem Version](https://badge.fury.io/rb/kitchen-habitat.svg)](https://badge.fury.io/rb/kitchen-habitat) |
+Drivers create and manage test instances.
 
-The following are written by the [Progress Chef Software][chef].
+| Plugin | Target |
+| ------ | ------ |
+| [kitchen-azurerm](https://github.com/test-kitchen/kitchen-azurerm) | Microsoft Azure |
+| [kitchen-cloudstack](https://github.com/test-kitchen/kitchen-cloudstack) | Apache CloudStack |
+| [kitchen-digitalocean](https://github.com/test-kitchen/kitchen-digitalocean) | DigitalOcean |
+| [kitchen-docker](https://github.com/test-kitchen/kitchen-docker) | Docker |
+| [kitchen-dokken](https://github.com/test-kitchen/kitchen-dokken) | Docker or Podman for Chef Infra cookbook testing |
+| [kitchen-ec2](https://github.com/test-kitchen/kitchen-ec2) | Amazon EC2 |
+| [kitchen-google](https://github.com/test-kitchen/kitchen-google) | Google Compute Engine |
+| [kitchen-habitat](https://github.com/test-kitchen/kitchen-habitat) | Chef Habitat |
+| [kitchen-hyperv](https://github.com/test-kitchen/kitchen-hyperv) | Microsoft Hyper-V |
+| [kitchen-opennebula](https://github.com/test-kitchen/kitchen-opennebula) | OpenNebula |
+| [kitchen-openstack](https://github.com/test-kitchen/kitchen-openstack) | OpenStack |
+| [kitchen-rackspace](https://github.com/test-kitchen/kitchen-rackspace) | Rackspace Cloud |
+| [kitchen-vagrant](https://github.com/test-kitchen/kitchen-vagrant) | HashiCorp Vagrant |
+| [kitchen-vcair](https://github.com/test-kitchen/kitchen-vcair) | VMware vCloud Air |
+| [kitchen-vcenter](https://github.com/chef/kitchen-vcenter) | VMware vCenter |
+| [kitchen-vra](https://github.com/test-kitchen/kitchen-vra) | VMware vRealize Automation |
+| [kitchen-vro](https://github.com/test-kitchen/kitchen-vro) | VMware vRealize Orchestrator |
 
-| [kitchen-vcenter][vcenter] | [kitchen-inspec][inspec] |
-|----------------------------|---------------------------|
-| [![Build status](https://badge.buildkite.com/4b0ca1bb5cd02dee51d9ce789f8346eb05730685c5be7fbba9.svg?branch=master)](https://buildkite.com/chef-oss/chef-kitchen-vcenter-master-verify) | Unknown |
-| [![Gem Version](https://badge.fury.io/rb/kitchen-vcenter.svg)](https://rubygems.org/gems/kitchen-vcenter) | [![Gem Version](https://badge.fury.io/rb/kitchen-inspec.svg)](https://badge.fury.io/rb/kitchen-inspec) |
+## Provisioners
 
-The following are community-maintained plugins
+Provisioners configure an instance after the driver creates it.
 
-| [kitchen-sync][sync] | [kitchen-ansible][ansible] | [kitchen-puppet][puppet] | [kitchen-salt][salt] | [kitchen-lxc][lxc] |
-|----------------------|----------------------------|--------------------------|----------------------|--------------------|
-| [![Status](https://travis-ci.org/coderanger/kitchen-sync.svg?branch=master)](https://travis-ci.org/coderanger/kitchen-sync) | [![Status](https://travis-ci.org/neillturner/kitchen-ansible.svg?branch=master)](https://travis-ci.org/neillturner/kitchen-ansible) | [![Status](https://travis-ci.org/neillturner/kitchen-puppet.svg?branch=master)](https://travis-ci.org/neillturner/kitchen-puppet) | [![Status](https://travis-ci.org/kitchen-salt/kitchen-salt.svg?branch=master)](https://travis-ci.org/kitchen-salt/kitchen-salt) | [![Status](https://travis-ci.org/chrisroberts/kitchen-lxc.svg?branch=master)](https://travis-ci.org/chrisroberts/kitchen-lxc) |
-| [![Gem Version](https://badge.fury.io/rb/kitchen-sync.svg)](https://badge.fury.io/rb/kitchen-sync) | [![Gem Version](https://badge.fury.io/rb/kitchen-ansible.svg)](https://badge.fury.io/rb/kitchen-ansible) | [![Gem Version](https://badge.fury.io/rb/kitchen-puppet.svg)](https://badge.fury.io/rb/kitchen-puppet) | [![Gem Version](https://badge.fury.io/rb/kitchen-salt.svg)](https://badge.fury.io/rb/kitchen-salt) | [![Gem Version](https://badge.fury.io/rb/kitchen-lxc.svg)](https://badge.fury.io/rb/kitchen-lxc) |
+| Plugin | Target |
+| ------ | ------ |
+| [kitchen-ansible](https://github.com/neillturner/kitchen-ansible) | Ansible |
+| [kitchen-cinc](https://github.com/test-kitchen/kitchen-cinc) | Cinc Client |
+| [kitchen-dsc](https://github.com/test-kitchen/kitchen-dsc) | PowerShell DSC |
+| [kitchen-omnibus-chef](https://github.com/test-kitchen/kitchen-omnibus-chef) | Chef Infra Client |
+| [kitchen-puppet](https://github.com/neillturner/kitchen-puppet) | Puppet |
+| [kitchen-salt](https://github.com/kitchen-salt/kitchen-salt) | Salt |
 
-| [kitchen-nodes][nodes] | [kitchen-zcloudjp][zcloudjp] | [kitchen-softlayer][softlayer] | [kitchen-linode][linode] | [kitchen-docker][docker] |
-|------------------------|------------------------------|--------------------------------|--------------------------|--------------------------|
-| [![Status](https://travis-ci.org/mwrock/kitchen-nodes.svg?branch=master)](https://travis-ci.org/mwwrock/kitchen-nodes) | [![Status](https://travis-ci.org/higanworks/kitchen-zcloudjp.svg?branch=master)](https://travis-ci.org/higanworks/kitchen-zcloudjp) |  [![Status](https://travis-ci.org/neillturner/kitchen-softlayer.svg?branch=master)](https://travis-ci.org/neillturner/kitchen-softlayer) | [![Status](https://github.com/ssplatt/kitchen-linode/actions/workflows/ci.yml/badge.svg)](https://github.com/ssplatt/kitchen-linode/actions/workflows/ci.yml) | [![Status](https://travis-ci.org/ssplatt/kitchen-docker.svg?branch=master)](https://travis-ci.org/portertech/kitchen-docker) |
-| [![Gem Version](https://badge.fury.io/rb/kitchen-nodes.svg)](https://badge.fury.io/rb/kitchen-nodes) | [![Gem Version](https://badge.fury.io/rb/kitchen-zcloudjp.svg)](https://badge.fury.io/rb/kitchen-zcloudjp) | [![Gem Version](https://badge.fury.io/rb/kitchen-softlayer.svg)](https://badge.fury.io/rb/kitchen-softlayer) | [![Gem Version](https://badge.fury.io/rb/kitchen-linode.svg)](https://badge.fury.io/rb/kitchen-linode)  | [![Gem Version](https://badge.fury.io/rb/kitchen-docker.svg)](https://badge.fury.io/rb/kitchen-docker) |
+## Verifiers
 
-| [kitchen-qemu][qemu] | [kitchen-cfengine][cfengine] | [kitchen-cloudformation][cloudformation] | [kitchen-wpar][wpar] |
-|----------------------|------------------------------|------------------------------------------|----------------------|
-| Unknown | [![Status](https://travis-ci.org/nmische/kitchen-cfengine.svg?branch=master)](https://travis-ci.org/nmische/kitchen-cfengine) | [![Status](https://travis-ci.org/neillturner/kitchen-cloudformation.svg?branch=master)](https://travis-ci.org/neillturner/kitchen-cloudformation)  | [![Status](https://travis-ci.org/adejoux/kitchen-wpar.svg?branch=master)](https://travis-ci.org/adejoux/kitchen-wpar) |
-| [![Gem Version](https://badge.fury.io/rb/kitchen-qemu.svg)](https://badge.fury.io/rb/kitchen-qemu) | [![Gem Version](https://badge.fury.io/rb/kitchen-cfengine.svg)](https://badge.fury.io/rb/kitchen-cfengine) | [![Gem Version](https://badge.fury.io/rb/kitchen-cloudformation.svg)](https://badge.fury.io/rb/kitchen-cloudformation) | [![Gem Version](https://badge.fury.io/rb/kitchen-wpar.svg)](https://badge.fury.io/rb/kitchen-wpar) |
+Verifiers test the instance after convergence.
 
-| [kitchen-sparkleformation][sparkleformation] | [kitchen-terraform][terraform] |
-|----------------------------------------------|--------------------------------|
-| [![Status](https://travis-ci.org/devkid/kitchen-sparkleformation.svg?branch=master)](https://travis-ci.org/devkid/kitchen-sparkleformation) | [![Status](https://travis-ci.org/newcontext-oss/kitchen-terraform.svg?branch=master)](https://travis-ci.org/newcontext-oss/kitchen-terraform) |
-| [![Gem Version](https://badge.fury.io/rb/kitchen-sparkleformation.svg)](https://badge.fury.io/rb/kitchen-sparkleformation) | [![Gem Version](https://badge.fury.io/rb/kitchen-terraform.svg)](https://badge.fury.io/rb/kitchen-terraform) |
+| Plugin | Target |
+| ------ | ------ |
+| [busser-bash](https://github.com/test-kitchen/busser-bash) | Bash tests through the legacy busser verifier |
+| [busser-bats](https://github.com/test-kitchen/busser-bats) | BATS tests through the legacy busser verifier |
+| [busser-cucumber](https://github.com/test-kitchen/busser-cucumber) | Cucumber tests through the legacy busser verifier |
+| [busser-minitest](https://github.com/test-kitchen/busser-minitest) | Minitest tests through the legacy busser verifier |
+| [busser-rspec](https://github.com/test-kitchen/busser-rspec) | RSpec tests through the legacy busser verifier |
+| [busser-serverspec](https://github.com/test-kitchen/busser-serverspec) | ServerSpec tests through the legacy busser verifier |
+| [kitchen-cinc-auditor](https://github.com/test-kitchen/kitchen-cinc-auditor) | Cinc Auditor |
+| [kitchen-inspec](https://github.com/inspec/kitchen-inspec) | Chef InSpec |
+| [kitchen-pester](https://github.com/test-kitchen/kitchen-pester) | Pester |
 
-[ec2]: https://github.com/test-kitchen/kitchen-ec2
-[do]: https://github.com/test-kitchen/kitchen-digitalocean
-[open]: https://github.com/test-kitchen/kitchen-openstack
-[rs]: https://github.com/test-kitchen/kitchen-rackspace
-[google]: https://github.com/test-kitchen/kitchen-google
-[vagrant]: https://github.com/test-kitchen/kitchen-vagrant
-[dsc]: https://github.com/test-kitchen/kitchen-dsc
-[pester]: https://github.com/test-kitchen/kitchen-pester
-[opennebula]: https://github.com/test-kitchen/kitchen-opennebula
-[hyperv]: https://github.com/test-kitchen/kitchen-hyperv
-[habitat]: https://github.com/test-kitchen/kitchen-habitat
-[cloudstack]: https://github.com/test-kitchen/kitchen-cloudstack
-[vra]: https://github.com/chef-partners/kitchen-vra
-[vro]: https://github.com/chef-partners/kitchen-vro
-[vcenter]: https://github.com/chef/kitchen-vcenter
-[vcair]: https://github.com/chef-partners/kitchen-vcair
-[sync]:  https://github.com/coderanger/kitchen-sync
-[ansible]: https://github.com/neillturner/kitchen-ansible
-[puppet]: https://github.com/neillturner/kitchen-puppet
-[salt]: https://github.com/kitchen-salt/kitchen-salt
-[dokken]: https://github.com/test-kitchen/kitchen-dokken
-[lxc]: https://github.com/chrisroberts/kitchen-lxc
-[nodes]: https://github.com/mwrock/kitchen-nodes
-[zcloudjp]: https://github.com/higanworks/kitchen-zcloudjp
-[softlayer]: https://github.com/neillturner/kitchen-softlayer
-[linode]:  https://github.com/ssplatt/kitchen-linode
-[qemu]:  https://github.com/esmil/kitchen-qemu
-[cfengine]: https://github.com/nmische/kitchen-cfengine
-[cloudformation]: https://github.com/neillturner/kitchen-cloudformation
-[sparkleformation]: https://github.com/devkid/kitchen-sparkleformation
-[wpar]:  https://github.com/adejoux/kitchen-wpar
-[inspec]: https://github.com/chef/kitchen-inspec
-[chef]: https://chef.io
-[azurerm]: https://github.com/test-kitchen/kitchen-azurerm
-[docker]: https://github.com/portertech/kitchen-docker
-[terraform]: https://github.com/newcontext-oss/kitchen-terraform
+## Transports and helpers
+
+| Plugin | Purpose |
+| ------ | ------- |
+| [kitchen-sync](https://github.com/test-kitchen/kitchen-sync) | Transport plugin for faster file synchronization |
+| [guard-kitchen](https://github.com/test-kitchen/guard-kitchen) | Guard integration |
+
+## Historical plugins
+
+Some plugins that existed over Test Kitchen's lifetime may be obsolete,
+archived, or superseded by newer drivers. Prefer the plugin's repository,
+RubyGems page, and your selected Workstation package metadata when deciding
+whether a plugin is still suitable for new work.

--- a/README.md
+++ b/README.md
@@ -39,8 +39,10 @@ kitchen init
 A `kitchen.yml` file will be created in your project base directory. This file
 describes your testing configuration; what you want to test and on which target
 platforms. Each of these suite and platform combinations are called instances.
-By default your instances will be converged with Chef Solo and run in Vagrant
-virtual machines.
+By default `kitchen init` generates a Vagrant-backed instance with the shell
+provisioner. Chef, Cinc, and other configuration management tooling is supplied
+by the Ruby environment you run Kitchen from, such as system gems, Cinc
+Workstation, or Chef Workstation.
 
 Get a listing of your instances with:
 
@@ -48,7 +50,7 @@ Get a listing of your instances with:
 kitchen list
 ```
 
-Run Chef Infra Client on an instance, in this case `default-ubuntu-2004`, with:
+Converge an instance, in this case `default-ubuntu-2004`, with:
 
 ```shell
 kitchen converge default-ubuntu-2004

--- a/docs/content/docs/drivers/_index.md
+++ b/docs/content/docs/drivers/_index.md
@@ -8,24 +8,31 @@ menu:
 
 A Test Kitchen *driver* is what supports configuring the compute instance that is used for isolated testing. This is typically a local hypervisor (Hyper-V), hypervisor abstraction layer (Vagrant), or cloud service (AWS EC2).
 
-[Chef Workstation](https://community.chef.io/tools/chef-workstation) includes Test Kitchen along with the following drivers:
+Driver availability depends on the Ruby environment that runs `kitchen`. A system Ruby install, Cinc Workstation, and Chef Workstation may each provide a different set of installed driver gems. Check the environment you are using before assuming a driver is available:
 
-- Amazon EC2 (AWS) via the [kitchen-ec2](https://github.com/test-kitchen/kitchen-ec2) project
-- DigitalOcean via the [kitchen-digitalocean](https://github.com/test-kitchen/kitchen-digitalocean) project
-- Dokken (Chef Infra specific Docker driver) via the [kitchen-dokken](https://github.com/test-kitchen/kitchen-dokken) project
-- Google Cloud Platform via the [kitchen-google](https://github.com/test-kitchen/kitchen-google) project
-- HashiCorp Vagrant via the [kitchen-vagrant](https://github.com/test-kitchen/kitchen-vagrant) project
-- Microsoft Azure via the [kitchen-azurerm](https://github.com/test-kitchen/kitchen-azurerm) project
-- Microsoft Hyper-V via the [kitchen-hyperv](https://github.com/test-kitchen/kitchen-hyperv) project
-- Openstack via the [kitchen-openstack](https://github.com/test-kitchen/kitchen-openstack) project
-- VMware vCenter via the [kitchen-vcenter](https://github.com/chef/kitchen-vcenter) project
-- VMware vRealize Automation via the [kitchen-vra](https://github.com/test-kitchen/kitchen-vra) project
+```bash
+gem list kitchen-vagrant
+chef gem list kitchen-vagrant
+```
 
-The Test Kitchen community also maintains several additional plugins not bundled directly in Chef Workstation:
+Install missing driver gems into that same environment. Common driver plugin projects include:
 
+- [kitchen-azurerm](https://github.com/test-kitchen/kitchen-azurerm)
+- [kitchen-cloudstack](https://github.com/test-kitchen/kitchen-cloudstack)
+- [kitchen-digitalocean](https://github.com/test-kitchen/kitchen-digitalocean)
 - [kitchen-docker](https://github.com/test-kitchen/kitchen-docker)
+- [kitchen-dokken](https://github.com/test-kitchen/kitchen-dokken)
+- [kitchen-ec2](https://github.com/test-kitchen/kitchen-ec2)
+- [kitchen-google](https://github.com/test-kitchen/kitchen-google)
+- [kitchen-habitat](https://github.com/test-kitchen/kitchen-habitat)
+- [kitchen-hyperv](https://github.com/test-kitchen/kitchen-hyperv)
+- [kitchen-opennebula](https://github.com/test-kitchen/kitchen-opennebula)
+- [kitchen-openstack](https://github.com/test-kitchen/kitchen-openstack)
 - [kitchen-rackspace](https://github.com/test-kitchen/kitchen-rackspace)
+- [kitchen-vagrant](https://github.com/test-kitchen/kitchen-vagrant)
 - [kitchen-vcair](https://github.com/test-kitchen/kitchen-vcair)
+- [kitchen-vcenter](https://github.com/chef/kitchen-vcenter)
+- [kitchen-vra](https://github.com/test-kitchen/kitchen-vra)
 - [kitchen-vro](https://github.com/test-kitchen/kitchen-vro)
 
 There are other drivers that have existed over the life of Test Kitchen that we do not list here, either because they are un-maintained or have been supplanted by other drivers.

--- a/docs/content/docs/getting-started/01-installing.md
+++ b/docs/content/docs/getting-started/01-installing.md
@@ -21,19 +21,22 @@ To run 64-bit virtual machines, your computer must have a 64-bit operating syste
 Unfortunately Hyper-V doesn't like other hypervisors running at the same time and it must be disabled as a Windows Feature for VirtualBox to function properly.
 </div>
 
-##### Chef Workstation
+##### Test Kitchen and Workstation tooling
 
-First, install the [Chef Workstation](https://www.chef.io/downloads). This package includes Chef Infra Client, Chef InSpec, Test Kitchen, Cookstyle, and a variety of useful tools for the Chef ecosystem.
+Install Test Kitchen from RubyGems, your system packages, [Cinc Workstation](https://cinc.sh/start/workstation/), or [Chef Workstation](https://www.chef.io/downloads). Test Kitchen itself does not bundle Chef or Cinc tooling. When you use a Workstation package, the available drivers, provisioners, verifiers, and Chef-compatible commands are the ones bundled by that package.
 
-```ruby
+For a RubyGems install:
+
+```bash
+$ gem install test-kitchen
+$ kitchen version
+Test Kitchen version 4.0.0
+```
+
+For a Workstation install, use the Workstation command to see what it bundles:
+
+```bash
 $ chef --version
-Chef Workstation version: 25.5.1084
-Chef CLI version: 5.6.21
-Chef Habitat version: 1.6.1243
-Test Kitchen version: 3.7.0
-Cookstyle version: 7.32.8
-Chef Infra Client version: 18.7.10
-Chef InSpec version: 5.22.80
 ```
 
 ##### VirtualBox
@@ -54,9 +57,9 @@ $ vagrant --version
 Vagrant 2.4.7
 ```
 
-With Chef Workstation, VirtualBox, and Vagrant installed, you're ready to use Test Kitchen's default setup. By default, Test Kitchen uses the `kitchen-vagrant` driver, which leverages Vagrant to create, manage, and destroy local virtual machines. Vagrant supports a variety of hypervisors and cloud providers, but for this guide, we'll use VirtualBox for local virtualization.
+With Test Kitchen, VirtualBox, and Vagrant installed, you're ready to create a local virtual machine. By default, `kitchen init` generates a `kitchen-vagrant` driver configuration and a shell provisioner. This guide uses Vagrant with VirtualBox for virtualization, and a Chef-compatible Workstation environment for the Chef Infra examples.
 
-Test Kitchen is highly modular, allowing you to mix and match different drivers (such as Vagrant, VMware, Azure, EC2, or Docker), provisioners (like Chef Infra, Ansible, Puppet, Salt, or DSC), and verifiers (including InSpec, Serverspec, or BATS). In this quick start, we'll focus on the most common workflow: Vagrant with VirtualBox for virtualization, Chef Infra for provisioning, and InSpec for testing.
+Test Kitchen is highly modular, allowing you to mix and match drivers (such as Vagrant, VMware, Azure, EC2, or Docker), provisioners (such as shell, Chef/Cinc, Ansible, Puppet, Salt, or DSC), and verifiers (including InSpec, Serverspec, or BATS). Install those plugins into the same Ruby environment that runs `kitchen`.
 
 <div class="sidebar--footer">
 <a class="button primary-cta" href="/docs/getting-started/getting-help">Next - Getting Help</a>

--- a/docs/content/docs/getting-started/02-getting-help.md
+++ b/docs/content/docs/getting-started/02-getting-help.md
@@ -23,8 +23,9 @@ Commands:
   kitchen init                                    # Adds some configuration to your cookbook so Kitchen can rock
   kitchen list [INSTANCE|REGEXP|all]              # Lists one or more instances
   kitchen login INSTANCE|REGEXP                   # Log in to one instance
+  kitchen logs [INSTANCE|REGEXP|all]              # Show structured logs
   kitchen package INSTANCE|REGEXP                 # package an instance
-  kitchen setup [INSTANCE|REGEXP|all]             # Change instance state to setup. Prepare to run automated tests. Install busser and related gems on one or more instances
+  kitchen setup [INSTANCE|REGEXP|all]             # Change instance state to setup. Prepare one or more instances for verification
   kitchen test [INSTANCE|REGEXP|all]              # Test (destroy, create, converge, setup, verify and destroy) one or more instances
   kitchen verify [INSTANCE|REGEXP|all]            # Change instance state to verify. Run automated tests on one or more instances
   kitchen version                                 # Print Test Kitchen's version information

--- a/docs/content/docs/getting-started/04-kitchen-yml.md
+++ b/docs/content/docs/getting-started/04-kitchen-yml.md
@@ -7,9 +7,9 @@ menu:
     weight: 40
 ---
 
-Let's take a closer look at the `kitchen.yml` file. Although Chef Workstation generates an initial version for you, it's important to review and customize this file to suit your testing needs.
+Let's take a closer look at the `kitchen.yml` file. Although `kitchen init` generates an initial version for you, it's important to review and customize this file to suit your testing needs.
 
-Suppose you want to test your Chef cookbook exclusively on Ubuntu 24.04 using the latest Chef Infra Client. In this scenario, you can update the `kitchen.yml` file to specify the desired Chef version and limit the `platforms` section to just one entry, as shown below:
+Suppose you want to test your Chef or Cinc cookbook exclusively on Ubuntu 24.04 using the latest compatible client from your selected Workstation or system Ruby environment. In this scenario, you can update the `kitchen.yml` file to specify the desired provisioner and limit the `platforms` section to just one entry, as shown below:
 
 ```yaml
 ---

--- a/docs/content/docs/provisioners/_index.md
+++ b/docs/content/docs/provisioners/_index.md
@@ -6,7 +6,7 @@ menu:
     weight: 1
 ---
 
-A Test Kitchen *provisioner* takes care of configuring the compute instance provided by the *driver*. This is most commonly a configuration management framework like Chef Infra or the Shell provisioner, both of which are included in test-kitchen by default.
+A Test Kitchen *provisioner* takes care of configuring the compute instance provided by the *driver*. The `test-kitchen` gem includes the `shell` provisioner, which is the default provisioner, and a `dummy` provisioner for tests. Chef, Cinc, and other configuration management provisioners are supplied by plugin gems installed in the Ruby environment that runs `kitchen`.
 
 There are common settings that all provisioners inherit and can override. These are typically set in the context of a specific provisioner but are provided here for reference.
 
@@ -31,8 +31,10 @@ provisioner:
     "/tmp/kitchen/validation.pem": "./downloads/validation.pem"
 ```
 
-Community provisioners:
+Common provisioner plugins:
 
+* [kitchen-omnibus-chef](https://github.com/test-kitchen/kitchen-omnibus-chef)
+* [kitchen-cinc](https://github.com/test-kitchen/kitchen-cinc)
 * [kitchen-ansible](https://github.com/neillturner/kitchen-ansible)
 * [kitchen-dsc](https://github.com/test-kitchen/kitchen-dsc)
 * [kitchen-puppet](https://github.com/neillturner/kitchen-puppet)

--- a/docs/content/docs/provisioners/chef.md
+++ b/docs/content/docs/provisioners/chef.md
@@ -11,7 +11,7 @@ kitchen-omnibus-chef is a Test Kitchen *provisioner* for chef-client.
 
 ## Overview
 
-[kitchen-omnibus-chef](https://github.com/test-kitchen/kitchen-omnibus-chef) plugin includes three provisioners for Chef Infra: `chef_solo`, `chef_infra` and `chef_target`, that support similar options. `chef_zero` was renamed `chef_infra`.
+The [kitchen-omnibus-chef](https://github.com/test-kitchen/kitchen-omnibus-chef) plugin includes three provisioners for Chef Infra: `chef_solo`, `chef_infra` and `chef_target`, that support similar options. `chef_zero` was renamed `chef_infra`. This plugin is not bundled by the `test-kitchen` gem itself; use the version provided by your Workstation package or install it into the Ruby environment that runs `kitchen`.
 
 `chef_target` is for using Chef 19 Target Mode without remotely installing any agents and is based on `kitchen-transport-train` and the Train framework, which are not installed from Test Kitchen by default. For links to these two tools, look at the end of this page.
 

--- a/docs/content/docs/reference/faq.md
+++ b/docs/content/docs/reference/faq.md
@@ -12,11 +12,12 @@ These are frequently asked questions or tips that don't have a better home just 
 
 #### How do I add another driver other than Vagrant?
 
-If you're using Chef Workstation, check for it `chef gem list | grep $DRIVER` you need to make sure the driver [exists](https://github.com/test-kitchen/test-kitchen/blob/main/ECOSYSTEM.md),
-if it does:
+First check whether the driver is installed in the Ruby environment that runs `kitchen`. With system Ruby, use `gem list`. With Chef Workstation, use `chef gem list`. If your selected Workstation package does not bundle the plugin, install it into that same environment.
 
 ```bash
-~$ gem install kitchen-openstack # for instance
+~$ gem list kitchen-openstack
+~$ chef gem list kitchen-openstack
+~$ gem install kitchen-openstack # or chef gem install kitchen-openstack
 ~$ vi cookbooks/demo/kitchen.yml # wherever your kitchen.yml is for your cookbook
 ```
 
@@ -34,7 +35,7 @@ Certain drivers, like `kitchen-dokken` [recommend](https://github.com/test-kitch
 
 ##### How do I update just Test Kitchen if I'm using Chef Workstation?
 
-Due to the nature of how the Chef Workstation is built, it is not possible to update a gem that is part of the package. To get the latest versions of component software, builds from the [current](https://www.chef.io/downloads/tools/workstation) channel can be consumed.
+Due to the nature of how Workstation packages are built, it is not possible to update a gem that is part of the package in place. To get newer component versions, install a newer Workstation build or run Test Kitchen from a separate Ruby environment where you control the gem versions.
 
 ##### How do I change the user to access the instance?
 

--- a/docs/content/docs/verifiers/_index.md
+++ b/docs/content/docs/verifiers/_index.md
@@ -6,10 +6,12 @@ menu:
     weight: 1
 ---
 
-A Test Kitchen *verifier* tests the configuration applied by the *provisioner*. This is most commonly InSpec or ServerSpec, both of which are included in Chef Workstation.
+A Test Kitchen *verifier* tests the configuration applied by the *provisioner*. The `test-kitchen` gem includes the legacy `busser` verifier and the built-in `shell` verifier. InSpec, Cinc Auditor, ServerSpec, Pester, and BATS support is supplied by plugin gems installed in the Ruby environment that runs `kitchen`.
 
-Other verifiers:
+Common verifier plugins:
 
-* shell (built-in)
+* [kitchen-inspec](https://github.com/inspec/kitchen-inspec)
+* [kitchen-cinc-auditor](https://github.com/test-kitchen/kitchen-cinc-auditor)
 * [busser-bats](https://github.com/test-kitchen/busser-bats/)
+* [busser-serverspec](https://github.com/test-kitchen/busser-serverspec/)
 * [kitchen-pester](https://github.com/test-kitchen/kitchen-pester/)

--- a/docs/content/docs/verifiers/serverspec.md
+++ b/docs/content/docs/verifiers/serverspec.md
@@ -7,9 +7,9 @@ menu:
     weight: 5
 ---
 
-[ServerSpec](https://serverspec.org/) is a framework that gives you RSpec tests for your infrastructure. Test Kitchen's busser plugin utilizes [busser-serverspec](https://github.com/test-kitchen/busser-serverspec) for executing ServerSpec tests.
+[ServerSpec](https://serverspec.org/) is a framework that gives you RSpec tests for your infrastructure. Test Kitchen's legacy busser verifier can use [busser-serverspec](https://github.com/test-kitchen/busser-serverspec) for executing ServerSpec tests.
 
-Files can be placed in `test/integration/$SUITE/serverspec/` and no configuration is required in the user's `kitchen.yml`.
+Install `busser-serverspec` into the same Ruby environment that runs `kitchen`. When using the busser verifier, files can be placed in `test/integration/$SUITE/serverspec/`.
 
 Example test to check that the httpd package is installed:
 

--- a/lib/kitchen/cli.rb
+++ b/lib/kitchen/cli.rb
@@ -155,8 +155,7 @@ module Kitchen
       converge: "Change instance state to converge. " \
                    "Use a provisioner to configure one or more instances",
       setup: "Change instance state to setup. " \
-                   "Prepare to run automated tests. " \
-                   "Install busser and related gems on one or more instances",
+                   "Prepare one or more instances for verification",
       verify: "Change instance state to verify. " \
                    "Run automated tests on one or more instances",
       destroy: "Change instance state to destroy. " \


### PR DESCRIPTION
## Summary
- clarify that Test Kitchen does not bundle Chef or Cinc tooling and defers to the active Ruby/Workstation environment
- update driver, provisioner, verifier, and ecosystem plugin guidance
- correct generated/default provisioner wording to shell and refresh CLI help docs for logs/setup

## Verification
- bundle exec cucumber features/kitchen_help_command.feature features/kitchen_logs_command.feature
- bundle exec ruby -Ilib -Ispec spec/kitchen/cli_spec.rb
- mise exec -- hugo --source docs --destination /tmp/test-kitchen-docs-build
- git diff --check