### PR TITLE
test: fix typos in spec names, feature narratives, and driver template

### DIFF
--- a/features/kitchen_action_commands.feature
+++ b/features/kitchen_action_commands.feature
@@ -1,7 +1,7 @@
 Feature: Running instance actions
   In order to trigger discrete instance lifecycle actions
   As an operator
-  I want to run a action commands
+  I want to run action commands
 
   Background:
     Given a file named ".kitchen.yml" with:

--- a/features/kitchen_command.feature
+++ b/features/kitchen_command.feature
@@ -1,5 +1,5 @@
 Feature: A command line interface for Test Kitchen
-  In order to provide a quick and response development workflow
+  In order to provide a quick and responsive development workflow
   As a Test Kitchen user
   I want a command line interface that has sane defaults and built in help
 

--- a/features/kitchen_help_command.feature
+++ b/features/kitchen_help_command.feature
@@ -1,7 +1,7 @@
 Feature: Using Test Kitchen CLI help
   In order to access the self describing documentation
   As a user of Test Kitchen
-  I want to run a command help help for kitchen commands
+  I want to run a help command for kitchen commands
 
   @spawn
   Scenario: Printing help

--- a/features/kitchen_test_command.feature
+++ b/features/kitchen_test_command.feature
@@ -1,5 +1,5 @@
 Feature: Running a full test instance test
-  In order to "fire-and-forget" or run help setup a CI job
+  In order to "fire-and-forget" or help set up a CI job
   As an operator or CI script
   I want to run a command that will fully test one or more instances
 

--- a/spec/kitchen/provisioner/base_spec.rb
+++ b/spec/kitchen/provisioner/base_spec.rb
@@ -129,7 +129,7 @@ describe Kitchen::Provisioner::Base do
       _(provisioner[:http_proxy]).must_be_nil
     end
 
-    it ":http_proxys defaults to nil" do
+    it ":https_proxy defaults to nil" do
       _(provisioner[:https_proxy]).must_be_nil
     end
 

--- a/templates/driver/README.md.erb
+++ b/templates/driver/README.md.erb
@@ -26,7 +26,7 @@ installed. There are several different behaviors available:
 * `latest` - the latest release will be installed. Subsequent converges
   will always re-install even if chef is present.
 * `<VERSION_STRING>` (ex: `10.24.0`) - the desired version string will
-  be passed the the install.sh script. Subsequent converges will skip if
+  be passed to the install.sh script. Subsequent converges will skip if
   the installed version and the desired version match.
 * `false` or `nil` - no chef is installed.
 


### PR DESCRIPTION
Tier 6 of a typo audit across the project — the last one. Test names, cucumber feature narratives, and the driver scaffold template.

## The one worth a look

`spec/kitchen/provisioner/base_spec.rb`:

```ruby
it ":http_proxys defaults to nil" do
  _(provisioner[:https_proxy]).must_be_nil
end
```

The assertion is correct — it is the name that is wrong. `:http_proxys` is not a config key, and the sibling test directly above it is already named `":http_proxy defaults to nil"`. Anyone scanning test output would conclude `:https_proxy` had no coverage. Renamed to `":https_proxy defaults to nil"`; no assertion change.

## Feature narratives

Four `Feature:` blocks had typos in their "In order to" / "I want to" lines. These are documentation, not steps, so no step definitions are affected:

| File | Was |
|---|---|
| `kitchen_command.feature` | "a quick and **response** development workflow" |
| `kitchen_help_command.feature` | "I want to run a command **help help** for kitchen commands" |
| `kitchen_action_commands.feature` | "I want to run **a** action commands" |
| `kitchen_test_command.feature` | "or **run help setup** a CI job" |

## Driver template

`templates/driver/README.md.erb` — generated driver READMEs told authors a version string would "be passed **the the** install.sh script".

## Verification

```
1723 runs, 2700 assertions, 0 failures, 0 errors, 0 skips
```

`cucumber --dry-run` reports `62 scenarios / 334 steps`, identical to `main` (the single undefined step is pre-existing and unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
