### PR TITLE
docs: fix spelling and grammar in source comments

### DIFF
--- a/lib/kitchen.rb
+++ b/lib/kitchen.rb
@@ -162,7 +162,7 @@ end
 # Initialize the base logger
 Kitchen.logger = Kitchen.default_logger
 
-# Setup a collection of instance crash exceptions for error reporting
+# Set up a collection of instance crash exceptions for error reporting
 Kitchen.mutex = Mutex.new
 
 # Initialize the mutex for Dir.chdir coordination

--- a/lib/kitchen/cli.rb
+++ b/lib/kitchen/cli.rb
@@ -32,7 +32,7 @@ module Kitchen
       #
       # @param task [String] action to take, usually corresponding to the
       #   subcommand name
-      # @param command [String] command class to create and invoke]
+      # @param command [String] command class to create and invoke
       # @param args [Array] remainder arguments from processed ARGV
       #   (default: `nil`)
       # @param additional_options [Hash] additional configuration needed to
@@ -341,7 +341,7 @@ module Kitchen
     class << self
       private
 
-      # Ensure the any failing commands exit non-zero.
+      # Ensure that any failing commands exit non-zero.
       #
       # @return [true] you die always on failure
       # @api private
@@ -374,7 +374,7 @@ module Kitchen
 
       @config.debug = options[:debug]
 
-      # Now that we have required configs, lets create our file logger
+      # Now that we have required configs, let's create our file logger
       Kitchen.logger = Kitchen.default_file_logger(
         log_level,
         log_overwrite
@@ -401,7 +401,7 @@ module Kitchen
       @log_level = level
     end
 
-    # Check to whether a provided log level is valid
+    # Check whether a provided log level is valid
     #
     # @api private
     def valid_log_level?(level)

--- a/lib/kitchen/command.rb
+++ b/lib/kitchen/command.rb
@@ -100,7 +100,7 @@ module Kitchen
         end
       end
 
-      # Return an array on instances whose name matches the regular expression.
+      # Return an array of instances whose name matches the regular expression.
       #
       # @param regexp [Regexp] a regular expression matching on instance names
       # @return [Array<Instance>] an array of instances
@@ -131,7 +131,7 @@ module Kitchen
         Kitchen.logger
       end
 
-      # Return an array on instances whose name matches the regular expression,
+      # Return an array of instances whose name matches the regular expression,
       # the full instance name, or  the `"all"` literal.
       #
       # @param arg [String] an instance name, a regular expression, the literal

--- a/lib/kitchen/config.rb
+++ b/lib/kitchen/config.rb
@@ -163,7 +163,7 @@ module Kitchen
     end
 
     # Determines the default absolute path to the testing files directory,
-    # based on the the value of `#kitchen_root`.
+    # based on the value of `#kitchen_root`.
     #
     # @return [String] an absolute path to the testing files directory
     # @api private
@@ -289,12 +289,12 @@ module Kitchen
       )
     end
 
-    # Builds a newly configured LifecycleHooks object, for a given a Suite and
+    # Builds a newly configured LifecycleHooks object, for a given Suite and
     # Platform.
     #
     # @param suite [Suite,#name] a Suite
     # @param platform [Platform,#name] a Platform
-    # @param state_file [Kitchen::StateFile] a SateFile
+    # @param state_file [Kitchen::StateFile] a StateFile
     # @return [LifecycleHooks] a new LifecycleHooks object
     # @api private
     def new_lifecycle_hooks(suite, platform, state_file)
@@ -337,7 +337,7 @@ module Kitchen
       Transport.for_plugin(tdata[:name], tdata)
     end
 
-    # Builds a newly configured Verifier object, for a given a Suite and
+    # Builds a newly configured Verifier object, for a given Suite and
     # Platform.
     #
     # @param suite [Suite,#name] a Suite

--- a/lib/kitchen/configurable.rb
+++ b/lib/kitchen/configurable.rb
@@ -35,7 +35,7 @@ module Kitchen
 
     # A lifecycle method that should be invoked when the object is about ready
     # to be used. A reference to an Instance is required as configuration
