### PR TITLE
docs: fix typos and grammar across the documentation site

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@
 |             |                                                                                 |
 | ----------- | --------------------------------------------------------------------------------|
 | Website     | [https://kitchen.ci/][website]                                                  |
-| Source Code | [https://kitchen.ci/docs/getting-started/introduction/][guide]                  |
+| Source Code | [https://github.com/test-kitchen/test-kitchen][repo]                            |
 | Slack       | [#test-kitchen][slack] channel on Chef Community Slack                          |
 
 **Test Kitchen is an integration tool for developing and testing infrastructure code and software on isolated target platforms.**
 
 ## Getting Started Guide
 
-To learn how to install and setup Test Kitchen for developing infrastructure
+To learn how to install and set up Test Kitchen for developing infrastructure
 code, check out the [Getting Started Guide][guide].
 
 If you want to get going super fast, then try the Quick Start next...

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@ Run `mise install` from the repository root to install the pinned Hugo version.
 
 Run `mise run docs:serve` from the repository root and browse the URL presented.
 
-If you are not using mise, install Hugo 0.163.2 directly and run `hugo server` from this directory.
+If you are not using mise, install Hugo 0.165.0 directly and run `hugo server` from this directory.
 
 ## Style Guide
 

--- a/docs/content/docs/drivers/aws.md
+++ b/docs/content/docs/drivers/aws.md
@@ -10,7 +10,7 @@ kitchen-ec2 is a Test Kitchen *driver* for EC2 in Amazon AWS.
 
 ### Setting Driver Configuration
 
-The Amazon AWS driver for Test Kitchen includes many configuration options that can be set globally in the driver section of your kitchen.yml config file or within each platform configuration. Global settings apply to all platforms in the `kitchen.yml`, while platform level driver configuration is applied to only those platforms and override globally set configuration options. Even if you use platform level configuration options, it's a good idea to specify the driver you use to use globally.
+The Amazon AWS driver for Test Kitchen includes many configuration options that can be set globally in the driver section of your kitchen.yml config file or within each platform configuration. Global settings apply to all platforms in the `kitchen.yml`, while platform level driver configuration is applied to only those platforms and override globally set configuration options. Even if you use platform level configuration options, it's a good idea to specify the driver you want to use globally.
 
 #### Example Global Driver Option
 
@@ -40,9 +40,9 @@ platforms:
 
 In order to connect to AWS, you must specify AWS credentials. We rely on the SDK to find credentials in the standard way, documented here: <https://github.com/aws/aws-sdk-ruby/#configuration>
 
-The SDK Chain will search environment variables, then config files, then IAM role data from the instance profile, in that order. In the case config files being present, the 'default' profile will be used unless `shared_credentials_profile` is defined to point to another profile.
+The SDK Chain will search environment variables, then config files, then IAM role data from the instance profile, in that order. In the case of config files being present, the 'default' profile will be used unless `shared_credentials_profile` is defined to point to another profile.
 
-Because the Test Kitchen test should be checked into source control and ran through CI we no longer support storing the AWS credentials in the `.kitchen.yml` file.
+Because the Test Kitchen test should be checked into source control and run through CI we no longer support storing the AWS credentials in the `.kitchen.yml` file.
 
 ### Instance Login Configuration
 
@@ -276,7 +276,7 @@ subnet_filter:
 
 #### tags
 
-The Hash of EC tag name/value pairs which will be applied to the instance.
+The Hash of EC2 tag name/value pairs which will be applied to the instance.
 
 The default is `{ "created-by" => "test-kitchen" }`.
 
@@ -357,7 +357,7 @@ Specify a proxy to send AWS requests through.  Should be of the format `http://<
 
 The default is `ENV["HTTPS_PROXY"] || ENV["HTTP_PROXY"]`.  If you have these environment variables set and do not want to use a proxy when contacting aws set `http_proxy: nil`.
 
-**Note** - The AWS command line utility allow you to specify [two proxies](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-proxy.html), one for HTTP and one for HTTPS.  The AWS Ruby SDK only allows you to specify 1 proxy and because all requests are `https://` this proxy needs to support HTTPS.
+**Note** - The AWS command line utility allows you to specify [two proxies](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-proxy.html), one for HTTP and one for HTTPS.  The AWS Ruby SDK only allows you to specify 1 proxy and because all requests are `https://` this proxy needs to support HTTPS.
 
 #### ssl_verify_peer
 
@@ -452,7 +452,7 @@ If you don't set this it will default to whatever DHCP address EC2 hands out.
 
 #### interface
 
-The place from which to derive the hostname for communicating with the instance. May be `dns`, `public`, `private`, `private_dns` or `id`.  If this is unset, the driver will derive the hostname by failing back in the following order:
+The place from which to derive the hostname for communicating with the instance. May be `dns`, `public`, `private`, `private_dns` or `id`.  If this is unset, the driver will derive the hostname by falling back in the following order:
 
 1. DNS Name
 2. Public IP Address
@@ -481,7 +481,7 @@ If you want to run your instances on hardware that is not shared with other cust
 
 The most specific run type is a dedicated `host`. In this mode your instance will not run on a random host dedicated to your account, but you can reserve a specific host instead. This approach offers options like selecting AZ-level separation or savings plans. It is used mainly for licensing or security considerations; for example, it is needed to work with `mac` instance types.
 
-The default is `default'.
+The default is `default`.
 
 #### allocate_dedicated_host
 

--- a/docs/content/docs/drivers/azurerm.md
+++ b/docs/content/docs/drivers/azurerm.md
@@ -10,7 +10,7 @@ kitchen-azurerm is a Test Kitchen *driver* for Microsoft Azure.
 
 ### Setting Driver Configuration
 
-The Microsoft Azure driver for Test Kitchen includes many configuration options that can be set globally in the driver section of your kitchen.yml config file or within each platform configuration. Global settings apply to all platforms in the `kitchen.yml`, while platform level driver configuration is applied to only those platforms and override globally set configuration options. Even if you use platform level configuration options, it's a good idea to specify the driver you use to use globally.
+The Microsoft Azure driver for Test Kitchen includes many configuration options that can be set globally in the driver section of your kitchen.yml config file or within each platform configuration. Global settings apply to all platforms in the `kitchen.yml`, while platform level driver configuration is applied to only those platforms and override globally set configuration options. Even if you use platform level configuration options, it's a good idea to specify the driver you want to use globally.
 
 #### Example Global Driver Option
 

--- a/docs/content/docs/drivers/digitalocean.md
+++ b/docs/content/docs/drivers/digitalocean.md
@@ -10,7 +10,7 @@ kitchen-digitalocean is a Test Kitchen *driver* for DigitalOcean that runs again
 
 ### Setting Driver Configuration
 
-The DigitalOcean driver for Test Kitchen includes many configuration options that can be set globally in the driver section of your kitchen.yml config file or within each platform configuration. Global settings apply to all platforms in the `kitchen.yml`, while platform level driver configuration is applied to only those platforms and override globally set configuration options. Even if you use platform level configuration options, it's a good idea to specify the driver you use to use globally.
+The DigitalOcean driver for Test Kitchen includes many configuration options that can be set globally in the driver section of your kitchen.yml config file or within each platform configuration. Global settings apply to all platforms in the `kitchen.yml`, while platform level driver configuration is applied to only those platforms and override globally set configuration options. Even if you use platform level configuration options, it's a good idea to specify the driver you want to use globally.
 
 #### Example Global Driver Option
 

--- a/docs/content/docs/drivers/dokken.md
+++ b/docs/content/docs/drivers/dokken.md
@@ -40,7 +40,7 @@ driver:
 
 #### binds
 
-The `binds` configuration option allows you bind mount a local path into your Test Kitchen containers.
+The `binds` configuration option allows you to bind mount a local path into your Test Kitchen containers.
 
 ```yaml
 driver:
@@ -73,7 +73,7 @@ driver:
 
 #### chef_image
 
-The `chef_image` configuration option allows you to specify Docker image other than the official Chef Infra Client image. This can be used to specify the Cinc Docker image or internal customer builds of Chef Infra Client.
+The `chef_image` configuration option allows you to specify a Docker image other than the official Chef Infra Client image. This can be used to specify the Cinc Docker image or internal customer builds of Chef Infra Client.
 
 ```yaml
 driver:
@@ -101,7 +101,7 @@ Reference: [4.3.0 Release notes](https://docs.docker.com/desktop/release-notes/#
 
 #### chef_version
 
-The `chef_version` configuration option allows you to specify which Docker image tag of the Chef Infra Client image to use. By default `latest` is used, which is equivalent to the latest version the Chef's `stable` channel. For a complete list of available tags see [chef/chef tags](https://hub.docker.com/r/chef/chef/tags) on Docker Hub.
+The `chef_version` configuration option allows you to specify which Docker image tag of the Chef Infra Client image to use. By default `latest` is used, which is equivalent to the latest version in Chef's `stable` channel. For a complete list of available tags see [chef/chef tags](https://hub.docker.com/r/chef/chef/tags) on Docker Hub.
 
 ```yaml
 driver:
@@ -269,7 +269,7 @@ driver:
 
 #### intermediate_instructions
 
-The `intermediate_instructions` configuration option allows you to define steps to run on the Test Kitchen container before you converge Chef Infra Client. This is very useful for updating package caches on operation systems like Debian/Ubuntu or other preparation tasks that you might need to run.
+The `intermediate_instructions` configuration option allows you to define steps to run on the Test Kitchen container before you converge Chef Infra Client. This is very useful for updating package caches on operating systems like Debian/Ubuntu or other preparation tasks that you might need to run.
 
 ```yaml
 platforms:
@@ -284,7 +284,7 @@ platforms:
 
 #### ipv6
 
-The `ipv6` configuration options enables IPv6 in the Docker daemon. This configuration option should be considered a global setting for all containers since dokken does not update the dokken network once it's been created. It is not recommend to use this configuration option within suites.
+The `ipv6` configuration options enables IPv6 in the Docker daemon. This configuration option should be considered a global setting for all containers since dokken does not update the dokken network once it's been created. It is not recommended to use this configuration option within suites.
 
 ```yaml
 driver:

--- a/docs/content/docs/drivers/openstack.md
+++ b/docs/content/docs/drivers/openstack.md
@@ -123,10 +123,10 @@ Expose read/write timeout parameters passed down to HTTP connection created via 
 
 ### server_wait
 
-`server_wait` is a workaround to deal with how some VMs with `cloud-init`.
-Some clouds need this some, most OpenStack instances don't. This is a stop gap
-wait makes sure that the machine is in a good state to work with. Ideally the
-transport layer in Test-Kitchen will have a more intelligent way to deal with this.
+`server_wait` is a workaround to deal with how some VMs behave with `cloud-init`.
+Some clouds need this, most OpenStack instances don't. This is a stop-gap
+wait that makes sure the machine is in a good state to work with. Ideally the
+transport layer in Test Kitchen will have a more intelligent way to deal with this.
 There will be a dot that appears every 10 seconds as the timer counts down.
 You may want to add this for **WinRM** instances due to the multiple restarts that
 happen on creation and boot. A good default is `300` seconds to make sure it's
@@ -273,7 +273,7 @@ Timeout to wait for volume to become available.  If a large volume is provisione
 
 #### attach_timeout
 
-If using a customized version of Openstack such a VMWare Integrated OPenstack (VIO), it may mark a volume active even though it is still performing some actions which may cause test kitchen to attach the volume to early which results in errors. Specify in seconds the amount of time to delay attaching the volume after its been marked active. Default timeout is 0.
+If using a customized version of OpenStack such as VMware Integrated OpenStack (VIO), it may mark a volume active even though it is still performing some actions which may cause test kitchen to attach the volume too early which results in errors. Specify in seconds the amount of time to delay attaching the volume after it's been marked active. Default timeout is 0.
 
 #### Example
 

--- a/docs/content/docs/drivers/vagrant.md
+++ b/docs/content/docs/drivers/vagrant.md
@@ -6,7 +6,7 @@ menu:
     weight: 15
 ---
 
-Kitchen-vagrant is a Test Kitchen *driver* for HashiCorp Vagrant 1.6 and later. The Vagrant driver is the preferred driver for local cookbooks testing due to the extensive platform and hypervisor support in Vagrant before running Test Kitchen.
+Kitchen-vagrant is a Test Kitchen *driver* for HashiCorp Vagrant 1.6 and later. The Vagrant driver is the preferred driver for local cookbooks testing due to the extensive platform and hypervisor support in Vagrant.
 
 ## Supported Virtualization Hypervisors
 
@@ -52,7 +52,7 @@ To learn more about the installation, upgrade, and usage of these plugins see [V
 
 ### Setting up Hyper-V
 
-Microsoft Hyper-V is an exclusive hypervisor, meaning it cannot be used when another hypervisor is active on a system. Due to this restriction it is recommended that you either set the provider to `hyperv` in your `kitchen.yml` config or set the environment variable `VAGRANT_DEFAULT_PROVIDER` to `hyperv`. The `VAGRANT_DEFAULT_PROVIDER` environment variable allows controlling the default provider when one is not defined in the `kitchen.yml`. This environment variable is particularly useful is you are using Hyper-V in a project where other users rely on VirtualBox.
+Microsoft Hyper-V is an exclusive hypervisor, meaning it cannot be used when another hypervisor is active on a system. Due to this restriction it is recommended that you either set the provider to `hyperv` in your `kitchen.yml` config or set the environment variable `VAGRANT_DEFAULT_PROVIDER` to `hyperv`. The `VAGRANT_DEFAULT_PROVIDER` environment variable allows controlling the default provider when one is not defined in the `kitchen.yml`. This environment variable is particularly useful if you are using Hyper-V in a project where other users rely on VirtualBox.
 
 It is also important to consider how network switches are defined and selected when using Hyper-V. Kitchen-vagrant will select the switch to use with new VMs in the following order:
 
@@ -72,7 +72,7 @@ driver:
 
 ## Default Boxes
 
-Kitchen-vagrant defaults to using Vagrant boxes published under the [Bento organization][bento_org] on [Vagrant Cloud][vagrant_cloud]. These systems are purpose-built for use with Test Kitchen are can be configured in the `kitchen.yml` config without specifying the full path to a Vagrant box.
+Kitchen-vagrant defaults to using Vagrant boxes published under the [Bento organization][bento_org] on [Vagrant Cloud][vagrant_cloud]. These systems are purpose-built for use with Test Kitchen and can be configured in the `kitchen.yml` config without specifying the full path to a Vagrant box.
 
 Example configuration using Bento images:
 
@@ -136,7 +136,7 @@ platforms:
       box: my_vagrant_account/redhat-10
 ```
 
-Vagrant boxes can also be fetched from non-Vagrant Cloud location by specifying the `box_url`:
+Vagrant boxes can also be fetched from a non-Vagrant Cloud location by specifying the `box_url`:
 
 ```yaml
 platforms:
@@ -264,7 +264,7 @@ The default is `nil` assuming ssh will be used.
 ### customize
 
 A **Hash** of customizations to a Vagrant virtual machine. Each key/value
-pair will be passed to your providers customization block. For example, with
+pair will be passed to your provider's customization block. For example, with
 the default `virtualbox` provider:
 
 ```yaml
@@ -502,7 +502,7 @@ is `virtualbox` unless set by `VAGRANT_DEFAULT_PROVIDER` environment variable.
 ### provision
 
 Set to true if you want to do the provision of vagrant in create.
-Useful in case of you want to customize the OS in provision phase of vagrant
+Useful in case you want to customize the OS in provision phase of vagrant
 
 ### ssh_key
 
@@ -641,7 +641,7 @@ To prevent this value from being rendered in the default Vagrantfile, you can
 set this value to `false`.
 
 The default will be computed from the name of the instance. For example, the
-instance was called "default-fuzz-9" will produce a default `vm_hostname` value
+instance called "default-fuzz-9" will produce a default `vm_hostname` value
 of `"default-fuzz-9"`. For Windows-based platforms, a default of `nil` is used
 to save on boot time and potential rebooting.
 

--- a/docs/content/docs/drivers/vcenter.md
+++ b/docs/content/docs/drivers/vcenter.md
@@ -50,9 +50,9 @@ The following optional parameters should be used in the `driver` for the platfor
 - `poweron` - Power on the new virtual machine. Default: true
 - `vm_name` - Specify name of virtual machine in vSphere. Default: `<suite>-<platform>-<random-hexid>`
 - `clone_type` - Type of clone, use "full" to create complete copies of template. Values: "full", "linked", "instant". Default: "full"
-- `networks` - A list of networks to either reconfigure or attached to the newly created vm, needs a VM Network name. Default: do not change
+- `networks` - A list of networks to either reconfigure or attach to the newly created vm, needs a VM Network name. Default: do not change
 - `tags` - Array of pre-defined vCenter tag names to assign (VMware tags are not key/value pairs). Default: none
-- `vm_customization` - Dictionary customizations like annotation, memoryMB or numCPUs (see below for details). Default: none
+- `vm_customization` - Dictionary of customizations like annotation, memoryMB or numCPUs (see below for details). Default: none
 - `interface`- VM Network name to use for kitchen connections. Default: not set = first interface with usable IP
 
  The following optional parameters are relevant for active IP discovery.
@@ -231,7 +231,7 @@ Required privileges in addition to "Clone mode: full":
 
 ## Active Discovery Mode
 
-This mode is used to speed up provisioning of kitchen machines as much as possible. One of the limiting factors despite actual provisioning time
+This mode is used to speed up provisioning of kitchen machines as much as possible. One of the limiting factors besides actual provisioning time
 (which can be improved using the linked/instant clone modes) is waiting for the VM to return its IP address. While VMware tools are usually available and
 responding within 10-20 seconds, sending back IP/OS information to vCenter can take additional 30-40 seconds easily.
 
@@ -271,7 +271,7 @@ The previous configuration for managing the networks was `network_name` which co
 This configuration is now deprecated and the `networks` configuration is introduced to support the multi-network functionality.
 
 The type of operation that needs to be performed on the network device is also configurable.
-By default, the network will be added to the VM. If the user specify the `edit` operation, then the existing network in the template will be replaced by the specified network.
+By default, the network will be added to the VM. If the user specifies the `edit` operation, then the existing network in the template will be replaced by the specified network.
 Currently, only `add` and `edit` operations are implemented.
 
 Example:

--- a/docs/content/docs/drivers/vra.md
+++ b/docs/content/docs/drivers/vra.md
@@ -10,7 +10,7 @@ kitchen-vra is a Test Kitchen driver for vRealize Automation that runs against t
 
 ### Setting Driver Configuration
 
-The VMware vra driver for Test Kitchen includes many configuration options that can be set globally in the driver section of your kitchen.yml config file or within each platform configuration. Global settings apply to all platforms in the `kitchen.yml`, while platform level driver configuration is applied to only those platforms and override globally set configuration options. Even if you use platform level configuration options, it's a good idea to specify the driver you use to use globally.
+The VMware vra driver for Test Kitchen includes many configuration options that can be set globally in the driver section of your kitchen.yml config file or within each platform configuration. Global settings apply to all platforms in the `kitchen.yml`, while platform level driver configuration is applied to only those platforms and override globally set configuration options. Even if you use platform level configuration options, it's a good idea to specify the driver you want to use globally.
 
 #### Example Global Driver Option
 
@@ -52,7 +52,7 @@ driver:
   verify_ssl: true
 ```
 
-If you want username and password to be prompted, remove usename and password in your .kitchen.yml as shown below:
+If you want username and password to be prompted, remove username and password in your .kitchen.yml as shown below:
 
 ```yaml
 driver:
@@ -130,7 +130,7 @@ Defaults to `nil`.  Set to your domain suffix, for example 'mydomain.com'.  This
 
 #### extra_parameters
 
-a hash of other data to set on a catalog request, most notably custom properties. Allows updates to existing properties on the blueprint as well as the addition of new properties. Each key in the hash is the property name, and the value is a another hash containing the value data type and the value itself. It is possible to use a `~` to add nested parameters.
+a hash of other data to set on a catalog request, most notably custom properties. Allows updates to existing properties on the blueprint as well as the addition of new properties. Each key in the hash is the property name, and the value is another hash containing the value data type and the value itself. It is possible to use a `~` to add nested parameters.
 
 
 Example **kitchen.yml**:

--- a/docs/content/docs/getting-started/11-running-test.md
+++ b/docs/content/docs/getting-started/11-running-test.md
@@ -7,7 +7,7 @@ menu:
     weight: 110
 ---
 
-Now it's time to introduce to the **test** meta-action which helps you automate all the previous actions so far into one command. Checking `kitchen list`, the "Last Action" of our instance should be "Verified". With this in mind, let's run `kitchen test`:
+Now it's time to introduce the **test** meta-action which helps you automate all the previous actions so far into one command. Checking `kitchen list`, the "Last Action" of our instance should be "Verified". With this in mind, let's run `kitchen test`:
 
 ```ruby
 $ kitchen test

--- a/docs/content/docs/getting-started/14-adding-suite.md
+++ b/docs/content/docs/getting-started/14-adding-suite.md
@@ -47,7 +47,7 @@ server-ubuntu-2404   Vagrant  ChefInfra     Inspec    Ssh        <Not Created>  
 server-almalinux-10  Vagrant  ChefInfra     Inspec    Ssh        <Not Created>  <None>
 ```
 
-Woah, we've doubled our number of instances! Yes, that is going to happen. This explosion of test cases is just one reason why testing is hard.
+Whoa, we've doubled our number of instances! Yes, that is going to happen. This explosion of test cases is just one reason why testing is hard.
 
 <div class="sidebar--footer">
 <a class="button primary-cta" href="/docs/getting-started/adding-test">Next - Adding a Test</a>

--- a/docs/content/docs/getting-started/17-excluding-platforms.md
+++ b/docs/content/docs/getting-started/17-excluding-platforms.md
@@ -54,7 +54,7 @@ suites:
       - almalinux-10
 ```
 
-**Note:** in above example the `almalinux-10` platform is explicitly excluded. You could have use a regexp syntax `/<pattern>/` to exclude any platform matching the given pattern.
+**Note:** in the above example the `almalinux-10` platform is explicitly excluded. You could have used a regexp syntax `/<pattern>/` to exclude any platform matching the given pattern.
 
 Now let's run `kitchen list` to ensure the instance is gone:
 

--- a/docs/content/docs/reference/configuration.md
+++ b/docs/content/docs/reference/configuration.md
@@ -43,7 +43,7 @@ driver:
 Keep in mind this assumes you have an OpenStack deployment setup and ready to use. This is only an example so to illustrate using environment variables via ERB snippets in the configuration file.
 
 Another handy use of the ERB fragments is to dynamically override the log_level of
-the provisioner. Since Test Kitchen 1.7.0 the log level for the provisioner is now independent of the Test Kitchen log level. Using the following snippet, allows the environment to override the provisioner log level without modifying the config file.:
+the provisioner. Since Test Kitchen 1.7.0 the log level for the provisioner is now independent of the Test Kitchen log level. Using the following snippet allows the environment to override the provisioner log level without modifying the config file:
 
 ```yaml
 ---

--- a/docs/content/docs/reference/glossary.md
+++ b/docs/content/docs/reference/glossary.md
@@ -16,7 +16,7 @@ hypervisor
 : a piece of software that allows one to create and run virtual machines
 
 regular expression
-: a "a sequence of characters that define a search pattern", in the context of Test Kitchen we allow a user to specify instances with regular expressions like `^default-ubuntu`
+: a "sequence of characters that define a search pattern", in the context of Test Kitchen we allow a user to specify instances with regular expressions like `^default-ubuntu`
 
 Vagrant
 : a piece of software that abstracts away hypervisor details to provide a consistent experience and interface to virtual machines

--- a/docs/content/docs/transports/winrm.md
+++ b/docs/content/docs/transports/winrm.md
@@ -14,7 +14,7 @@ menu:
 
 #### port
 
-The port used to connect to the test instance. This defaults `5985` when using `http` or `5986` when using `https`.
+The port used to connect to the test instance. This defaults to `5985` when using `http` or `5986` when using `https`.
 
 #### username
 
@@ -46,11 +46,11 @@ The identity that the task runs under. This may also be set to service accounts 
 
 #### rdp_port
 
-Port used making rdp connections for kitchen login commands. This defaults to `3389`.
+Port used for making rdp connections for kitchen login commands. This defaults to `3389`.
 
 #### winrm_transport
 
-The transport type used by winrm as [explained here](https://learn.microsoft.com/en-us/windows/win32/winrm/authentication-for-remote-connections). This defaults to `negotiate`. `ssl,` and `plaintext` are also acceptable values.
+The transport type used by winrm as [explained here](https://learn.microsoft.com/en-us/windows/win32/winrm/authentication-for-remote-connections). This defaults to `negotiate`. `ssl` and `plaintext` are also acceptable values.
 
 ### Retry Settings
 

--- a/docs/content/docs/verifiers/inspec.md
+++ b/docs/content/docs/verifiers/inspec.md
@@ -7,7 +7,7 @@ menu:
     weight: 5
 ---
 
-[InSpec](https://community.chef.io/tools/chef-inspec) framework for testing and auditing your applications and infrastructure. It can be utilized for validating Test Kitchen instances via the [kitchen-inspec plugin](https://github.com/inspec/kitchen-inspec).
+[InSpec](https://community.chef.io/tools/chef-inspec) is a framework for testing and auditing your applications and infrastructure. It can be utilized for validating Test Kitchen instances via the [kitchen-inspec plugin](https://github.com/inspec/kitchen-inspec).
 
 To enable kitchen-inspec in your `kitchen.yml`:
 


### PR DESCRIPTION
Tier 5 of a typo audit across the project. Documentation content only — no code. 17 files, 45 lines.

## Shared boilerplate (4 files)

The driver-configuration paragraph is duplicated verbatim across `aws.md`, `azurerm.md`, `digitalocean.md`, and `vra.md`, and all four read:

> it's a good idea to specify the driver **you use to use** globally

## Per-page highlights

**`openstack.md`** had the densest cluster. One sentence contained four errors:

> If using a customized version of **Openstack** such **a VMWare** Integrated **OPenstack** (VIO) … attach the volume **to early** … after **its** been marked active

And the `server_wait` section was missing words in three consecutive sentences:

> `server_wait` is a workaround to deal with how some VMs ~with~ `cloud-init`. Some clouds need this ~some,~ most OpenStack instances don't. This is a stop gap wait ~makes sure~ …

Reworded minimally — `behave with`, drop the stray `some`, `a stop-gap wait **that** makes sure` — to preserve the original meaning rather than rewrite the section.

**`vagrant.md`** — `are can be configured`→`and can`, `useful is you are`→`if you are`, `providers customization block`→`provider's`, `the instance was called`→`the instance called`, `in case of you want to`→`in case you want to`, `from non-Vagrant Cloud location`→`from a`. Also drops a dangling `before running Test Kitchen` from the opening sentence, which had no referent.

**`aws.md`** — `In the case config files being present` (missing "of"), `ran through CI`→`run`, **`The Hash of EC tag`→`EC2`**, `utility allow you`→`allows`, `by failing back`→`falling back`, and a mismatched quote in ``The default is `default'.``

**`dokken.md`** — `operation systems`→`operating`, `not recommend to use`→`recommended`, `allows you bind mount`→`you to bind mount`, `specify Docker image`→`a Docker image`, `the latest version the Chef's stable channel`→`in Chef's`

**`vcenter.md`** — `or attached to`→`or attach to`, `Dictionary customizations`→`Dictionary of`, `If the user specify`→`specifies`, `limiting factors **despite** actual provisioning time`→`besides` (wrong word, inverted the meaning)

**`vra.md`** — `remove usename`→`username`, `a another hash`

**`transports/winrm.md`** — ``This defaults `5985` `` (missing "to"), a comma inside a code span (`` `ssl,` ``), `Port used making rdp connections`→`used for making`

**`verifiers/inspec.md`** — opening sentence was missing `is a`

**Getting Started** — `introduce to the test meta-action`, `You could have use a regexp`, `in above example`, `Woah`→`Whoa`

**Reference** — duplicated article in the glossary regex definition (`: a "a sequence of characters…"`), stray `.:` ending a sentence in `configuration.md`

## Repo docs

- `README.md` — `install and setup`→`set up`; the **Source Code** table row linked to the getting-started guide rather than the repository. Now uses the existing `[repo]` link reference, which was already defined and used further down.
- `docs/README.md` — manual Hugo install said `0.163.2`; `mise.toml` pins `0.165.0`.

## Deliberately not fixed

**`aws.md` — duplicated paragraph.** The `allocate_dedicated_host` section (line 488) repeats the `tenancy` paragraph (line 482) verbatim, so the option is effectively undocumented. Writing a correct description needs someone who knows the intended behavior, so I have left it rather than guess.

**`docs/README.md` style guide** references kramdown docs while the site renders with Hugo/goldmark. The `~~~` fences it documents are valid CommonMark so nothing is broken, but the links point at the wrong renderer's documentation.

## Verification

`markdownlint-cli2` clean on the linted globs; `typos` clean across `docs/` apart from the known `HashiCorp` false positive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
