### PR TITLE
fix: make provisioner and verifier downloads best-effort

### DIFF
--- a/docs/content/docs/provisioners/_index.md
+++ b/docs/content/docs/provisioners/_index.md
@@ -24,7 +24,9 @@ provisioner:
   wait_for_retry: 30
   uploads: # a Hash of local => remote file mappings to upload at the start of invocation
     "contrib/some_file.cfg": "/etc"
-  downloads: # a Hash of remote => local file mappings to download after converge (downloaded even when converge fails, so logs can be retrieved)
+  downloads: # a Hash of remote => local file mappings to download after converge
+  # files are downloaded even when converge fails, so logs can be retrieved
+  # a file that cannot be downloaded logs a warning and does not fail the converge
   # if the local value is an existing dir, the file will be copied into it
   # if the local value does not exist, a file with that value as name will be created
     "/tmp/kitchen/client.rb": "./downloads"

--- a/docs/content/docs/reference/current-provisioner-contract.md
+++ b/docs/content/docs/reference/current-provisioner-contract.md
@@ -81,6 +81,15 @@ The base workflow:
 * downloads configured `downloads`
 * cleans up the local sandbox
 
+Downloads are attempted in an ensure block, so configured downloads may run even
+after the converge command fails. This is what makes it possible to retrieve logs
+that explain a failed converge.
+
+Downloads are best-effort. A file that cannot be downloaded logs a warning rather
+than failing the action, and a download failure never replaces an error already
+propagating from the converge command. A transport that does not implement
+`download` raises `Kitchen::ClientError`, which still surfaces.
+
 Each command hook may return `nil`. Current transports are expected to no-op
 for `execute(nil)`.
 

--- a/docs/content/docs/reference/current-verifier-contract.md
+++ b/docs/content/docs/reference/current-verifier-contract.md
@@ -84,6 +84,11 @@ The base workflow:
 Downloads are attempted in an ensure block, so configured downloads may run even
 after the verifier command fails.
 
+Downloads are best-effort. A file that cannot be downloaded logs a warning rather
+than failing the action, and a download failure never replaces an error already
+propagating from the verifier command. A transport that does not implement
+`download` raises `Kitchen::ClientError`, which still surfaces.
+
 Each command hook may return `nil`. Current transports are expected to no-op
 for `execute(nil)`.
 

--- a/lib/kitchen/provisioner/base.rb
+++ b/lib/kitchen/provisioner/base.rb
@@ -113,12 +113,24 @@ module Kitchen
               config[:wait_for_retry]
             )
           ensure
-            info("Downloading files from #{instance.to_str}")
-            config[:downloads].to_h.each do |remotes, local|
-              debug("Downloading #{Array(remotes).join(", ")} to #{local}")
-              conn.download(remotes, local)
+            # Retrieval is best-effort: a file we could not fetch must not
+            # fail an otherwise successful converge, and must never replace
+            # an error already in flight from the run command. A transport
+            # that cannot download at all is a bug, not a missing file, so
+            # it still raises when there is no converge error to protect.
+            run_error = $!
+            begin
+              info("Downloading files from #{instance.to_str}")
+              config[:downloads].to_h.each do |remotes, local|
+                debug("Downloading #{Array(remotes).join(", ")} to #{local}")
+                conn.download(remotes, local)
+              end
+              debug("Download complete")
+            rescue => ex
+              raise unless run_error || ex.is_a?(Kitchen::Transport::TransportFailed)
+
+              warn("Failed to download files from #{instance.to_str}: #{ex.message}")
             end
-            debug("Download complete")
           end
         end
       rescue Kitchen::Transport::TransportFailed => ex

--- a/lib/kitchen/verifier/base.rb
+++ b/lib/kitchen/verifier/base.rb
@@ -77,12 +77,24 @@ module Kitchen
           begin
             conn.execute(run_command)
           ensure
-            info("Downloading files from #{instance.to_str}")
-            config[:downloads].to_h.each do |remotes, local|
-              debug("Downloading #{Array(remotes).join(", ")} to #{local}")
-              conn.download(remotes, local)
+            # Retrieval is best-effort: a file we could not fetch must not
+            # fail an otherwise successful verify, and must never replace
+            # an error already in flight from the run command. A transport
+            # that cannot download at all is a bug, not a missing file, so
+            # it still raises when there is no verify error to protect.
+            run_error = $!
+            begin
+              info("Downloading files from #{instance.to_str}")
+              config[:downloads].to_h.each do |remotes, local|
+                debug("Downloading #{Array(remotes).join(", ")} to #{local}")
+                conn.download(remotes, local)
+              end
+              debug("Download complete")
+            rescue => ex
+              raise unless run_error || ex.is_a?(Kitchen::Transport::TransportFailed)
+
+              warn("Failed to download files from #{instance.to_str}: #{ex.message}")
             end
