### PR TITLE
chore: set TargetRubyVersion to 3.1 to match the gemspec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ require:
   - cookstyle/chefstyle
 
 AllCops:
-  TargetRubyVersion: 3.4
+  TargetRubyVersion: 3.1
   Include:
     - "**/*.rb"
   Exclude:


### PR DESCRIPTION
The gemspec declares:

```ruby
gem.required_ruby_version = ">= 3.1"
```

but `.rubocop.yml` set `TargetRubyVersion: 3.4`.

That mismatch means cookstyle evaluates the codebase against Ruby 3.4 semantics — so it will not flag syntax that is valid on 3.4 but fails on the 3.1 the gem claims to support, and its autocorrections may target 3.4-only forms. Aligning the linter with the declared minimum closes that gap.

## Verification

```
79 files inspected, no offenses detected
```

No new offenses surface at 3.1, so this is a config-only change.

## Related, not changed here

CI only runs Ruby `3.4` (`matrix.ruby: ["3.4"]` in `ci.yml` and `lint.yml`), so the `>= 3.1` floor is not actually exercised by tests. Worth considering adding 3.1 to the matrix, but that is a separate call — happy to open it if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)