### PR TITLE
docs: correct copy-pasted class and method descriptions

### DIFF
--- a/lib/kitchen/command/action.rb
+++ b/lib/kitchen/command/action.rb
@@ -21,7 +21,7 @@ require "benchmark" unless defined?(Benchmark)
 
 module Kitchen
   module Command
-    # Command to run a single action one or more instances.
+    # Command to run a single action on one or more instances.
     #
     # @author Fletcher Nichol <fnichol@nichol.ca>
     class Action < Kitchen::Command::Base

--- a/lib/kitchen/command/diagnose.rb
+++ b/lib/kitchen/command/diagnose.rb
@@ -22,7 +22,7 @@ autoload :YAML, "yaml"
 
 module Kitchen
   module Command
-    # Command to log into to instance.
+    # Command to show the computed diagnostic configuration.
     #
     # @author Fletcher Nichol <fnichol@nichol.ca>
     class Diagnose < Kitchen::Command::Base

--- a/lib/kitchen/command/login.rb
+++ b/lib/kitchen/command/login.rb
@@ -19,7 +19,7 @@ require_relative "../command"
 
 module Kitchen
   module Command
-    # Command to log into to instance.
+    # Command to log into an instance.
     #
     # @author Fletcher Nichol <fnichol@nichol.ca>
     class Login < Kitchen::Command::Base

--- a/lib/kitchen/command/package.rb
+++ b/lib/kitchen/command/package.rb
@@ -16,7 +16,7 @@ require_relative "../command"
 
 module Kitchen
   module Command
-    # Execute command on remote instance.
+    # Command to package one or more instances.
     #
     class Package < Kitchen::Command::Base
       # Invoke the command.

--- a/lib/kitchen/instance.rb
+++ b/lib/kitchen/instance.rb
@@ -60,7 +60,7 @@ module Kitchen
     # @return [LifecycleHooks] lifecycle hooks manager object
     attr_accessor :lifecycle_hooks
 
-    # @return [Provisioner::Base] provisioner object which will the setup
+    # @return [Provisioner::Base] provisioner object which will provide the setup
     #   and invocation instructions for configuration management and other
     #   automation tools
     attr_accessor :provisioner
@@ -83,9 +83,10 @@ module Kitchen
     # @option options [Platform] :platform the platform (**Required**)
     # @option options [Driver::Base] :driver the driver (**Required**)
     # @option options [Provisioner::Base] :provisioner the provisioner
+    #   (**Required**)
     # @option options [Transport::Base] :transport the transport
     #   (**Required**)
-    # @option options [Verifier] :verifier the verifier logger (**Required**)
+    # @option options [Verifier] :verifier the verifier (**Required**)
     # @option options [Logger] :logger the instance logger
     #   (default: Kitchen.logger)
     # @option options [StateFile] :state_file the state file object to use

--- a/lib/kitchen/provisioner/dummy.rb
+++ b/lib/kitchen/provisioner/dummy.rb
@@ -19,7 +19,7 @@ require_relative "../../kitchen"
 
 module Kitchen
   module Provisioner
-    # Dummy provisioner for Kitchen. This driver does nothing but report what
+    # Dummy provisioner for Kitchen. This provisioner does nothing but report what
     # would happen if this provisioner did anything of consequence. As a result
     # it may be a useful provisioner to use when debugging or developing new
     # features or plugins.

--- a/lib/kitchen/transport/winrm.rb
+++ b/lib/kitchen/transport/winrm.rb
@@ -498,7 +498,7 @@ module Kitchen
       # future reuse.
       #
       # @param options [Hash] connection options
-      # @return [Ssh::Connection] a WinRM Connection instance
+      # @return [Winrm::Connection] a WinRM Connection instance
       # @api private
       def create_new_connection(options, &block)
         if @connection


### PR DESCRIPTION
Tier 3 of a typo audit across the project. This PR covers doc comments that describe a *different* class than the one they are attached to — copied from a sibling file and never updated. Comments only, no behavior change.

## Changes

| File | Was | Now |
|---|---|---|
| `command/diagnose.rb` | "Command to log into to instance." | "Command to show the computed diagnostic configuration." |
| `command/package.rb` | "Execute command on remote instance." | "Command to package one or more instances." |
| `command/login.rb` | "Command to log into to instance." | "Command to log into an instance." |
| `command/action.rb` | "a single action one or more instances" | "a single action **on** one or more instances" |
| `provisioner/dummy.rb` | "Dummy provisioner… This **driver** does nothing" | "This **provisioner** does nothing" |
| `transport/winrm.rb` | `@return [Ssh::Connection]` | `@return [Winrm::Connection]` |
| `instance.rb` | "provisioner object which will the setup" | "which will **provide** the setup" |
| `instance.rb` | `:verifier the verifier logger` | `:verifier the verifier` |

The replacements are derived from what the code does rather than guessed: `Package#call` invokes `instance.package_action`, `Diagnose#call` assembles and prints diagnostic config, and `Winrm#create_new_connection` returns `Kitchen::Transport::Winrm::Connection.new`.

## One addition outside the typo sweep

`Instance#initialize` did not mark `:provisioner` as `(**Required**)`, although `validate_options` enforces it alongside the six options that *are* marked. Corrected here since it sits in the same option list, but calling it out separately as it is an accuracy fix rather than a typo — happy to split it out if preferred.

## Tests

```
1723 runs, 2700 assertions, 0 failures, 0 errors, 0 skips
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)