-    # dependant data may be access through an Instance. This also acts as a
+    # dependent data may be accessed through an Instance. This also acts as a
     # hook point where the object may wish to perform other last minute
     # checks, validations, or configuration expansions.
     #
@@ -73,7 +73,7 @@ module Kitchen
     # fallback rules or returns nil if path cannot be determined.
     #
     # Given an instance with suite named `"server"`, a `test_base_path` of
-    # `"/a/b"`, and a path segment of `"roles"` then following will be tried
+    # `"/a/b"`, and a path segment of `"roles"` then the following will be tried
     # in order (first match that exists wins):
     #
     # 1. /a/b/server/roles
@@ -207,7 +207,7 @@ module Kitchen
     end
 
     # Expands file paths for certain configuration values. A configuration
-    # value is marked for file expansion with a expand_path_for declaration
+    # value is marked for file expansion with an expand_path_for declaration
     # in the included class.
     #
     # @api private

--- a/lib/kitchen/instance.rb
+++ b/lib/kitchen/instance.rb
@@ -343,7 +343,7 @@ module Kitchen
     # @api private
     attr_reader :state_file
 
-    # Validate the initial internal state of this object and raising an
+    # Validate the initial internal state of this object, raising an
     # exception if any preconditions are not met.
     #
     # @param options[Hash] options hash passed into the constructor
@@ -375,7 +375,7 @@ module Kitchen
     end
 
     # Perform any final configuration or preparation needed for the driver
-    # object carry out its duties.
+    # object to carry out its duties.
     #
     # @api private
     def setup_driver
@@ -384,7 +384,7 @@ module Kitchen
     end
 
     # Perform any final configuration or preparation needed for the lifecycle hooks
-    # object carry out its duties.
+    # object to carry out its duties.
     #
     # @api private
     def setup_lifecycle_hooks
@@ -392,7 +392,7 @@ module Kitchen
     end
 
     # Perform any final configuration or preparation needed for the provisioner
-    # object carry out its duties.
+    # object to carry out its duties.
     #
     # @api private
     def setup_provisioner
@@ -401,7 +401,7 @@ module Kitchen
     end
 
     # Perform any final configuration or preparation needed for the transport
-    # object carry out its duties.
+    # object to carry out its duties.
     #
     # @api private
     def setup_transport
@@ -410,7 +410,7 @@ module Kitchen
     end
 
     # Perform any final configuration or preparation needed for the verifier
-    # object carry out its duties.
+    # object to carry out its duties.
     #
     # @api private
     def setup_verifier
@@ -776,7 +776,7 @@ module Kitchen
 
       TRANSITIONS = %i{destroy create converge setup verify}.freeze
 
-      # Determines the index of a state in the state lifecycle vector. Woah.
+      # Determines the index of a state in the state lifecycle vector. Whoa.
       #
       # @param transition [Symbol,#to_sym] a state
       # @param [Integer] the index position

--- a/lib/kitchen/lazy_hash.rb
+++ b/lib/kitchen/lazy_hash.rb
@@ -77,7 +77,7 @@ module Kitchen
 
     # Returns a rendered value from the hash for the given key. If the key
     # can't be found, there are several options: With no other arguments, it
-    # will raise an KeyError exception; if default is given, then that will be
+    # will raise a KeyError exception; if default is given, then that will be
     # returned; if the optional code block is specified, then that will be run
     # and its result returned.
     #

--- a/lib/kitchen/lifecycle_hook/base.rb
+++ b/lib/kitchen/lifecycle_hook/base.rb
@@ -37,7 +37,7 @@ module Kitchen
         end
       end
 
-      # @return [Logger] the lifecycle hooks's logger
+      # @return [Logger] the lifecycle hook's logger
       #   otherwise
       # @api private
       def logger

--- a/lib/kitchen/loader/yaml.rb
+++ b/lib/kitchen/loader/yaml.rb
@@ -57,7 +57,7 @@ module Kitchen
       end
 
       # Reads, parses, and merges YAML configuration files and returns a Hash
-      # of tne merged data.
+      # of the merged data.
       #
       # @return [Hash] merged configuration data
       def read
