### PR TITLE
fix: require time so Time#iso8601 is available for structured logs

### DIFF
--- a/lib/kitchen/driver/base.rb
+++ b/lib/kitchen/driver/base.rb
@@ -16,7 +16,7 @@ require_relative "../lazy_hash"
 require_relative "../logging"
 require_relative "../plugin_base"
 require_relative "../shell_out"
-require "time" unless defined?(Time)
+require "time"
 
 module Kitchen
   module Driver

--- a/lib/kitchen/driver/base.rb
+++ b/lib/kitchen/driver/base.rb
@@ -16,7 +16,7 @@ require_relative "../lazy_hash"
 require_relative "../logging"
 require_relative "../plugin_base"
 require_relative "../shell_out"
-require "time"
+require "time" unless defined?(Time.zone_offset)
 
 module Kitchen
   module Driver

--- a/lib/kitchen/driver/dummy.rb
+++ b/lib/kitchen/driver/dummy.rb
@@ -11,7 +11,7 @@
 # limitations under the License.
 
 require_relative "../../kitchen"
-require "time" unless defined?(Time)
+require "time"
 
 module Kitchen
   module Driver

--- a/lib/kitchen/driver/dummy.rb
+++ b/lib/kitchen/driver/dummy.rb
@@ -11,7 +11,7 @@
 # limitations under the License.
 
 require_relative "../../kitchen"
-require "time"
+require "time" unless defined?(Time.zone_offset)
 
 module Kitchen
   module Driver

--- a/lib/kitchen/instance.rb
+++ b/lib/kitchen/instance.rb
@@ -18,7 +18,7 @@
 require "benchmark" unless defined?(Benchmark)
 require "fileutils" unless defined?(FileUtils)
 require "securerandom" unless defined?(SecureRandom)
-require "time" unless defined?(Time)
+require "time"
 
 module Kitchen
   # An instance of a suite running on a platform. A created instance may be a

--- a/lib/kitchen/instance.rb
+++ b/lib/kitchen/instance.rb
@@ -18,7 +18,7 @@
 require "benchmark" unless defined?(Benchmark)
 require "fileutils" unless defined?(FileUtils)
 require "securerandom" unless defined?(SecureRandom)
-require "time"
+require "time" unless defined?(Time.zone_offset)
 
 module Kitchen
   # An instance of a suite running on a platform. A created instance may be a

--- a/lib/kitchen/logger.rb
+++ b/lib/kitchen/logger.rb
@@ -18,7 +18,7 @@
 require "fileutils" unless defined?(FileUtils)
 require "json" unless defined?(JSON)
 require "logger" unless defined?(Logger)
-require "time" unless defined?(Time)
+require "time"
 
 module Kitchen
   # Logging implementation for Kitchen. By default the console/stdout output

--- a/lib/kitchen/logger.rb
+++ b/lib/kitchen/logger.rb
@@ -18,7 +18,7 @@
 require "fileutils" unless defined?(FileUtils)
 require "json" unless defined?(JSON)
 require "logger" unless defined?(Logger)
-require "time"
+require "time" unless defined?(Time.zone_offset)
 
 module Kitchen
   # Logging implementation for Kitchen. By default the console/stdout output

--- a/spec/kitchen/driver/base_spec.rb
+++ b/spec/kitchen/driver/base_spec.rb
@@ -95,6 +95,7 @@ describe Kitchen::Driver::Base do
     _(status[:source]).must_equal "driver"
     _(status[:message]).must_match(/does not support status/)
     _(status[:checked_at]).wont_be_nil
+    _(Time.iso8601(status[:checked_at])).must_be_kind_of Time
   end
 
   describe ".pre_create_command" do

--- a/spec/kitchen/logger_spec.rb
+++ b/spec/kitchen/logger_spec.rb
@@ -426,6 +426,7 @@ describe Kitchen::Logger do
       _(event["instance"]).must_equal "default-ubuntu-2404"
       _(event["sequence"]).must_equal 1
       _(event["timestamp"]).wont_be_nil
+      _(Time.iso8601(event["timestamp"])).must_be_kind_of Time
     end
 
     it "writes banner events without relying on text log prefixes" do

--- a/spec/kitchen/logger_spec.rb
+++ b/spec/kitchen/logger_spec.rb
@@ -470,6 +470,26 @@ describe Kitchen::Logger do
     end
   end
 
+  describe "the time stdlib" do
+    # Timestamp formatting relies on Time#iso8601, which the "time" stdlib adds
+    # to core Time. On Ruby 3.4+ the instance method is part of core, and other
+    # specs in this suite load "time" transitively, so a missing require is only
+    # visible in a clean process on the oldest supported Ruby. See #2082.
+    it "is required by every file that formats a timestamp" do
+      script = <<-RUBY
+        require "kitchen"
+        require "kitchen/driver/dummy"
+        Time.now.utc.iso8601(6)
+        Time.iso8601("2026-01-01T00:00:00Z")
+      RUBY
+      lib = File.expand_path("../../lib", __dir__)
+      output = IO.popen([Gem.ruby, "-I#{lib}", "-e", script], err: %i{child out}, &:read)
+
+      _($?.success?).must_equal true,
+        "requiring kitchen in a clean Ruby process failed:\n#{output}"
+    end
+  end
+
   describe "combined stdout and logdev logger" do
     let(:stdout) { StringIO.new }
     let(:logdev) { StringIO.new }


### PR DESCRIPTION
Fixes #2082. `Time.now.utc.iso8601` blows up with `undefined method 'iso8601' for ...:Time (NoMethodError)` on a fresh Ruby because `iso8601` lives in the `time` stdlib, not core Time.

The require was guarded with `require "time" unless defined?(Time)`, but `Time` is a core constant that is always defined, so the guard skips the require and the stdlib extension never loads. Dropping the guard (the require is idempotent) restores `iso8601` in the four files that call it: the structured logger, `Instance`, and the base/dummy drivers.

Also tightened the structured-log spec to assert the emitted `timestamp` parses back with `Time.iso8601`, which fails without the require.