### PR TITLE
docs: bring YARD coverage to 100% and add a rake yard task

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ group :test do
   gem "maruku",    "~> 0.7"
   gem "minitest",  "~> 6.0", "< 6.1"
   gem "mocha",     "~> 3.0"
+  gem "yard",      "~> 0.9"
 end
 
 group :integration do

--- a/Rakefile
+++ b/Rakefile
@@ -38,6 +38,16 @@ rescue LoadError
   puts "cookstyle/chefstyle is not available. (sudo) gem install cookstyle to do style checking."
 end
 
+# Generation options live in .yardopts so that `yard` and `rake yard` agree.
+begin
+  require "yard"
+  YARD::Rake::YardocTask.new(:yard) do |task|
+    task.options += ["--no-cache"]
+  end
+rescue LoadError
+  puts "yard is not available. (sudo) gem install yard to generate the docs."
+end
+
 desc "Run all quality tasks"
 task quality: %i{style stats}
 

--- a/lib/kitchen/cli.rb
+++ b/lib/kitchen/cli.rb
@@ -121,6 +121,11 @@ module Kitchen
       type: :boolean,
       desc: "[Deprecated] Please use `kitchen diagnose'"
     log_options
+    # Lists one or more instances and their last known action state.
+    #
+    # @param args [Array<String>] instance names or regexps to match; matches
+    #   all instances when empty
+    # @return [void]
     def list(*args)
       log_overwrite = options[:log_overwrite].nil? ? false : options[:log_overwrite]
       update_config!(log_overwrite:)
@@ -144,6 +149,12 @@ module Kitchen
       desc: "Include all diagnostics"
     log_options
     test_base_path
+    # Prints the fully computed diagnostic configuration for one or more
+    # instances, after all loader and plugin data has been merged.
+    #
+    # @param args [Array<String>] instance names or regexps to match; matches
+    #   all instances when empty
+    # @return [void]
     def diagnose(*args)
       update_config!
       perform("diagnose", "diagnose", args, loader: @loader)
@@ -250,6 +261,12 @@ module Kitchen
       desc: "Run the converge and verify with debugging enabled."
     test_base_path
     log_options
+    # Runs a full test cycle (destroy, create, converge, setup, verify,
+    # destroy) against one or more instances.
+    #
+    # @param args [Array<String>] instance names or regexps to match; matches
+    #   all instances when empty
+    # @return [void]
     def test(*args)
       update_config!
       ensure_initialized
@@ -258,6 +275,11 @@ module Kitchen
 
     desc "login INSTANCE|REGEXP", "Log in to one instance"
     log_options
+    # Opens an interactive login session on a single instance.
+    #
+    # @param args [Array<String>] an instance name or regexp matching exactly
+    #   one instance
+    # @return [void]
     def login(*args)
       update_config!
       perform("login", "login", args)
@@ -279,6 +301,11 @@ module Kitchen
       type: :boolean,
       desc: "Follow the structured log file"
     log_options
+    # Prints the structured log events recorded for one or more instances.
+    #
+    # @param args [Array<String>] instance names or regexps to match; matches
+    #   all instances when empty
+    # @return [void]
     def logs(*args)
       update_config!(log_overwrite: false)
       perform("logs", "logs", args)
@@ -286,6 +313,12 @@ module Kitchen
 
     desc "package INSTANCE|REGEXP", "package an instance"
     log_options
+    # Packages a single instance into a distributable artifact, as
+    # implemented by the instance's driver.
+    #
+    # @param args [Array<String>] an instance name or regexp matching exactly
+    #   one instance
+    # @return [void]
     def package(*args)
       update_config!
       perform("package", "package", args)
@@ -296,6 +329,12 @@ module Kitchen
     method_option :all,
       aliases: "-a",
       desc: "Check all instances"
+    # Checks one or more instances for common system and configuration
+    # problems.
+    #
+    # @param args [Array<String>] instance names or regexps to match; matches
+    #   all instances when empty
+    # @return [void]
     def doctor(*args)
       update_config!
       perform("doctor", "doctor", args)
@@ -307,23 +346,39 @@ module Kitchen
       aliases: "-c",
       desc: "execute via ssh"
     log_options
+    # Executes a remote command on one or more instances over their
+    # configured transport.
+    #
+    # @param args [Array<String>] instance names or regexps to match; matches
+    #   all instances when empty
+    # @return [void]
     def exec(*args)
       update_config!
       perform("exec", "exec", args)
     end
 
     desc "version", "Print Test Kitchen's version information"
+    # Prints Test Kitchen's version information to stdout.
+    #
+    # @return [void]
     def version
       puts "Test Kitchen version #{Kitchen::VERSION}"
     end
     map %w{-v --version} => :version
 
     desc "sink", "Show the Kitchen sink!", hide: true
+    # Shows the Kitchen sink. A hidden easter egg command.
+    #
+    # @return [void]
     def sink
       perform("sink", "sink")
     end
 
     desc "console", "Test Kitchen Console!"
+    # Starts an interactive console session with the Test Kitchen
+    # configuration loaded.
+    #
+    # @return [void]
     def console
       perform("console", "console")
     end

--- a/lib/kitchen/color.rb
+++ b/lib/kitchen/color.rb
@@ -22,6 +22,9 @@ module Kitchen
   #
   # @author Fletcher Nichol <fnichol@nichol.ca>
   module Color
+    # Maps color names to their ANSI SGR parameter codes.
+    #
+    # @return [Hash{Symbol => Integer}] color name to ANSI code mapping
     ANSI = {
       reset: 0, black: 30, red: 31, green: 32, yellow: 33,
       blue: 34, magenta: 35, cyan: 36, white: 37,
@@ -30,6 +33,10 @@ module Kitchen
       bright_cyan: 96, bright_white: 97
     }.freeze
 