@@ -99,7 +99,7 @@ module Kitchen
       # @api private
       attr_reader :global_config_file
 
-      # Performed a prioritized recursive merge of several source Hashes and
+      # Performs a prioritized recursive merge of several source Hashes and
       # returns a new merged Hash. There are 3 sources of configuration data:
       #
       # 1. local config
@@ -178,7 +178,7 @@ module Kitchen
       # Reads a file and returns its contents as a string.
       #
       # @param file [String] a path to a file
-      # @return [String] the files contents, or an empty string if the file
+      # @return [String] the file's contents, or an empty string if the file
       #   does not exist
       # @api private
       def read_file(file)
@@ -208,7 +208,7 @@ module Kitchen
         File.join(Dir.pwd, "kitchen.yml")
       end
 
-      # The absolute path to an hidden Kitchen config YAML file.
+      # The absolute path to a hidden Kitchen config YAML file.
       def dot_kitchen_yml
         File.join(Dir.pwd, ".kitchen.yml")
       end

--- a/lib/kitchen/logger.rb
+++ b/lib/kitchen/logger.rb
@@ -22,7 +22,7 @@ require "time" unless defined?(Time.zone_offset)
 
 module Kitchen
   # Logging implementation for Kitchen. By default the console/stdout output
-  # will be displayed differently than the file log output. Therefor, this
+  # will be displayed differently than the file log output. Therefore, this
   # class wraps multiple loggers that conform to the stdlib `Logger` class
   # behavior.
   #
@@ -49,7 +49,7 @@ module Kitchen
     # Constructs a new logger.
     #
     # @param options [Hash] configuration for a new logger
-    # @option options [Symbol] :color color to use when when outputting
+    # @option options [Symbol] :color color to use when outputting
     #   messages
     # @option options [Integer] :level the logging severity threshold
     #   (default: `Kitchen::DEFAULT_LOG_LEVEL`)

--- a/lib/kitchen/metadata_chopper.rb
+++ b/lib/kitchen/metadata_chopper.rb
@@ -33,7 +33,7 @@ module Kitchen
       [mc[:name], mc[:version]]
     end
 
-    # Creates a new instances and loads in the contents of the metadata.rb
+    # Creates a new instance and loads in the contents of the metadata.rb
     # file. If you value your life, you may want to avoid reading the
     # implementation.
     #

--- a/lib/kitchen/platform_filter.rb
+++ b/lib/kitchen/platform_filter.rb
@@ -18,8 +18,8 @@
 module Kitchen
   # A wrapper on Regexp and strings to mix them in platform filters.
   #
-  # This should handle backward compatibility in most cases were
-  # platform are matched against a filters array using Array.include?
+  # This should handle backward compatibility in most cases where
+  # platforms are matched against a filter array using Array.include?
   #
   # This wrapper does not work if filters arrays are converted to Set.
   #
@@ -29,7 +29,7 @@ module Kitchen
     REGEXP_LIKE_PATTERN = %r{^/(?<pattern>.*)/(?<options>[ix]*)$}
 
     # Converts platform filters into an array of PlatformFilter handling both strings and Regexp.
-    # A string "looks-like" a regexp if it starts by / and end by / + Regexp options i or x
+    # A string "looks-like" a regexp if it starts with / and ends with / + Regexp options i or x
     #
     # @return [Array] filters with regexp-like string converted to PlatformRegexpFilter
     def self.convert(filters)
@@ -57,7 +57,7 @@ module Kitchen
       @value = value
     end
 
-    # Override of the equality operator to check whether the wrapped Regexp match the given object.
+    # Override of the equality operator to check whether the wrapped Regexp matches the given object.
     #
     # @param [Object] other object to compare to
     # @return [Boolean] whether the objects are equal or the wrapped Regexp matches the given string or symbol

--- a/lib/kitchen/provisioner.rb
+++ b/lib/kitchen/provisioner.rb
@@ -20,7 +20,7 @@ require_relative "plugin"
 
 module Kitchen
   # A provisioner is responsible for generating the commands necessary to
