### PR TITLE
fix: correct typos in user-facing messages

### DIFF
--- a/lib/kitchen/cli.rb
+++ b/lib/kitchen/cli.rb
@@ -302,7 +302,7 @@ module Kitchen
     end
 
     desc "exec INSTANCE|REGEXP -c REMOTE_COMMAND",
-      "Execute command on one or more instance"
+      "Execute command on one or more instances"
     method_option :command,
       aliases: "-c",
       desc: "execute via ssh"

--- a/lib/kitchen/provisioner/base.rb
+++ b/lib/kitchen/provisioner/base.rb
@@ -215,7 +215,7 @@ module Kitchen
       #   by calling `#create_sandbox`
       def sandbox_path
         @sandbox_path ||= raise ClientError, "Sandbox directory has not yet " \
-          "been created. Please run #{self.class}#create_sandox before " \
+          "been created. Please run #{self.class}#create_sandbox before " \
           "trying to access the path."
       end
 

--- a/lib/kitchen/transport/ssh.rb
+++ b/lib/kitchen/transport/ssh.rb
@@ -106,7 +106,7 @@ module Kitchen
       # (see Base#cleanup!)
       def cleanup!
         if @connection
-          string_to_mask = "[SSH] shutting previous connection #{@connection}"
+          string_to_mask = "[SSH] shutting down previous connection #{@connection}"
           masked_string = Util.mask_values(string_to_mask, %w{password ssh_http_proxy_password})
           logger.debug(masked_string)
           @connection.close

--- a/lib/kitchen/transport/winrm.rb
+++ b/lib/kitchen/transport/winrm.rb
@@ -502,7 +502,7 @@ module Kitchen
       # @api private
       def create_new_connection(options, &block)
         if @connection
-          string_to_mask = "[WinRM] shutting previous connection #{@connection}"
+          string_to_mask = "[WinRM] shutting down previous connection #{@connection}"
           masked_string = Util.mask_values(string_to_mask, %w{password ssh_http_proxy_password})
           logger.debug(masked_string)
           @connection.close

--- a/lib/kitchen/verifier/base.rb
+++ b/lib/kitchen/verifier/base.rb
@@ -184,7 +184,7 @@ module Kitchen
       #   by calling `#create_sandbox`
       def sandbox_path
         @sandbox_path ||= raise ClientError, "Sandbox directory has not yet " \
-           "been created. Please run #{self.class}#create_sandox before " \
+           "been created. Please run #{self.class}#create_sandbox before " \
            "trying to access the path."
       end
 

--- a/spec/kitchen/transport/ssh_spec.rb
+++ b/spec/kitchen/transport/ssh_spec.rb
@@ -664,7 +664,7 @@ describe Kitchen::Transport::Ssh do
         make_connection(state.merge(port: 9000))
 
         _(logged_output.string.lines.count do |l|
-          l =~ debug_line_with("[SSH] shutting previous connection ")
+          l =~ debug_line_with("[SSH] shutting down previous connection ")
         end).must_equal 1
       end
     end

--- a/spec/kitchen/transport/winrm_spec.rb
+++ b/spec/kitchen/transport/winrm_spec.rb
@@ -443,7 +443,7 @@ describe Kitchen::Transport::Winrm do
         make_connection(state.merge(port: 9000))
 
         _(logged_output.string.lines.count do |l|
-          l =~ debug_line_with("[WinRM] shutting previous connection ")
+          l =~ debug_line_with("[WinRM] shutting down previous connection ")
         end).must_equal 1
       end
     end

--- a/test-kitchen.gemspec
+++ b/test-kitchen.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "ostruct",            "~> 0.6"
   gem.add_dependency "syslog",             "~> 0.3"
   gem.add_dependency "thor",               ">= 0.19", "< 2.0"
-  # Chef Forked versions with additional fixes since no one is maintining them upstream
+  # Chef Forked versions with additional fixes since no one is maintaining them upstream
   gem.add_dependency "chef-winrm",         ">= 2.5.0", "< 3.0"
   gem.add_dependency "chef-winrm-elevated", ">= 1.0", "< 2.0"
   gem.add_dependency "chef-winrm-fs",      ">= 1.0", "< 2.0"


### PR DESCRIPTION
Tier 1 of a typo audit across the project. This PR covers only strings that reach users at runtime; the remaining tiers (YARD tags, doc comments, docs site, tests) follow in separate PRs so they can be reviewed independently.

## Changes

| File | Fix |
|---|---|
| `lib/kitchen/provisioner/base.rb`, `lib/kitchen/verifier/base.rb` | `#create_sandox` → `#create_sandbox` in the sandbox error message |
| `lib/kitchen/cli.rb` | exec description: "one or more instance" → "instances" |
| `lib/kitchen/transport/{ssh,winrm}.rb` | "shutting previous connection" → "shutting down previous connection" |
| `test-kitchen.gemspec` | "maintining" → "maintaining" |

## Why the sandbox one matters

`sandbox_path` raises with:

> Sandbox directory has not yet been created. Please run `Kitchen::Provisioner::Foo#create_sandox` before trying to access the path.

There is no `create_sandox` method — it is `create_sandbox`, which the `@raise` doc line two lines above already spells correctly. A plugin author hitting this error and following its instruction gets a `NoMethodError`.

## Tests

`spec/kitchen/transport/ssh_spec.rb` and `winrm_spec.rb` assert on the "shutting previous connection" debug line; both are updated in step.

```
1723 runs, 2700 assertions, 0 failures, 0 errors, 0 skips
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)