### PR TITLE
fix: make individually-required lib files load on their own

### DIFF
--- a/lib/kitchen.rb
+++ b/lib/kitchen.rb
@@ -57,8 +57,23 @@ module Kitchen
     # @return [Mutex] a common mutex for global coordination
     attr_accessor :mutex
 
+    # Returns the mutex used for Dir.chdir coordination.
+    #
     # @return [Mutex] a mutex used for Dir.chdir coordination
-    attr_accessor :mutex_chdir
+    # @deprecated Use {Kitchen::Util.mutex_chdir}, which owns the mutex and is
+    #   available without loading all of Test Kitchen.
+    def mutex_chdir
+      Kitchen::Util.mutex_chdir
+    end
+
+    # Sets the mutex used for Dir.chdir coordination.
+    #
+    # @param mutex [Mutex] the mutex to use for Dir.chdir coordination
+    # @return [Mutex] the newly set mutex
+    # @deprecated Use {Kitchen::Util.mutex_chdir=}.
+    def mutex_chdir=(mutex)
+      Kitchen::Util.mutex_chdir = mutex
+    end
 
     # @return [String] identifier for the current Kitchen process invocation
     attr_writer :run_id
@@ -164,6 +179,3 @@ Kitchen.logger = Kitchen.default_logger
 
 # Set up a collection of instance crash exceptions for error reporting
 Kitchen.mutex = Mutex.new
-
-# Initialize the mutex for Dir.chdir coordination
-Kitchen.mutex_chdir = Mutex.new

--- a/lib/kitchen/instance.rb
+++ b/lib/kitchen/instance.rb
@@ -20,6 +20,8 @@ require "fileutils" unless defined?(FileUtils)
 require "securerandom" unless defined?(SecureRandom)
 require "time" unless defined?(Time.zone_offset)
 
+require_relative "logging"
+
 module Kitchen
   # An instance of a suite running on a platform. A created instance may be a
   # local virtual machine, cloud instance, container, or even a bare metal

--- a/lib/kitchen/shell_out.rb
+++ b/lib/kitchen/shell_out.rb
@@ -17,6 +17,8 @@
 
 require "mixlib/shellout" unless defined?(Mixlib::ShellOut)
 
+require_relative "errors" # for TransientFailure
+
 module Kitchen
   # Mixin that wraps a command shell out invocation, providing a #run_command
   # method.

--- a/lib/kitchen/util.rb
+++ b/lib/kitchen/util.rb
@@ -24,6 +24,17 @@ module Kitchen
   #
   # @author Fletcher Nichol <fnichol@nichol.ca>
   module Util
+    class << self
+      # @return [Mutex] a mutex used to serialize the process-global Dir.chdir
+      attr_accessor :mutex_chdir
+    end
+
+    # Dir.chdir mutates process-global state, so every call has to be
+    # serialized. The mutex is owned here rather than in lib/kitchen.rb
+    # because Util is its only consumer and has to keep working when
+    # "kitchen/util" is required on its own.
+    @mutex_chdir = Mutex.new
+
     # Returns the standard library Logger level constants for a given symbol
     # representation.
     #
@@ -178,7 +189,7 @@ module Kitchen
       # the directory does not exist
       return [] unless Dir.exist?(path)
 
-      Kitchen.mutex_chdir.synchronize do
+      mutex_chdir.synchronize do
         Dir.chdir(path) do
           glob_pattern = if recurse
                            "**/*"
@@ -214,7 +225,7 @@ module Kitchen
     def self.safe_glob(path, pattern, *flags)
       return [] unless Dir.exist?(path)
 
-      Kitchen.mutex_chdir.synchronize do
+      mutex_chdir.synchronize do
         Dir.chdir(path) do
           Dir.glob(pattern, *flags).map { |f| File.join(path, f) }
         end

--- a/spec/kitchen/require_isolation_spec.rb
+++ b/spec/kitchen/require_isolation_spec.rb
@@ -1,0 +1,56 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative "../spec_helper"
+
+require "open3"
+
+# Every file under lib/ must be loadable on its own.
+#
+# Driver, provisioner, verifier and transport plugins routinely require a
+# single Test Kitchen file (`require "kitchen/shell_out"`) rather than all of
+# `kitchen`. When a file leans on a constant that some *other* file happened to
+# require first, it loads fine inside this suite -- which loads everything --
+# and blows up with a NameError for the plugin author.
+#
+# The suite cannot catch that from inside a single process, so each file is
+# required in a clean subprocess. Subprocesses are I/O bound, so they run on a
+# small thread pool to keep this to roughly a second.
+describe "every file in lib" do
+  def self.lib_dir
+    @lib_dir ||= File.expand_path("../../lib", __dir__)
+  end
+
+  def self.lib_requires
+    Dir.glob("**/*.rb", base: lib_dir).sort.map { |path| path.sub(/\.rb\z/, "") }
+  end
+
+  def self.require_in_clean_process(feature)
+    out, status = Open3.capture2e(
+      Gem.ruby, "-I", lib_dir, "-e", "require #{feature.dump}"
+    )
+    [feature, status.success?, out]
+  end
+
+  # Fan out across the whole graph once, then assert per file, so a broken
+  # require names itself instead of hiding behind the first failure.
+  results = lib_requires.each_slice(24).flat_map do |batch|
+    batch.map { |feature| Thread.new { require_in_clean_process(feature) } }.map(&:value)
+  end
+
+  results.each do |feature, ok, out|
+    it "can require #{feature.inspect} on its own" do
+      _(ok).must_equal true, "`require #{feature.dump}` failed:\n\n#{out}"
+    end
+  end
+end