-  # install set up and use a configuration management tool such as Chef and
+  # install, set up, and use a configuration management tool such as Chef and
   # Puppet.
   #
   # @author Fletcher Nichol <fnichol@nichol.ca>

--- a/lib/kitchen/provisioner/base.rb
+++ b/lib/kitchen/provisioner/base.rb
@@ -211,7 +211,7 @@ module Kitchen
       # exception if `#create_sandbox` has not yet been called.
       #
       # @return [String] the absolute path to the sandbox directory
-      # @raise [ClientError] if the sandbox directory has no yet been created
+      # @raise [ClientError] if the sandbox directory has not yet been created
       #   by calling `#create_sandbox`
       def sandbox_path
         @sandbox_path ||= raise ClientError, "Sandbox directory has not yet " \

--- a/lib/kitchen/state_file.rb
+++ b/lib/kitchen/state_file.rb
@@ -26,7 +26,7 @@ module Kitchen
   #
   # @author Fletcher Nichol <fnichol@nichol.ca>
   class StateFile
-    # Constructs an new instance taking the kitchen root and instance name.
+    # Constructs a new instance taking the kitchen root and instance name.
     #
     # @param kitchen_root [String] path to the Kitchen project's root directory
     # @param name [String] name of the instance representing this state

--- a/lib/kitchen/suite.rb
+++ b/lib/kitchen/suite.rb
@@ -35,7 +35,7 @@ module Kitchen
     # Constructs a new suite.
     #
     # @param [Hash] options configuration for a new suite
-    # @option options [String] :name logical name of this suit (**Required**)
+    # @option options [String] :name logical name of this suite (**Required**)
     # @option options [String] :excludes Array of names of excluded platforms
     # @option options [String] :includes Array of names of only included
     #   platforms

--- a/lib/kitchen/transport/ssh.rb
+++ b/lib/kitchen/transport/ssh.rb
@@ -299,17 +299,17 @@ module Kitchen
         # @api private
         attr_reader :ssh_http_proxy
 
-        # @return [Integer] The port to use when using an kitchen ssh proxy
+        # @return [Integer] The port to use when using a kitchen ssh proxy
         #   remote SSH host via http proxy
         # @api private
         attr_reader :ssh_http_proxy_port
 
-        # @return [String] The username to use when using an kitchen ssh proxy
+        # @return [String] The username to use when using a kitchen ssh proxy
         #   remote SSH host via http proxy
         # @api private
         attr_reader :ssh_http_proxy_user
 
-        # @return [String] The password to use when using an kitchen ssh proxy
+        # @return [String] The password to use when using a kitchen ssh proxy
         #   remote SSH host via http proxy
         # @api private
         attr_reader :ssh_http_proxy_password
@@ -570,7 +570,7 @@ module Kitchen
         current_net_ssh >= new_option_version ? :never : false
       end
 
-      # Creates a new SSH Connection instance and save it for potential future
+      # Creates a new SSH Connection instance and saves it for potential future
       # reuse.
       #
       # @param options [Hash] connection options

--- a/lib/kitchen/transport/winrm.rb
+++ b/lib/kitchen/transport/winrm.rb
@@ -225,7 +225,7 @@ module Kitchen
         # @api private
         attr_reader :max_wait_until_ready
 
-        # @return [Integer] the TCP port number to use when connection to the
+        # @return [Integer] the TCP port number to use when connecting to the
         #   remote WinRM host
         # @api private
         attr_reader :rdp_port
@@ -494,7 +494,7 @@ module Kitchen
         end
       end
 
-      # Creates a new WinRM Connection instance and save it for potential
+      # Creates a new WinRM Connection instance and saves it for potential
       # future reuse.
       #
       # @param options [Hash] connection options

--- a/lib/kitchen/util.rb
+++ b/lib/kitchen/util.rb
@@ -37,7 +37,7 @@ module Kitchen
       Logger.const_get(symbol.to_s.upcase)
     end
 
-    # Returns the symbol representation of a logging levels for a given
+    # Returns the symbol representation of a logging level for a given
     # standard library Logger::Severity constant.
     #
     # @param const [Integer] Logger::Severity constant value for a logging
