### PR TITLE
Let cookstyle decide which files to lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,7 +35,7 @@ jobs:
           bundler-cache: true
       - uses: r7kamura/rubocop-problem-matchers-action@v1
         if: steps.check.outputs.gemfile == 'true'
-      - name: Cook Style
+      - name: Cookstyle
         if: steps.check.outputs.gemfile == 'true'
         run: bundle exec cookstyle --chefstyle
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,8 +4,6 @@ require:
 
 AllCops:
   TargetRubyVersion: 3.1
-  Include:
-    - "**/*.rb"
   Exclude:
     - "vendor/**/*"
     - "spec/**/*"

--- a/test-kitchen.gemspec
+++ b/test-kitchen.gemspec
@@ -38,5 +38,5 @@ Gem::Specification.new do |gem|
   # Chef Forked versions with additional fixes since no one is maintaining them upstream
   gem.add_dependency "chef-winrm",         ">= 2.5.0", "< 3.0"
   gem.add_dependency "chef-winrm-elevated", ">= 1.0", "< 2.0"
-  gem.add_dependency "chef-winrm-fs",      ">= 1.0", "< 2.0"
+  gem.add_dependency "chef-winrm-fs", ">= 1.0", "< 2.0"
 end


### PR DESCRIPTION
`AllCops/Include` pinned the file list to `**/*.rb`, which quietly excluded the **gemspec, Gemfile and Rakefile** — cookstyle reported success while never looking at them.

Removing the `Include` list restores cookstyle's own defaults, which already cover those files. The offenses that surfaced are autocorrected here.

Verified after the change: `cookstyle --chefstyle` is clean, the gemspec still loads, and the Gemfile/Rakefile still parse.

Also renames the workflow step from "Cook Style" to "Cookstyle", which is the actual name of the tool.