--- a/spec/kitchen/util_spec.rb
+++ b/spec/kitchen/util_spec.rb
@@ -18,6 +18,7 @@
 require_relative "../spec_helper"
 
 require "logger"
+require "open3"
 
 require "kitchen/util"
 
@@ -264,6 +265,34 @@ describe Kitchen::Util do
       dne_dir = File.join(@root, "notexist")
       _(Kitchen::Util.safe_glob(dne_dir, "**/*"))
         .must_equal Dir.glob(File.join(dne_dir, "**/*"))
+    end
+  end
+
+  # Kitchen::Util is required directly by driver, provisioner and verifier
+  # plugins, so it has to stand on its own without lib/kitchen.rb being
+  # loaded first. These run in a subprocess because the rest of the suite has
+  # already loaded the whole library into this process.
+  describe "when required on its own" do
+    def run_in_clean_process(code)
+      Open3.capture2e(
+        Gem.ruby, "-I", File.expand_path("../../lib", __dir__), "-e", code
+      ).first
+    end
+
+    it "can call .list_directory without kitchen.rb being loaded" do
+      out = run_in_clean_process(
+        'require "kitchen/util"; Kitchen::Util.list_directory("."); print "OK"'
+      )
+
+      _(out).must_equal "OK"
+    end
+
+    it "can call .safe_glob without kitchen.rb being loaded" do
+      out = run_in_clean_process(
+        'require "kitchen/util"; Kitchen::Util.safe_glob(".", "*"); print "OK"'
+      )
+
+      _(out).must_equal "OK"
     end
   end
 end


### PR DESCRIPTION
## Problem

Plugins commonly require a single Test Kitchen file rather than all of `kitchen` — a driver doing `require "kitchen/shell_out"` to pick up the mixin, for example. Three files leaned on a constant that some *other* file happened to load first. They work inside our test suite, which loads the entire library into one process, and raise for anyone requiring them directly:

```ruby
require "kitchen/shell_out"
#=> NameError: uninitialized constant Kitchen::ShellOut::TransientFailure

require "kitchen/instance"
#=> NameError: uninitialized constant Kitchen::Instance::Logging

require "kitchen/util"
Kitchen::Util.list_directory(".")
#=> NoMethodError: undefined method 'mutex_chdir' for module Kitchen
```

`kitchen/shell_out` and `kitchen/instance` were each missing a `require`. Because `shell_out` is itself required by others, it also broke `kitchen/lifecycle_hook/local` and `kitchen/transport/exec` — 4 of 69 files under `lib/` could not be loaded standalone.

## `Kitchen::Util` is a different bug

Not a missing require — a misplaced helper. `Kitchen::Util.list_directory` and `.safe_glob` synchronize on `Kitchen.mutex_chdir`, but that mutex was created at the *bottom* of `lib/kitchen.rb`:

```ruby
require_relative "kitchen/util"   # line 25
# ...144 lines later...
Kitchen.mutex_chdir = Mutex.new   # line 169
```

So even on the normal full-load path, `Kitchen::Util` was defined long before the mutex it depends on existed. It only worked because nothing calls into those methods during load. Required on its own, line 169 never runs at all.

`Util` is the mutex's only consumer, so it now owns it. `Kitchen.mutex_chdir` reads and writes that same mutex and is unchanged for callers — same object, one lock, so `Dir.chdir` serialization is preserved:

```ruby
Kitchen.mutex_chdir.equal?(Kitchen::Util.mutex_chdir)  #=> true
```

## Regression test

A suite that loads the whole library into a single process is structurally incapable of catching this, so `spec/kitchen/require_isolation_spec.rb` requires every file under `lib/` in a clean subprocess. It fails on `main` naming all 4 broken files, and passes here. Subprocesses are I/O bound so they run on a small thread pool — about 4s for all 69.

## Verification

- `rake unit`: 1794 runs, 2771 assertions, 0 failures, 0 errors (was 1723 before the new specs)
- `cookstyle --chefstyle`: 82 files, no offenses
- `rake yard`: 100% documented, unchanged