### PR TITLE
chore: ignore .claude/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ _cache
 docs/public
 .idea/
 docs/.hugo_build.lock
+.claude/


### PR DESCRIPTION
Adds `.claude/` to `.gitignore`.

Claude Code writes per-project settings and local state into `.claude/`, which currently shows up as untracked noise in `git status` for anyone using it. It is developer-local tooling config, not project source.

Matches the existing entries for other editor/tool state in this file (`.idea/`, `.rvmrc`, `.rbenv-version`, `.envrc`, `.direnv/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)