-            debug("Download complete")
           end
         end
       rescue Kitchen::Transport::TransportFailed => ex

--- a/spec/kitchen/provisioner/base_spec.rb
+++ b/spec/kitchen/provisioner/base_spec.rb
@@ -286,12 +286,40 @@ describe Kitchen::Provisioner::Base do
 
       connection.expects(:download).with("/remote", "/local")
 
-      connection.expects(:execute_with_retry).raises
+      connection.expects(:execute_with_retry)
+        .raises(Kitchen::Transport::TransportFailed.new("converge boom"))
 
-      begin
-        cmd
-      rescue
-      end
+      err = _ { cmd }.must_raise Kitchen::ActionFailed
+      _(err.message).must_match(/converge boom/)
+    end
+
+    it "reports the run failure when downloading also fails" do
+      connection.stubs(:execute_with_retry)
+        .raises(Kitchen::Transport::TransportFailed.new("converge boom"))
+      connection.stubs(:download)
+        .raises(Kitchen::Transport::TransportFailed.new("download boom"))
+
+      err = _ { cmd }.must_raise Kitchen::ActionFailed
+      _(err.message).must_match(/converge boom/)
+      _(logged_output.string).must_match(/WARN -- : Failed to download files/)
+    end
+
+    it "warns but does not fail when only the download fails" do
+      connection.stubs(:download)
+        .raises(Kitchen::Transport::TransportFailed.new("download boom"))
+
+      cmd
+
+      _(logged_output.string).must_match(/WARN -- : Failed to download files/)
+      _(logged_output.string).must_match(/download boom/)
+    end
+
+    it "raises when the transport cannot download at all" do
+      connection.stubs(:download)
+        .raises(Kitchen::ClientError.new("#download must be implemented"))
+
+      err = _ { cmd }.must_raise Kitchen::ClientError
+      _(err.message).must_match(/must be implemented/)
     end
 
     it "raises an ActionFailed on transfer when TransportFailed is raised" do

--- a/spec/kitchen/verifier/base_spec.rb
+++ b/spec/kitchen/verifier/base_spec.rb
@@ -257,12 +257,40 @@ describe Kitchen::Verifier::Base do
 
       connection.expects(:download).with("/remote", "/local")
 
-      connection.expects(:execute).with("run").raises
+      connection.expects(:execute).with("run")
+        .raises(Kitchen::Transport::TransportFailed.new("verify boom"))
 
-      begin
-        cmd
-      rescue
-      end
+      err = _ { cmd }.must_raise Kitchen::ActionFailed
+      _(err.message).must_match(/verify boom/)
+    end
+
+    it "reports the run failure when downloading also fails" do
+      connection.stubs(:execute).with("run")
+        .raises(Kitchen::Transport::TransportFailed.new("verify boom"))
+      connection.stubs(:download)
+        .raises(Kitchen::Transport::TransportFailed.new("download boom"))
+
+      err = _ { cmd }.must_raise Kitchen::ActionFailed
+      _(err.message).must_match(/verify boom/)
+      _(logged_output.string).must_match(/WARN -- : Failed to download files/)
+    end
+
+    it "warns but does not fail when only the download fails" do
+      connection.stubs(:download)
+        .raises(Kitchen::Transport::TransportFailed.new("download boom"))
+
+      cmd
+
+      _(logged_output.string).must_match(/WARN -- : Failed to download files/)
+      _(logged_output.string).must_match(/download boom/)
+    end
+
+    it "raises when the transport cannot download at all" do
+      connection.stubs(:download)
+        .raises(Kitchen::ClientError.new("#download must be implemented"))
+
+      err = _ { cmd }.must_raise Kitchen::ClientError
+      _(err.message).must_match(/must be implemented/)
     end
 
     it "raises an ActionFailed on transfer when TransportFailed is raised" do


### PR DESCRIPTION
## What

Follow-up to #2068. Makes provisioner and verifier `downloads:` best-effort, and stops a failed download from destroying the error that explains a failed run.

## Why

#2068 moved the provisioner's download loop into an `ensure` block so downloads run even when converge fails. That was the right shape, but the `ensure` is unguarded, and Ruby discards the in-flight exception when an `ensure` raises.