@@ -166,7 +166,7 @@ module Kitchen
     # @return A listing of the specified path
     #
     # @note You should prefer this method to using Dir.glob directly. The reason is
-    # because Dir.glob behaves strangely on Windows. It wont accept '\'
+    # because Dir.glob behaves strangely on Windows. It won't accept '\'
     # and doesn't like fake directories (C:\Documents and Settings)
     # It also does not do any sort of error checking, so things one would
     # expect to fail just return an empty list

--- a/lib/kitchen/verifier/base.rb
+++ b/lib/kitchen/verifier/base.rb
@@ -180,7 +180,7 @@ module Kitchen
       # exception if `#create_sandbox` has not yet been called.
       #
       # @return [String] the absolute path to the sandbox directory
-      # @raise [ClientError] if the sandbox directory has no yet been created
+      # @raise [ClientError] if the sandbox directory has not yet been created
       #   by calling `#create_sandbox`
       def sandbox_path
         @sandbox_path ||= raise ClientError, "Sandbox directory has not yet " \

--- a/lib/kitchen/verifier/busser.rb
+++ b/lib/kitchen/verifier/busser.rb
@@ -23,7 +23,7 @@ require_relative "base"
 module Kitchen
   module Verifier
     # Command string generator to interface with Busser. The commands that are
-    # generated are safe to pass to an SSH command or as an unix command
+    # generated are safe to pass to an SSH command or as a Unix command
     # argument (escaped in single quotes).
     #
     # @author Fletcher Nichol <fnichol@nichol.ca>

--- a/lib/kitchen/verifier/shell.rb
+++ b/lib/kitchen/verifier/shell.rb
@@ -19,7 +19,7 @@ require_relative "base"
 
 module Kitchen
   module Verifier
-    # Shell verifier for Kitchen. This verifier just execute shell command from local.
+    # Shell verifier for Kitchen. This verifier just executes a shell command locally.
     #
     # @author SAWANOBORI Yukihiko (<sawanoboriyu@higanworks.com>)
     class Shell < Kitchen::Verifier::Base


### PR DESCRIPTION
Tier 4 of a typo audit across the project — the bulk of it. Comment-only changes across 22 files in `lib/`; no code, no strings, no behavior change.

## Categories

**Misspellings** — `Therefor`→`Therefore`, `this suit`→`this suite`, `tne`→`the`, `SateFile`→`StateFile`, `wont`→`won't`, `Woah`→`Whoa`

**Duplicated words** — `the the value`, `when when outputting`, `for a given a Suite` (×2)

**Article agreement** — `an KeyError`, `an hidden`, `an new instance`, `an kitchen ssh proxy` (×3), `a expand_path_for`, `an unix command`

**Verb agreement / missing words** — `may be access through`→`accessed`, `array on instances`→`of instances` (×2), `object carry out its duties`→`object **to** carry out` (×5), `Performed a … merge`→`Performs`, `and save it`→`and saves it`, `when connection to`→`when connecting to`, `Regexp match`→`matches`, `a new instances`→`a new instance`, `has no yet been created`→`has **not** yet` (×2)

**Other** — stray `]` in a `@param`, `hooks's`→`hook's`, `Setup a collection`→`Set up`, `install set up and use`→`install, set up, and use`

## Two comments that were hard to parse before

`platform_filter.rb` class comment:

> This should handle backward compatibility in most cases **were platform are** matched against a **filters array**

→ `where platforms are` … `a filter array`. Also `starts by / and end by /` → `starts with / and ends with /`.

`verifier/shell.rb`:

> This verifier just **execute shell command from local**.

→ `just executes a shell command locally`.

## Verification

`typos` now reports clean across `lib/` (excluding the vendored `lib/vendor/`).

```
1723 runs, 2700 assertions, 0 failures, 0 errors, 0 skips
```

## Not included

`lib/vendor/hash_recursive_merge.rb` has a real typo (`abd` → `and`) but is vendored third-party code, so I left it alone rather than diverge from upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)