### PR TITLE
feat: widen mixlib-install constraint to allow 4.x

### DIFF
--- a/test-kitchen.gemspec
+++ b/test-kitchen.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "csv",                "~> 3.3"
   gem.add_dependency "ed25519",            "~> 1.3" # ed25519 ssh key support
   gem.add_dependency "irb",                "~> 1.15"
-  gem.add_dependency "mixlib-install",     "~> 3.6"
+  gem.add_dependency "mixlib-install",     ">= 3.6", "< 5.0" # allow Cinc's mixlib-install 4.x fork
   gem.add_dependency "mixlib-shellout",    ">= 1.2", "< 4.0"
   gem.add_dependency "net-scp",            ">= 1.1", "< 5.0" # pinning until we can confirm 4+ works
   gem.add_dependency "net-ssh",            ">= 2.9", "< 8.0" # pinning until we can confirm 8+ works


### PR DESCRIPTION
The pessimistic "~> 3.6" constraint locks test-kitchen to the 3.x
series of mixlib-install. Cinc Workstation ships a mixlib-install fork
that was bumped to 4.x.x, so the tight pin prevents test-kitchen from
resolving against it.

Relax the constraint to ">= 3.6", "< 5.0" so the Cinc 4.x fork (and any
future 4.x release) can satisfy the dependency while still guarding
against an unvetted 5.0 major bump.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Signed-off-by: Lance Albertson <lance@osuosl.org>

# Description

Please describe what this change achieves

## Issues Resolved

List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant

## Type of Change

Our release process assumes you are using [Conventional Commit messages](https://www.conventionalcommits.org/en/v1.0.0/).

The most important prefixes you should have in mind are:

- `_fix_`: which represents bug fixes, and correlates to a SemVer patch.
- `_feat_`: which represents a new feature, and correlates to a SemVer minor.
- `_feat!_`:, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the !) and will result in a major version change.

If you have not included a conventional commit message this can be fixed on merge.

## Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] Commit message includes a [Conventional Commit Message](https://www.conventionalcommits.org/en/v1.0.0)