+    # The subset of {ANSI} color names cycled through when assigning a
+    # distinct color to each instance.
+    #
+    # @return [Array<String>] assignable color names
     COLORS = %w{
       cyan yellow green magenta blue bright_cyan bright_yellow
       bright_green bright_magenta bright_blue

--- a/lib/kitchen/command.rb
+++ b/lib/kitchen/command.rb
@@ -19,6 +19,9 @@ require_relative "errors"
 require_relative "logging"
 
 module Kitchen
+  # Namespace for the classes implementing each `kitchen` subcommand.
+  #
+  # @author Fletcher Nichol <fnichol@nichol.ca>
   module Command
     # Base class for CLI commands.
     #
@@ -191,6 +194,12 @@ module Kitchen
         end
       end
 
+      # Determines how many instances may be acted on at once, clamped to the
+      # number of instances available.
+      #
+      # @param instances [Array<Instance>] the instances to be acted on
+      # @return [Integer] the number of worker threads to start
+      # @api private
       def concurrency_setting(instances)
         concurrency = 1
         if options[:concurrency]
@@ -200,6 +209,14 @@ module Kitchen
         concurrency
       end
 
+      # Performs an action on a single instance, recording any instance or
+      # action failure rather than letting it escape the worker thread.
+      #
+      # @param action [String] action to perform
+      # @param instance [Instance] the instance to act on
+      # @param args [Array] additional arguments forwarded to the action
+      # @return [void]
+      # @api private
       def run_action_in_thread(action, instance, *args)
         instance.public_send(action, *args)
       rescue Kitchen::InstanceFailure => e
@@ -212,6 +229,12 @@ module Kitchen
         instance.cleanup!
       end
 
+      # Records an error raised by an action, synchronized across worker
+      # threads.
+      #
+      # @param error [StandardError] the error to record
+      # @return [void]
+      # @api private
       def record_action_error(error)
         @action_errors_mutex.synchronize { @action_errors << error }
       end

--- a/lib/kitchen/command/logs.rb
+++ b/lib/kitchen/command/logs.rb
@@ -19,6 +19,10 @@ module Kitchen
   module Command
     # Command to print structured logs for one instance.
     class Logs < Kitchen::Command::Base
+      # Log severity names in ascending order, used to resolve the minimum
+      # level filter.
+      #
+      # @return [Array<String>] severity names, lowest to highest
       LEVELS = %w{debug info warn error fatal unknown}.freeze
 
       # Invoke the command.

--- a/lib/kitchen/configurable.rb
+++ b/lib/kitchen/configurable.rb
@@ -26,6 +26,13 @@ module Kitchen
   #
   # @author Fletcher Nichol <fnichol@nichol.ca>
   module Configurable
+    # Extends the including class with {ClassMethods} so that the
+    # `default_config`, `required_config`, and related DSL is available at the
+    # class level.
+    #
+    # @param base [Class] the class including this module
+    # @return [void]
+    # @api private
     def self.included(base)
       base.extend(ClassMethods)
     end
@@ -396,7 +403,7 @@ module Kitchen
     # Helper method to export
     #
     # @param env [Array] the environment to modify
-    # @param code [String] the type of proxy to export, one of 'http', 'https' or 'ftp'
+    # @param type [String] the type of proxy to export, one of 'http', 'https' or 'ftp'
     # @api private
     def export_proxy(env, type)
       env << shell_env_var(type.to_s, ENV[type.to_s]) if ENV[type.to_s]
@@ -586,10 +593,16 @@ module Kitchen
         end
       end
 
+      # @return [Hash] a hash of attribute keys and deprecation messages which
+      #   has been merged with any superclass deprecations
+      # @api private
       def deprecated_attributes
         @deprecated_attributes ||= {}.merge(super_deprecated_attributes)
       end
 
+      # @return [Hash] a hash of deprecated attributes from the superclass, or
+      #   an empty hash when the superclass has none
+      # @api private
       def super_deprecated_attributes
         if superclass.respond_to?(:deprecated_attributes)
           superclass.deprecated_attributes

--- a/lib/kitchen/data_munger.rb
+++ b/lib/kitchen/data_munger.rb
@@ -651,6 +651,11 @@ module Kitchen
     # Runs all legacy configuration conversions while keeping DataMunger as the
     # public facade for destructive normalization.
     class LegacyConfigNormalizer
+      # The legacy conversion methods to invoke, in order, when normalizing
+      # raw configuration data.
+      #
+      # @return [Array<Symbol>] ordered DataMunger method names
+      # @api private
       STEPS = %i{
         convert_legacy_driver_format!
         convert_legacy_chef_paths_format!
@@ -665,6 +670,10 @@ module Kitchen
         @data_munger = data_munger
       end
 
+      # Destructively runs every conversion in {STEPS} against the data.
+      #
+      # @return [void]
+      # @api private
       def normalize!
         STEPS.each { |step| data_munger.send(step) }
       end
@@ -680,6 +689,16 @@ module Kitchen
         @data_munger = data_munger
       end
 
+      # Merges the default, common, platform, and suite layers for one plugin
+      # key, with later layers winning over earlier ones.
+      #
+      # @param key [Symbol] the plugin key to merge, such as `:driver`
+      # @param suite [String] a suite name
+      # @param platform [String] a platform name
+      # @param default_key [Symbol] the key used when normalizing data
+      #   sub-hashes
+      # @return [Hash] a new merged Hash
+      # @api private
       def merged_data_for(key, suite, platform, default_key)
         ddata = data_munger.send(:normalized_default_data, key, default_key, suite, platform)
         cdata = data_munger.send(:normalized_common_data, key, default_key)

--- a/lib/kitchen/driver/base.rb
+++ b/lib/kitchen/driver/base.rb
@@ -108,7 +108,7 @@ module Kitchen
       # Cache directory that a driver could implement to inform the provisioner
       # that it can leverage it internally
       #
-      # @return path [String] a path of the cache directory
+      # @return [String] a path of the cache directory
       def cache_directory; end
 
       private

--- a/lib/kitchen/driver/dummy.rb
+++ b/lib/kitchen/driver/dummy.rb
@@ -36,12 +36,18 @@ module Kitchen
         report(:create, state)
       end
 
-      # (see Base#setup)
+      # Reports that the setup action would have taken place.
+      #
+      # @param state [Hash] the instance state hash
+      # @return [void]
       def setup(state)
         report(:setup, state)
       end
 
-      # (see Base#verify)
+      # Reports that the verify action would have taken place.
+      #
+      # @param state [Hash] the instance state hash
+      # @return [void]
       def verify(state)
         report(:verify, state)
       end

--- a/lib/kitchen/errors.rb
+++ b/lib/kitchen/errors.rb
@@ -59,6 +59,12 @@ module Kitchen
       arr.flatten
     end
 
+    # Creates an array of strings representing an exception's backtrace,
+    # wrapped in header and footer lines.
+    #
+    # @param exception [::Exception] an exception
+    # @return [Array<String>] a formatted backtrace, or an empty array when the
+    #   exception has none
     def self.formatted_backtrace(exception)
       if exception.backtrace.nil?
         []

--- a/lib/kitchen/generator/init.rb
+++ b/lib/kitchen/generator/init.rb
@@ -19,6 +19,10 @@ require "rubygems/gem_runner"
 require "thor/group"
 
 module Kitchen
+  # Namespace for Thor generators that scaffold Test Kitchen configuration
+  # into a project.
+  #
+  # @author Fletcher Nichol <fnichol@nichol.ca>
   module Generator
     # A project initialization generator, to help prepare a cookbook project
     # for testing with Kitchen.

--- a/lib/kitchen/instance.rb
+++ b/lib/kitchen/instance.rb
@@ -654,6 +654,16 @@ module Kitchen
         @state_file = state_file
       end
 
+      # Runs one instance action, wrapping it in structured logging metadata
+      # and benchmarking, and serializing it when the action is registered as
+      # non-concurrent.
+      #
+      # @param what [Symbol] the action to run
+      # @yield the action body, given the current state hash
+      # @return [void]
+      # @raise [ActionFailed] if the state file could not be read or the action
+      #   did not complete
+      # @api private
       def call(what, &block)
         state = nil
         begin
@@ -775,6 +785,10 @@ module Kitchen
         end
       end
 
+      # The instance state lifecycle, ordered from least to most converged.
+      #
+      # @return [Array<Symbol>] ordered state names
+      # @api private
       TRANSITIONS = %i{destroy create converge setup verify}.freeze
 
       # Determines the index of a state in the state lifecycle vector. Whoa.

--- a/lib/kitchen/lazy_hash.rb
+++ b/lib/kitchen/lazy_hash.rb
@@ -115,7 +115,7 @@ module Kitchen
 
     # If no block provided, returns an enumerator over the keys and
     # rendered values in the underlying object.  If a block is
-    # provided, calls the block once for each [key, rendered_value]
+    # provided, calls the block once for each `[key, rendered_value]`
     # pair in the underlying object.
     #
     # @return [Enumerator, Array]

--- a/lib/kitchen/lifecycle_hook/base.rb
+++ b/lib/kitchen/lifecycle_hook/base.rb
@@ -1,15 +1,22 @@
 require_relative "../platform_filter"
 
 module Kitchen
+  # Namespace for the lifecycle hook implementations that run user-defined
+  # commands around instance actions.
   class LifecycleHook
+    # Base class for a lifecycle hook implementation.
+    #
+    # A hook is bound to a single phase (for example `pre_create`) and decides,
+    # via `#should_run?`, whether it applies to the instance's platform before
+    # `#run` carries out the command.
     class Base
       # @return [Kitchen::LifecycleHooks]
       attr_reader :lifecycle_hooks
 
-      # return [String]
+      # @return [String] the lifecycle phase this hook is bound to
       attr_reader :phase
 
-      # return [Hash]
+      # @return [Hash] the raw hook configuration
       attr_reader :hook
 
       # @param lifecycle_hooks [Kitchen::LifecycleHooks]
@@ -21,7 +28,10 @@ module Kitchen
         @hook = hook
       end
 
-      # return [void]
+      # Carries out the hook's command. Subclasses must implement this.
+      #
+      # @return [void]
+      # @raise [NotImplementedError] unless overridden by a subclass
       def run
         raise NotImplementedError
       end

--- a/lib/kitchen/lifecycle_hook/local.rb
+++ b/lib/kitchen/lifecycle_hook/local.rb
@@ -4,6 +4,8 @@ require_relative "../logging"
 
 module Kitchen
   class LifecycleHook
+    # A lifecycle hook that runs a command on the workstation running Test
+    # Kitchen, with the instance's details exported as environment variables.
     class Local < Base
       include ShellOut
       include Logging

--- a/lib/kitchen/lifecycle_hook/remote.rb
+++ b/lib/kitchen/lifecycle_hook/remote.rb
@@ -3,6 +3,8 @@ require_relative "../errors"
 
 module Kitchen
   class LifecycleHook
+    # A lifecycle hook that runs a command on the instance itself, over the
+    # instance's configured transport.
     class Remote < Base
       # Execute a specific remote command hook.
       #
@@ -33,7 +35,7 @@ module Kitchen
 
       private
 
-      # return [String]
+      # @return [String] the command to run on the instance
       def command
         hook.fetch(:remote)
       end

--- a/lib/kitchen/loader/yaml.rb
+++ b/lib/kitchen/loader/yaml.rb
@@ -21,6 +21,10 @@ require "psych" unless defined?(Psych)
 require "yaml" unless defined?(YAML)
 
 module Kitchen
+  # Namespace for configuration loaders, which turn on-disk configuration
+  # into the raw data hash Test Kitchen operates on.
+  #
+  # @author Fletcher Nichol <fnichol@nichol.ca>
   module Loader
     # YAML file loader for Test Kitchen configuration. This class is
     # responsible for parsing the main YAML file and the local YAML if it

--- a/lib/kitchen/logger.rb
+++ b/lib/kitchen/logger.rb
@@ -111,61 +111,72 @@ module Kitchen
       private
 
       # @api private
-      # @!macro delegate_to_first_logger
-      #   @method $1()
       def delegate_to_first_logger(meth)
         define_method(meth) { |*args, &block| @sink_set.first(meth, *args, &block) }
       end
 
       # @api private
-      # @!macro delegate_to_all_loggers
-      #   @method $1()
       def delegate_to_all_loggers(meth)
         define_method(meth) { |*args, &block| @sink_set.all(meth, *args, &block) }
       end
     end
 
+    # @!method level
     # @return [Integer] the logging severity threshold
     # @see http://is.gd/Okuy5p
     delegate_to_first_logger :level
 
+    # @!method level=(level)
     # Sets the logging severity threshold.
     #
     # @param level [Integer] the logging severity threshold
     # @see http://is.gd/H1VBFH
     delegate_to_all_loggers :level=
 
+    # @!method progname
     # @return [String] program name to include in log messages
     # @see http://is.gd/5uHGK0
     delegate_to_first_logger :progname
 
+    # @!method progname=(progname)
     # Sets the program name to include in log messages.
     #
     # @param progname [String] the program name to include in log messages
     # @see http://is.gd/f2U5Xj
     delegate_to_all_loggers :progname=
 
+    # @!method datetime_format
     # @return [String] the date format being used
     # @see http://is.gd/btmFWJ
     delegate_to_first_logger :datetime_format
 
+    # @!method datetime_format=(format)
     # Sets the date format being used.
     #
     # @param format [String] the date format
     # @see http://is.gd/M36ml8
     delegate_to_all_loggers :datetime_format=
 
+    # @!method add(severity, message = nil, progname = nil, &block)
     # Log a message if the given severity is high enough.
     #
+    # @param severity [Integer] a stdlib Logger severity constant
+    # @param message [#to_s, nil] the message to log; when nil the block's
+    #   value is used, falling back to +progname+
+    # @param progname [#to_s, nil] used as the message when both +message+ and
+    #   a block are absent
+    # @yield evaluates to the message to log
     # @see http://is.gd/5opBW0
     delegate_to_all_loggers :add
 
+    # @!method <<(message)
     # Dump one or more messages to info.
     #
     # @param message [#to_s] the message to log
     # @see http://is.gd/BCp5KV
     delegate_to_all_loggers :<<
 
+    # @!method banner(message_or_progname = nil, &block)
     # Log a message with severity of banner (high level).
     #
     # @param message_or_progname [#to_s] the message to log. In the block
@@ -179,6 +190,7 @@ module Kitchen
     # @see http://is.gd/pYUCYU
     delegate_to_all_loggers :banner
 
+    # @!method debug(message_or_progname = nil, &block)
     # Log a message with severity of debug.
     #
     # @param message_or_progname [#to_s] the message to log. In the block
@@ -192,11 +204,13 @@ module Kitchen
     # @see http://is.gd/Re97Zp
     delegate_to_all_loggers :debug
 
+    # @!method debug?
     # @return [true,false] whether or not the current severity level
     #   allows for the printing of debug messages
     # @see http://is.gd/Iq08xB
     delegate_to_first_logger :debug?
 
+    # @!method info(message_or_progname = nil, &block)
     # Log a message with severity of info.
     #
     # @param message_or_progname [#to_s] the message to log. In the block
@@ -210,11 +224,13 @@ module Kitchen
     # @see http://is.gd/pYUCYU
     delegate_to_all_loggers :info
 
+    # @!method info?
     # @return [true,false] whether or not the current severity level
     #   allows for the printing of info messages
     # @see http://is.gd/lBtJkT
     delegate_to_first_logger :info?
 
+    # @!method error(message_or_progname = nil, &block)
     # Log a message with severity of error.
     #
     # @param message_or_progname [#to_s] the message to log. In the block
@@ -228,11 +244,13 @@ module Kitchen
     # @see http://is.gd/mLwYMl
     delegate_to_all_loggers :error
 
+    # @!method error?
     # @return [true,false] whether or not the current severity level
     #   allows for the printing of error messages
     # @see http://is.gd/QY19JL
     delegate_to_first_logger :error?
 
+    # @!method warn(message_or_progname = nil, &block)
     # Log a message with severity of warn.
     #
     # @param message_or_progname [#to_s] the message to log. In the block
@@ -246,11 +264,13 @@ module Kitchen
     # @see http://is.gd/PX9AIS
     delegate_to_all_loggers :warn
 
+    # @!method warn?
     # @return [true,false] whether or not the current severity level
     #   allows for the printing of warn messages
     # @see http://is.gd/Gdr4lD
     delegate_to_first_logger :warn?
 
+    # @!method fatal(message_or_progname = nil, &block)
     # Log a message with severity of fatal.
     #
     # @param message_or_progname [#to_s] the message to log. In the block
@@ -264,11 +284,13 @@ module Kitchen
     # @see http://is.gd/5ElFPK
     delegate_to_all_loggers :fatal
 
+    # @!method fatal?
     # @return [true,false] whether or not the current severity level
     #   allows for the printing of fatal messages
     # @see http://is.gd/7PgwRl
     delegate_to_first_logger :fatal?
 
+    # @!method unknown(message_or_progname = nil, &block)
     # Log a message with severity of unknown.
     #
     # @param message_or_progname [#to_s] the message to log. In the block
@@ -282,6 +304,7 @@ module Kitchen
     # @see http://is.gd/Y4hqpf
     delegate_to_all_loggers :unknown
 
+    # @!method close
     # Close the logging devices.
     #
     # @see http://is.gd/b13cVn
@@ -341,10 +364,26 @@ module Kitchen
         @loggers = loggers
       end
 
+      # Invokes a method on the first configured sink only.
+      #
+      # @param meth [Symbol] the method to invoke
+      # @param args [Array] arguments to forward to the sink
+      # @yield an optional block forwarded to the sink
+      # @return [Object] the first sink's return value
+      # @api private
       def first(meth, *args, &block)
         @loggers.first.public_send(meth, *args, &block)
       end
 
+      # Invokes a method on every configured sink. A given block is memoized so
+      # that an expensive message block is evaluated at most once, no matter how
+      # many sinks consume it.
+      #
+      # @param meth [Symbol] the method to invoke
+      # @param args [Array] arguments to forward to each sink
+      # @yield an optional block forwarded to each sink
+      # @return [Object] the last sink's return value
+      # @api private
       def all(meth, *args, &block)
         result = nil
         block = memoized_block(block) if block
@@ -449,6 +488,13 @@ module Kitchen
         @line_handler = line_handler
       end
 
+      # Appends a chunk of stream output to the buffer, emitting each complete
+      # newline-terminated line to the line handler.
+      #
+      # @param msg [String] a chunk of stream output, which may contain zero or
+      #   more complete lines
+      # @return [void]
+      # @api private
       def <<(msg)
         @buffer += msg
         flush_lines
@@ -470,6 +516,12 @@ module Kitchen
         @logger = logger
       end
 
+      # Routes an already-prefixed stream line to the logger call matching its
+      # prefix, stripping the prefix before logging.
+      #
+      # @param line [String] a single line of prefixed stream output
+      # @return [void]
+      # @api private
       def format(line)
         case line
         when /^-----> / then log_line(:banner, line.gsub(/^[ >-]{6} /, ""))
@@ -540,6 +592,11 @@ module Kitchen
     class StructuredLogdevLogger
       include ::Logger::Severity
 
+      # Maps stdlib Logger severity constants to their lowercase string names
+      # as they appear in emitted JSON events.
+      #
+      # @return [Hash{Integer => String}] severity constant to name mapping
+      # @api private
       SEVERITY_NAMES = {
         DEBUG => "debug",
         INFO => "info",
@@ -562,6 +619,17 @@ module Kitchen
         @mutex = Mutex.new
       end
 
+      # Writes a log event if the given severity meets the current level.
+      #
+      # @param severity [Integer] a stdlib Logger severity constant
+      # @param message [#to_s, nil] the message to log; when nil the block's
+      #   value is used, falling back to +progname+
+      # @param progname [#to_s, nil] used as the message when both +message+ and
+      #   a block are absent
+      # @yield evaluates to the message to log, only when the severity is high
+      #   enough to be recorded
+      # @return [true] always, once the event has been considered
+      # @api private
       def add(severity, message = nil, progname = nil)
         severity ||= UNKNOWN
         return true if severity < level
@@ -574,40 +642,102 @@ module Kitchen
         write_event(severity, message, "log")
       end
 
+      # Appends raw stream output, emitting a structured event per complete
+      # line.
+      #
+      # @param msg [String] a chunk of stream output
+      # @return [void]
+      # @api private
       def <<(msg)
         line_buffer << msg
       end
 
+      # Writes a banner event at info severity.
+      #
+      # @param msg [#to_s, nil] the message to log; when nil the block's value is
+      #   used
+      # @yield evaluates to the message to log
+      # @return [void]
+      # @api private
       def banner(msg = nil)
         message = block_given? ? yield : msg
         write_event(INFO, message, "banner") unless INFO < level
       end
 
+      # Writes a stream event at the given severity.
+      #
+      # @param severity [Integer, Symbol] a stdlib Logger severity constant or its
+      #   symbol name
+      # @param msg [#to_s] the message to log
+      # @return [void]
+      # @api private
       def stream(severity, msg)
         severity = severity_const(severity)
         write_event(severity, msg, "stream") unless severity < level
       end
 
+      # Writes a log event at debug severity.
+      #
+      # @param msg [#to_s, nil] the message to log; when nil the block's value is
+      #   used
+      # @yield evaluates to the message to log
+      # @return [true]
+      # @api private
       def debug(msg = nil, &block)
         add(DEBUG, msg, nil, &block)
       end
 
+      # Writes a log event at info severity.
+      #
+      # @param msg [#to_s, nil] the message to log; when nil the block's value is
+      #   used
+      # @yield evaluates to the message to log
+      # @return [true]
+      # @api private
       def info(msg = nil, &block)
         add(INFO, msg, nil, &block)
       end
 
+      # Writes a log event at warn severity.
+      #
+      # @param msg [#to_s, nil] the message to log; when nil the block's value is
+      #   used
+      # @yield evaluates to the message to log
+      # @return [true]
+      # @api private
       def warn(msg = nil, &block)
         add(WARN, msg, nil, &block)
       end
 
+      # Writes a log event at error severity.
+      #
+      # @param msg [#to_s, nil] the message to log; when nil the block's value is
+      #   used
+      # @yield evaluates to the message to log
+      # @return [true]
+      # @api private
       def error(msg = nil, &block)
         add(ERROR, msg, nil, &block)
       end
 
+      # Writes a log event at fatal severity.
+      #
+      # @param msg [#to_s, nil] the message to log; when nil the block's value is
+      #   used
+      # @yield evaluates to the message to log
+      # @return [true]
+      # @api private
       def fatal(msg = nil, &block)
         add(FATAL, msg, nil, &block)
       end
 
+      # Writes a log event at unknown severity.
+      #
+      # @param msg [#to_s, nil] the message to log; when nil the block's value is
+      #   used
+      # @yield evaluates to the message to log
+      # @return [true]
+      # @api private
       def unknown(msg = nil, &block)
         add(UNKNOWN, msg, nil, &block)
       end
@@ -632,6 +762,10 @@ module Kitchen
         level <= FATAL
       end
 
+      # Closes the underlying log device if it is open and supports closing.
+      #
+      # @return [void]
+      # @api private
       def close
         return unless @logdev.respond_to?(:close)
 

--- a/lib/kitchen/logging.rb
+++ b/lib/kitchen/logging.rb
@@ -25,7 +25,7 @@ module Kitchen
 
       # @api private
       # @!macro logger_method
-      #   @method $1($2)
+      #   @method $1(message_or_progname = nil, &block)
       #   Log a message with severity of $1
       #   @param message_or_progname [#to_s] the message to log. In the block
       #     form, this is the progname to use in the log message.

--- a/lib/kitchen/login_command.rb
+++ b/lib/kitchen/login_command.rb
@@ -42,6 +42,9 @@ module Kitchen
       @options = options
     end
 
+    # Returns the arguments in the form expected by `Kernel#exec`.
+    #
+    # @return [Array] the command, its arguments, and the options hash
     def exec_args
       [command, *arguments, options]
     end

--- a/lib/kitchen/metadata_chopper.rb
+++ b/lib/kitchen/metadata_chopper.rb
@@ -42,6 +42,13 @@ module Kitchen
       instance_eval(File.read(metadata_file), metadata_file)
     end
 
+    # Captures any attribute call made while evaluating the metadata file,
+    # storing its first argument under the attribute name.
+    #
+    # @param meth [Symbol] the attribute name being set
+    # @param args [Array] the attribute's arguments; the first becomes the value
+    # @return [Object] the stored value
+    # @api private
     def method_missing(meth, *args, &_block)
       self[meth] = args.first
     end

--- a/lib/kitchen/plugin.rb
+++ b/lib/kitchen/plugin.rb
@@ -20,10 +20,13 @@ require_relative "errors"
 require_relative "util"
 
 module Kitchen
+  # Namespace for plugin loading and the shared plugin base class.
+  #
+  # @author Fletcher Nichol <fnichol@nichol.ca>
   module Plugin
     # Returns an instance of a plugin given a type, name, and config.
     #
-    # @param type [Module] a Kitchen::<Module> of one of the plugin types
+    # @param type [Module] a `Kitchen::<Module>` of one of the plugin types
     #   (Driver, Provisioner, Transport, Verifier)
     # @param plugin [String] a plugin name, which will be constantized
     # @param config [Hash] a configuration hash to initialize the plugin

--- a/lib/kitchen/plugin_base.rb
+++ b/lib/kitchen/plugin_base.rb
@@ -17,6 +17,11 @@
 
 module Kitchen
   module Plugin
+    # Common base class for every plugin type (Driver, Provisioner, Transport,
+    # and Verifier), providing the shared plugin lifecycle and the
+    # serial-action registry.
+    #
+    # @author Fletcher Nichol <fnichol@nichol.ca>
     class Base
       class << self
         # @return [Array<Symbol>] an array of action method names that cannot

--- a/lib/kitchen/provisioner/base.rb
+++ b/lib/kitchen/provisioner/base.rb
@@ -264,7 +264,7 @@ module Kitchen
 
       # Conditionally prefixes a command with a sudo command.
       #
-      # @param command [String] command to be prefixed
+      # @param script [String] command to be prefixed
       # @return [String] the command, conditionally prefixed with sudo
       # @api private
       def sudo(script)
@@ -285,7 +285,7 @@ module Kitchen
       # Cisco Nexus, require all commands to be run with a prefix to
       # obtain outbound network access.
       #
-      # @param command [String] command to be prefixed
+      # @param script [String] command to be prefixed
       # @return [String] the command, conditionally prefixed with the configured prefix
       # @api private
       def prefix_command(script)

--- a/lib/kitchen/provisioner/external.rb
+++ b/lib/kitchen/provisioner/external.rb
@@ -25,12 +25,30 @@ module Kitchen
   module Provisioner
     # Executes an external provisioner provider over the v1 stdio protocol.
     class External < Base
+      # The provider protocol version this provisioner speaks. A provider
+      # reporting any other version is rejected during capability negotiation.
+      #
+      # @return [String] a protocol version string
       PROTOCOL_VERSION = "1.0".freeze
+      # The result statuses a provider may report for an action.
+      #
+      # @return [Array<String>] valid result statuses
       RESULT_STATUSES = %w{passed failed skipped}.freeze
+      # The log levels a provider may attach to a log message.
+      #
+      # @return [Array<String>] valid log levels
       LOG_LEVELS = %w{debug info warn error}.freeze
+      # Configuration keys consumed by this provisioner itself, and so withheld
+      # from the configuration passed out to the provider.
+      #
+      # @return [Array<Symbol>] internal-only configuration keys
       INTERNAL_CONFIG_KEYS = %i{
         command provider pass_env kitchen_root test_base_path
       }.freeze
+      # Configuration keys whose values are redacted before configuration is
+      # logged or handed to a provider.
+      #
+      # @return [Array<String>] keys to redact
       REDACTED_KEYS = %w{password ssh_http_proxy_password}.freeze
 
       kitchen_provisioner_api_version 2
@@ -50,6 +68,10 @@ module Kitchen
         persist_provider_state(state, result)
       end
 
+      # Derives the provider's name from the configured command, stripping any
+      # directory portion and the conventional `kitchen-provider-` prefix.
+      #
+      # @return [String] the provider name
       def provider_name_from_command
         first_part = Shellwords.split(config[:command].to_s).first.to_s
         File.basename(first_part).sub(/^kitchen-provider-/, "")

--- a/lib/kitchen/transport/dummy.rb
+++ b/lib/kitchen/transport/dummy.rb
@@ -31,14 +31,21 @@ module Kitchen
       default_config :sleep, 1
       default_config :random_exit_code, 0
 
+      # Creates a new dummy connection, merging the instance state into the
+      # transport's configuration.
+      #
+      # @param state [Hash] the instance state hash
+      # @yield [Connection] yields the connection for block-style invocation
+      # @return [Connection] a new connection
       def connection(state, &block)
         options = config.to_hash.merge(state)
         Kitchen::Transport::Dummy::Connection.new(options, &block)
       end
 
-      # TODO: comment
+      # A connection that reports the actions it would have carried out
+      # rather than contacting any remote host.
       class Connection < Kitchen::Transport::Base::Connection
-        # (see Base#execute)
+        # (see Base::Connection#execute)
         def execute(command)
           report(:execute, command)
           if options[:random_exit_code] != 0
@@ -46,10 +53,20 @@ module Kitchen
           end
         end
 
+        # Reports that the given files would have been uploaded.
+        #
+        # @param locals [Array<String>] local paths that would be uploaded
+        # @param remote [String] the remote destination path
+        # @return [void]
         def upload(locals, remote)
           report(:upload, "#{locals.inspect} => #{remote}")
         end
 
+        # Reports that the given files would have been downloaded.
+        #
+        # @param remotes [Array<String>] remote paths that would be downloaded
+        # @param local [String] the local destination path
+        # @return [void]
         def download(remotes, local)
           report(:download, "#{remotes.inspect} => #{local}")
         end
@@ -60,7 +77,8 @@ module Kitchen
         # possibly fail randomly.
         #
         # @param action [Symbol] the action currently taking place
-        # @param state [Hash] the state hash
+        # @param msg [String] an optional message describing the action's
+        #   subject, appended to the log output
         # @api private
         def report(action, msg = "")
           what = action.capitalize

--- a/lib/kitchen/transport/exec.rb
+++ b/lib/kitchen/transport/exec.rb
@@ -66,7 +66,7 @@ module Kitchen
           end
         end
 
-        # (see Base#init_options)
+        # (see Base::Connection#init_options)
         def init_options(options)
           super
           @instance_name = @options.delete(:instance_name)

--- a/lib/kitchen/transport/ssh.rb
+++ b/lib/kitchen/transport/ssh.rb
@@ -77,6 +77,10 @@ module Kitchen
         transport[:compression] == false ? 0 : 6
       end
 
+      # (see Base#finalize_config!)
+      #
+      # Casts legacy `:compression` values to what net-ssh 2.10 and later
+      # expect.
       def finalize_config!(instance)
         super
 
@@ -121,7 +125,10 @@ module Kitchen
       #
       # @author Fletcher Nichol <fnichol@nichol.ca>
       class Connection < Kitchen::Transport::Base::Connection
-        # (see Base::Connection#initialize)
+        # Create a new Connection instance.
+        #
+        # @param config [Hash] connection options
+        # @yield [self] yields itself for block-style invocation
         def initialize(config = {})
           super(config)
           @session = nil

--- a/lib/kitchen/transport/winrm.rb
+++ b/lib/kitchen/transport/winrm.rb
@@ -58,6 +58,9 @@ module Kitchen
         transport[:winrm_transport] == :ssl ? 5986 : 5985
       end
 
+      # (see Base#finalize_config!)
+      #
+      # Coerces `:winrm_transport` to a Symbol.
       def finalize_config!(instance)
         super
 
@@ -84,7 +87,10 @@ module Kitchen
       #
       # @author Fletcher Nichol <fnichol@nichol.ca>
       class Connection < Kitchen::Transport::Base::Connection
-        # (see Base::Connection#initialize)
+        # Create a new Connection instance.
+        #
+        # @param config [Hash] connection options
+        # @yield [self] yields itself for block-style invocation
         def initialize(config = {})
           super(config)
           @unelevated_session = nil
@@ -293,7 +299,7 @@ module Kitchen
           @file_transporter ||= WinRM::FS::Core::FileTransporter.new(unelevated_session)
         end
 
-        # (see Base#init_options)
+        # (see Base::Connection#init_options)
         def init_options(options)
           super
           @instance_name = @options.delete(:instance_name)

--- a/lib/kitchen/util.rb
+++ b/lib/kitchen/util.rb
@@ -118,7 +118,7 @@ module Kitchen
     # This method uses the Bourne shell (/bin/sh) to maximize the chance of
     # cross platform portability on Unixlike systems.
     #
-    # @param [String] the command
+    # @param cmd [String] the command
     # @return [String] a wrapped command string
     def self.wrap_command(cmd)
       cmd = "false" if cmd.nil?
@@ -221,10 +221,18 @@ module Kitchen
       end
     end
 
+    # Returns a CamelCase version of a snake_case string.
+    #
+    # @param a_string [String] a snake_case string
+    # @return [String] a CamelCase string
     def self.camel_case(a_string)
       Thor::Util.camel_case(a_string)
     end
 
+    # Returns a snake_case version of a CamelCase string.
+    #
+    # @param a_string [String] a CamelCase string
+    # @return [String] a snake_case string
     def self.snake_case(a_string)
       Thor::Util.snake_case(a_string)
     end

--- a/lib/kitchen/verifier/base.rb
+++ b/lib/kitchen/verifier/base.rb
@@ -240,7 +240,7 @@ module Kitchen
 
       # Conditionally prefixes a command with a sudo command.
       #
-      # @param command [String] command to be prefixed
+      # @param script [String] command to be prefixed
       # @return [String] the command, conditionally prefixed with sudo
       # @api private
       def sudo(script)
@@ -253,7 +253,7 @@ module Kitchen
       # Cisco Nexus, require all commands to be run with a prefix to
       # obtain outbound network access.
       #
-      # @param command [String] command to be prefixed
+      # @param script [String] command to be prefixed
       # @return [String] the command, conditionally prefixed with the configured prefix
       # @api private
       def prefix_command(script)

--- a/lib/kitchen/version.rb
+++ b/lib/kitchen/version.rb
@@ -16,5 +16,8 @@
 # limitations under the License.
 
 module Kitchen
+  # The currently released version of Test Kitchen.
+  #
+  # @return [String] a semantic version string
   VERSION = "4.1.1".freeze
 end

--- a/lib/kitchen/which.rb
+++ b/lib/kitchen/which.rb
@@ -19,6 +19,8 @@ require "chef-utils/dsl/which" unless defined?(ChefUtils::DSL::Which)
 require_relative "chef_utils_wiring" unless defined?(Kitchen::ChefUtilsWiring)
 
 module Kitchen
+  # Mixin providing a `which` helper for locating executables on the PATH,
+  # wired up to Test Kitchen's chef-utils configuration.
   module Which
     include ChefUtils::DSL::Which
     include ChefUtilsWiring

--- a/lib/vendor/hash_recursive_merge.rb
+++ b/lib/vendor/hash_recursive_merge.rb
@@ -74,6 +74,11 @@ module HashRecursiveMerge
   end
 end
 
+# Reopened to mix in {HashRecursiveMerge}, which adds the `#rmerge` and
+# `#rmerge!` deep-merge methods used throughout Test Kitchen's
+# configuration merging.
+#
+# This file is vendored third-party code; see the header for attribution.
 class Hash
   include HashRecursiveMerge
 end


### PR DESCRIPTION
## Why

Test Kitchen has a `.yardopts` file, but `yard` was never a declared dependency and there was no rake task — API docs were only ever generated by hand from a globally installed gem. Unsurprisingly, things had drifted:

| | Before | After |
|---|---|---|
| Documented (public API) | 86.47% | **100.00%** |
| YARD warnings | 26 | **0** |
| Maruku render errors | 36 | **0** |

## What

**A `rake yard` task.** Guarded by a `LoadError` rescue in the same style as the existing `cucumber` and `cookstyle` blocks, so a checkout without yard still gets a working `rake`. `yard` is declared in the `:test` group next to `maruku`, which was already there as the markup provider. Generation options stay in `.yardopts` so `yard` and `rake yard` produce the same output.

**Docs for the 72 undocumented public objects** — 49 methods, 12 constants, 11 modules/classes.

**Fixes for the doc defects the old setup tolerated silently:**

- **Stale `@param` names.** `sudo(script)` and `prefix_command(script)` in both `provisioner/base.rb` and `verifier/base.rb` documented a `command` parameter that had been renamed. `configurable.rb#export_proxy` documented `code` for its `type` parameter — the description underneath ("the type of proxy") gave the game away. `transport/dummy.rb#report` documented a `state` parameter its signature no longer has.

- **Malformed tags.** `util.rb#wrap_command` had `@param [String]` with no parameter name; `driver/base.rb` had `@return path [String]` (`@return` takes no name); four `# return [X]` tags in the lifecycle hooks were missing their `@` and rendered as prose.

- **Dangling `(see ...)` references.** These resolve to an *empty* docstring with no warning, which is why several methods showed as undocumented despite visibly having a comment. `Driver::Dummy#setup` and `#verify` pointed at `Base#setup`/`Base#verify`, neither of which exists — `Driver::Base` only defines `create` and `destroy`. `transport/dummy.rb` pointed at `Base#execute` instead of `Base::Connection#execute`, and `winrm.rb`/`exec.rb` at `Base#init_options` instead of `Base::Connection#init_options` (`ssh.rb` already had it right). `transport/dummy.rb`'s `Connection` was documented as `# TODO: comment`.

- **Empty generated-method signatures.** `logger.rb`'s delegation macros declared `@method $1()` — literal empty parens — and `logging.rb`'s declared `@method $1($2)` where `$2` never exists, since `logger_method` takes one argument. Either way every delegated logging method was documented as taking zero parameters, so its `@param` tags had nothing to bind to. A single macro can't fix this because the delegated methods don't share a signature (`level` is a reader, `level=` takes `level`, `banner` takes `message_or_progname` plus a block), so this replaces the macro with per-call-site `@!method` directives declaring each real signature. These methods now appear in the generated docs with correct signatures.

- **Maruku rendering errors.** `{#method}` is parsed as an inline attribute list rather than a YARD cross-reference, so `{#run}`-style links are unusable while `.yardopts` pins `--markup-provider maruku`. `<Module>` and `[key, rendered_value]` were being read as an HTML tag and a reference link.

## Notes

- This is a docs-only change apart from `Rakefile` and `Gemfile`. No method signatures or behavior were touched — where a doc disagreed with a signature, the doc was corrected, not the code.
- The task generates only; there's no coverage gate and it isn't wired into `rake quality`.

## Verification

- `rake unit` — 1723 runs, 2700 assertions, **0 failures, 0 errors**
- `rake style` — 82 files inspected, **no offenses**
- `yard stats` — **100.00% documented, 0 warnings**
- `rake yard` — generates `doc/`, **0 maruku errors**
- `rake -T` lists `rake yard`; with `yard` unavailable the guard prints its message and leaves the task undefined

🤖 Generated with [Claude Code](https://claude.com/claude-code)