Driving the real `Provisioner::Base#call` with converge raising `TransportFailed("CONVERGE FAILED exit 1")` and the download raising `TransportFailed("SCP download failed for /var/log/app.log")`, the error that reaches the user is:

```
SCP download failed for /var/log/app.log
```

The converge error is gone. `Exception#cause` points at the download error too, so it isn't recoverable through the exception chain either.

This bites hardest on exactly the path the feature exists to serve. A converge that dies early often dies **before creating the log file you configured for download** — so the download fails precisely when you most need the converge error. Adding `downloads:` to debug a failing converge made the diagnostics worse.

The "the verifier already does this" precedent doesn't transfer: the verifier only runs *after* a successful converge, so its download targets almost always exist. The provisioner runs where failure is the expected state.

Second problem, independent of masking: a failed download on its own failed an otherwise successful run. The same missing file had opposite consequences depending on an unrelated converge outcome.

## Change

Capture the in-flight error via `$!` before downloading:

```ruby
rescue => ex
  raise unless run_error || ex.is_a?(Kitchen::Transport::TransportFailed)
  warn("Failed to download files from #{instance.to_str}: #{ex.message}")
end
```

- A download `TransportFailed` is always best-effort → warn.
- Any other error is suppressed only when a run error is already propagating, because protecting the run error outranks it.
- `Kitchen::ClientError` **is** a `StandardError`, so a blanket always-warn would silently swallow `Transport::Exec::Connection#download must be implemented` — a broken plugin, not a missing file. That still raises.

Applied to `Verifier::Base` too, which grew the same unguarded `ensure` in #1916 and has the same defect. Fixing both keeps the plugins symmetrical.

### Behavior verified

| Scenario | Before | After |
|---|---|---|
| converge fails + download fails | `SCP download failed` | `CONVERGE FAILED exit 1` |
| converge fails + download OK | `CONVERGE FAILED exit 1` | unchanged |
| Ctrl-C + download fails | `ActionFailed: SCP download failed` | `Interrupt` |
| converge OK + download fails | `ActionFailed` | no raise, warn logged |
| converge OK + transport lacks `#download` | `ClientError` | unchanged (still raises) |

The Ctrl-C case is a consequence of the same bug: `Interrupt` isn't a `StandardError`, but an `ensure` that raises replaces *any* in-flight exception, so a failed download converted a user's Ctrl-C into a spurious converge failure.

## Testing

The existing `"downloads files when run fails"` specs (both plugins) raised a bare `RuntimeError` and swallowed the result with `begin/rescue`, asserting only that `download` was called. They could not distinguish "error propagated" from "error silently swallowed".

Demonstrated by mutation — adding an error-swallowing `rescue StandardError` to the implementation:

```
61 runs, 100 assertions, 0 failures   # mutant passes the old suite
```

That mutant means `kitchen converge` exits 0 on a failed converge, and nothing caught it. With the strengthened specs the same mutant produces 2 failures.

Specs now assert *which* error propagates, and cover download-also-fails, download-fails-alone, and transport-cannot-download.

Full suite: **1722 runs, 2697 assertions, 0 failures**. `rake style`: 79 files, no offenses.

## Docs

Both contract references now document the failure and best-effort semantics. Note that the **provisioner** contract never recorded the ensure-block behavior added in #2068 — the verifier contract did — so the docs described an asymmetry the code no longer had. That's fixed here.

The `downloads:` comment in `provisioners/_index.md` was also a 145-char line inside a fenced `ruby` block (no soft wrap, 56 chars longer than anything else in the block); it now uses the continuation-comment style the neighbouring lines already used. `MD013` is disabled, so lint never flagged it.

## Reviewer notes

- **Behavior change:** a failed download no longer fails an otherwise successful converge or verify. No existing spec asserted the old behavior — it fell out of the method-level `rescue TransportFailed` incidentally rather than by design. Flagging it explicitly since a CI user relying on "converge goes red if artifacts can't be fetched" would now get a green run and a warning.
- **Not addressed here:** `info("Downloading files from ...")` and `debug("Download complete")` still log on every failed converge even when `downloads` is empty (the default), which is noise for users who never configured downloads. Happy to fix separately.
- The accepted ADRs (`docs/adr/0005`, `0006`) are deliberately untouched — 0005 names the reference doc as the user-facing home, so the reference doc is the living record and the ADR is the historical decision.
