### PR TITLE
docs: audit ECOSYSTEM.md and move dormant plugins to Historical

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -22,19 +22,15 @@ Drivers create and manage test instances.
 | Plugin | Target |
 | ------ | ------ |
 | [kitchen-azurerm](https://github.com/test-kitchen/kitchen-azurerm) | Microsoft Azure |
-| [kitchen-cloudstack](https://github.com/test-kitchen/kitchen-cloudstack) | Apache CloudStack |
 | [kitchen-digitalocean](https://github.com/test-kitchen/kitchen-digitalocean) | DigitalOcean |
 | [kitchen-docker](https://github.com/test-kitchen/kitchen-docker) | Docker |
 | [kitchen-dokken](https://github.com/test-kitchen/kitchen-dokken) | Docker or Podman for Chef Infra cookbook testing |
 | [kitchen-ec2](https://github.com/test-kitchen/kitchen-ec2) | Amazon EC2 |
 | [kitchen-google](https://github.com/test-kitchen/kitchen-google) | Google Compute Engine |
-| [kitchen-habitat](https://github.com/test-kitchen/kitchen-habitat) | Chef Habitat |
 | [kitchen-hyperv](https://github.com/test-kitchen/kitchen-hyperv) | Microsoft Hyper-V |
-| [kitchen-opennebula](https://github.com/test-kitchen/kitchen-opennebula) | OpenNebula |
 | [kitchen-openstack](https://github.com/test-kitchen/kitchen-openstack) | OpenStack |
 | [kitchen-rackspace](https://github.com/test-kitchen/kitchen-rackspace) | Rackspace Cloud |
 | [kitchen-vagrant](https://github.com/test-kitchen/kitchen-vagrant) | HashiCorp Vagrant |
-| [kitchen-vcair](https://github.com/test-kitchen/kitchen-vcair) | VMware vCloud Air |
 | [kitchen-vcenter](https://github.com/chef/kitchen-vcenter) | VMware vCenter |
 | [kitchen-vra](https://github.com/test-kitchen/kitchen-vra) | VMware vRealize Automation |
 | [kitchen-vro](https://github.com/test-kitchen/kitchen-vro) | VMware vRealize Orchestrator |
@@ -50,7 +46,7 @@ Provisioners configure an instance after the driver creates it.
 | [kitchen-dsc](https://github.com/test-kitchen/kitchen-dsc) | PowerShell DSC |
 | [kitchen-omnibus-chef](https://github.com/test-kitchen/kitchen-omnibus-chef) | Chef Infra Client |
 | [kitchen-puppet](https://github.com/neillturner/kitchen-puppet) | Puppet |
-| [kitchen-salt](https://github.com/kitchen-salt/kitchen-salt) | Salt |
+| [kitchen-salt](https://github.com/saltstack/kitchen-salt) | Salt |
 
 ## Verifiers
 
@@ -58,26 +54,32 @@ Verifiers test the instance after convergence.
 
 | Plugin | Target |
 | ------ | ------ |
-| [busser-bash](https://github.com/test-kitchen/busser-bash) | Bash tests through the legacy busser verifier |
 | [busser-bats](https://github.com/test-kitchen/busser-bats) | BATS tests through the legacy busser verifier |
-| [busser-cucumber](https://github.com/test-kitchen/busser-cucumber) | Cucumber tests through the legacy busser verifier |
-| [busser-minitest](https://github.com/test-kitchen/busser-minitest) | Minitest tests through the legacy busser verifier |
-| [busser-rspec](https://github.com/test-kitchen/busser-rspec) | RSpec tests through the legacy busser verifier |
 | [busser-serverspec](https://github.com/test-kitchen/busser-serverspec) | ServerSpec tests through the legacy busser verifier |
 | [kitchen-cinc-auditor](https://github.com/test-kitchen/kitchen-cinc-auditor) | Cinc Auditor |
 | [kitchen-inspec](https://github.com/inspec/kitchen-inspec) | Chef InSpec |
 | [kitchen-pester](https://github.com/test-kitchen/kitchen-pester) | Pester |
 
-## Transports and helpers
-
-| Plugin | Purpose |
-| ------ | ------- |
-| [kitchen-sync](https://github.com/test-kitchen/kitchen-sync) | Transport plugin for faster file synchronization |
-| [guard-kitchen](https://github.com/test-kitchen/guard-kitchen) | Guard integration |
-
 ## Historical plugins
 
-Some plugins that existed over Test Kitchen's lifetime may be obsolete,
-archived, or superseded by newer drivers. Prefer the plugin's repository,
-RubyGems page, and your selected Workstation package metadata when deciding
-whether a plugin is still suitable for new work.
+These plugins are still published, but none has had a release in five or more
+years. They may not work with current Test Kitchen, current Ruby, or their
+target platform, and some target services that no longer exist. Check the
+plugin's repository and RubyGems page, along with your selected Workstation
+package metadata, before using one for new work.
+
+| Plugin | Target | Last release |
+| ------ | ------ | ------------ |
+| [busser-bash](https://github.com/test-kitchen/busser-bash) | Bash tests through the legacy busser verifier | 0.1.4 (2014-10-11) |
+| [busser-cucumber](https://github.com/test-kitchen/busser-cucumber) | Cucumber tests through the legacy busser verifier | 0.2.0 (2014-10-08) |
+| [busser-minitest](https://github.com/test-kitchen/busser-minitest) | Minitest tests through the legacy busser verifier | 0.3.0 (2014-10-11) |
+| [busser-rspec](https://github.com/test-kitchen/busser-rspec) | RSpec tests through the legacy busser verifier | 0.7.6 (2015-09-28) |
+| [guard-kitchen](https://github.com/test-kitchen/guard-kitchen) | Guard integration | 0.1.0 (2019-02-25) |
+| [kitchen-cloudstack](https://github.com/test-kitchen/kitchen-cloudstack) | Apache CloudStack | 0.24.0 (2019-06-20) |
+| [kitchen-habitat](https://github.com/test-kitchen/kitchen-habitat) | Chef Habitat | 0.12.1 (2020-07-29) |
+| [kitchen-opennebula](https://github.com/test-kitchen/kitchen-opennebula) | OpenNebula | 0.2.3 (2017-11-23) |
+| [kitchen-sync](https://github.com/test-kitchen/kitchen-sync) | Transport plugin for faster file synchronization | 2.2.1 (2018-02-13) |
+| [kitchen-vcair](https://github.com/test-kitchen/kitchen-vcair) | VMware vCloud Air (service discontinued) | 1.1.0 (2015-12-17) |
+
+Other plugins that existed over Test Kitchen's lifetime are not listed on this
+page at all.


### PR DESCRIPTION
Audit of `ECOSYSTEM.md`, moving dormant plugins into the Historical section.

## Archival status turned out to be the wrong signal

The intent was to move archived repos. I checked all 34 linked repositories via the GitHub API:

**None of them are archived.** Several that look long-dead (`kitchen-vcair`, `kitchen-opennebula`, `kitchen-cloudstack`) report recent `pushed_at` dates from what appear to be org-wide automated commits, so repo activity is not a usable signal either.

Last release on RubyGems is the signal that actually separates live from dormant. This PR uses a **five-year** cutoff.

## Moved to Historical (10)

The Historical section previously contained prose but no entries. It now has a table, with a `Last release` column so the basis for each move is visible and re-checkable later.

| Plugin | Last release | Age |
| --- | --- | --- |
| busser-cucumber | 0.2.0 (2014-10-08) | ~11.9 yrs |
| busser-bash | 0.1.4 (2014-10-11) | ~11.9 yrs |
| busser-minitest | 0.3.0 (2014-10-11) | ~11.9 yrs |
| busser-rspec | 0.7.6 (2015-09-28) | ~10.9 yrs |
| kitchen-vcair | 1.1.0 (2015-12-17) | ~10.7 yrs |
| kitchen-opennebula | 0.2.3 (2017-11-23) | ~8.8 yrs |
| kitchen-sync | 2.2.1 (2018-02-13) | ~8.5 yrs |
| guard-kitchen | 0.1.0 (2019-02-25) | ~7.5 yrs |
| kitchen-cloudstack | 0.24.0 (2019-06-20) | ~7.2 yrs |
| kitchen-habitat | 0.12.1 (2020-07-29) | ~6.1 yrs |

`kitchen-vcair` is additionally annotated as targeting a discontinued service — VMware vCloud Air was sold off and shut down, so that plugin has no working target regardless of its code.

## Nearest entries that stayed

The cutoff lands in a genuine gap, so nothing sits right on the boundary:

| Plugin | Last release | Age |
| --- | --- | --- |
| kitchen-salt | 0.7.2 (2022-01-15) | ~4.6 yrs |
| kitchen-pester | 1.2.0 (2022-05-14) | ~4.3 yrs |
| kitchen-puppet | 3.7.0 (2023-08-09) | ~3.0 yrs |

## Two things worth a maintainer's eye

**"Transports and helpers" section removed.** Both of its entries (`kitchen-sync`, `guard-kitchen`) crossed the cutoff, so the section would have been left with an empty table. I removed the heading rather than leave one. Say the word if you would rather keep it as a placeholder.

**`kitchen-salt` link corrected.** It pointed at `github.com/kitchen-salt/kitchen-salt`, which redirects to `saltstack/kitchen-salt`. The docs site (`docs/content/docs/provisioners/_index.md`) already used the correct org, so this page was the odd one out. This is a plain bug fix, independent of the audit.

## Verification

- All 34 plugins previously listed are still listed — 24 in the main tables, 10 in Historical. Nothing was dropped or duplicated (verified by diffing the extracted plugin sets before and after).
- Every GitHub link resolves with no redirect.
- `ECOSYSTEM.md` is in the `markdownlint-cli2` ignore list, so no lint change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
