### PR TITLE
docs: fix malformed YARD tags

### DIFF
--- a/lib/kitchen.rb
+++ b/lib/kitchen.rb
@@ -85,7 +85,7 @@ module Kitchen
     # log file.
     #
     # @param [Symbol] level logging level
-    # @param [Boolean] log_overwrite logging level
+    # @param [Boolean] log_overwrite whether to overwrite the log file
     # @return [Logger] a logger
     def default_file_logger(level = nil, log_overwrite = nil)
       level ||= env_log

--- a/lib/kitchen/config.rb
+++ b/lib/kitchen/config.rb
@@ -136,7 +136,7 @@ module Kitchen
 
     # Builds the filtered list of Instance objects.
     #
-    # @return [Array<Instance] an array of Instances
+    # @return [Array<Instance>] an array of Instances
     # @api private
     def build_instances
       filter_instances.map.with_index do |(suite, platform), index|

--- a/lib/kitchen/driver/base.rb
+++ b/lib/kitchen/driver/base.rb
@@ -59,7 +59,7 @@ module Kitchen
       # Check system and configuration for common errors.
       #
       # @param state [Hash] mutable instance and driver state
-      # @returns [Boolean] Return true if a problem is found.
+      # @return [Boolean] Return true if a problem is found.
       def doctor(state)
         false
       end

--- a/lib/kitchen/errors.rb
+++ b/lib/kitchen/errors.rb
@@ -100,7 +100,7 @@ module Kitchen
     # output when parsing the output from the commands like
     # kitchen diagnose.
     #
-    # @params lines [Array<String>] Array of lines that needs to be printed
+    # @param lines [Array<String>] Array of lines that needs to be printed
     def self.warn_on_stderr(lines)
       Array(lines).each do |line|
         line = Color.colorize(line, :blue) if Kitchen.tty?

--- a/lib/kitchen/instance.rb
+++ b/lib/kitchen/instance.rb
@@ -346,7 +346,7 @@ module Kitchen
     # Validate the initial internal state of this object and raising an
     # exception if any preconditions are not met.
     #
-    # @param options[Hash] options hash passed into the constructor
+    # @param options [Hash] options hash passed into the constructor
     # @raise [ClientError] if any validations fail
     # @api private
     def validate_options(options)
@@ -779,7 +779,7 @@ module Kitchen
       # Determines the index of a state in the state lifecycle vector. Woah.
       #
       # @param transition [Symbol,#to_sym] a state
-      # @param [Integer] the index position
+      # @return [Integer] the index position
       # @api private
       def self.index(transition)
         if transition.nil?

--- a/lib/kitchen/logger.rb
+++ b/lib/kitchen/logger.rb
@@ -53,7 +53,7 @@ module Kitchen
     #   messages
     # @option options [Integer] :level the logging severity threshold
     #   (default: `Kitchen::DEFAULT_LOG_LEVEL`)
-    # @option options [Boolean] whether to overwrite the log
+    # @option options [Boolean] :log_overwrite whether to overwrite the log
     #   when Test Kitchen runs. Only applies if the :logdev is a String.
     #   (default: `Kitchen::DEFAULT_LOG_OVERWRITE`)
     # @option options [String,IO] :logdev filepath String or IO object to be

--- a/lib/kitchen/provisioner/base.rb
+++ b/lib/kitchen/provisioner/base.rb
@@ -142,7 +142,7 @@ module Kitchen
       # Check system and configuration for common errors.
       #
       # @param state [Hash] mutable instance state
-      # @returns [Boolean] Return true if a problem is found.
+      # @return [Boolean] Return true if a problem is found.
       def doctor(state)
         false
       end

--- a/lib/kitchen/transport/base.rb
+++ b/lib/kitchen/transport/base.rb
@@ -69,7 +69,7 @@ module Kitchen
       # Check system and configuration for common errors.
       #
       # @param state [Hash] mutable instance state
-      # @returns [Boolean] Return true if a problem is found.
+      # @return [Boolean] Return true if a problem is found.
       def doctor(state)
         false
       end

--- a/lib/kitchen/util.rb
+++ b/lib/kitchen/util.rb
@@ -91,7 +91,7 @@ module Kitchen
     # Returns a string with masked values for specified parameters.
     #
     # @param string_to_mask [String] the object whose string representation is parsed
-    # @param [Array] the list of keys whose values should be masked
+    # @param keys [Array] the list of keys whose values should be masked
     # @return [String] the string representation of passed object with masked values
     def self.mask_values(string_to_mask, keys)
       masked_string = string_to_mask

--- a/lib/kitchen/verifier/base.rb
+++ b/lib/kitchen/verifier/base.rb
@@ -106,7 +106,7 @@ module Kitchen
       # Check system and configuration for common errors.
       #
       # @param state [Hash] mutable instance state
-      # @returns [Boolean] Return true if a problem is found.
+      # @return [Boolean] Return true if a problem is found.
       def doctor(state)
         false
       end


### PR DESCRIPTION
Tier 2 of a typo audit across the project. This PR covers only YARD tags that are malformed badly enough that YARD drops or misrenders them. Comments only — no behavior change.

## Changes

| File | Fix |
|---|---|
| `driver/base.rb`, `transport/base.rb`, `provisioner/base.rb`, `verifier/base.rb` | `@returns` → `@return` on `doctor` (×4) |
| `errors.rb` | `@params` → `@param` |
| `instance.rb` | `@param options[Hash]` → `@param options [Hash]` |
| `instance.rb` | `FSM.index` return value documented with `@param` → `@return` |
| `config.rb` | `[Array<Instance]` → `[Array<Instance>]` |
| `logger.rb` | `@option` missing its name → `:log_overwrite` |
| `util.rb` | `@param` missing its name → `keys` |
| `kitchen.rb` | `log_overwrite` described as "logging level" |

## Notes on the two that needed a name filled in

- `Logger#initialize` — the constructor reads `options[:log_overwrite]`, so that is the option being documented.
- `Util.mask_values(string_to_mask, keys)` — the undocumented second parameter is `keys`.

`Kitchen.default_file_logger` had its `log_overwrite` description copy-pasted from the `level` tag directly above it; replaced with what the parameter actually controls.

## Tests

```
1723 runs, 2700 assertions, 0 failures, 0 errors, 0 skips
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)