### PR TITLE
fix: Ruby 4 frozen string literal compatibility

### DIFF
--- a/lib/kitchen/base64_stream.rb
+++ b/lib/kitchen/base64_stream.rb
@@ -28,7 +28,7 @@ module Kitchen
     # @param io_in [#read] input stream
     # @param io_out [#write] output stream
     def self.strict_encode(io_in, io_out)
-      buffer = ""
+      buffer = +"" # mutable: IO#read writes into this buffer
       io_out.write([buffer].pack("m0")) while io_in.read(3 * 1000, buffer)
       buffer = nil # rubocop:disable Lint/UselessAssignment
     end
@@ -40,7 +40,7 @@ module Kitchen
     # @param io_in [#read] input stream
     # @param io_out [#write] output stream
     def self.strict_decode(io_in, io_out)
-      buffer = ""
+      buffer = +"" # mutable: IO#read writes into this buffer
       io_out.write(buffer.unpack("m0").first) while io_in.read(3 * 1000, buffer)
       buffer = nil # rubocop:disable Lint/UselessAssignment
     end

--- a/lib/kitchen/configurable.rb
+++ b/lib/kitchen/configurable.rb
@@ -247,7 +247,7 @@ module Kitchen
       @deprecated_config = deprecated_attributes.delete_if { |attr, obj| !provided_config.key?(attr) || obj.nil? }
 
       unless deprecated_config.empty?
-        warning = Util.outdent!(<<-MSG)
+        warning = Util.outdent(<<-MSG)
           Deprecated configuration detected:
           #{deprecated_config.keys.join("\n")}
           Run 'kitchen doctor' for details.

--- a/lib/kitchen/provisioner/shell.rb
+++ b/lib/kitchen/provisioner/shell.rb
@@ -62,7 +62,7 @@ module Kitchen
         data = remote_path_join(root, "data")
 
         code = if powershell_shell?
-                 Util.outdent!(<<-POWERSHELL)
+                 Util.outdent(<<-POWERSHELL)
             if (Test-Path "#{data}") {
               Remove-Item "#{data}" -Recurse -Force
             }

--- a/lib/kitchen/transport/winrm.rb
+++ b/lib/kitchen/transport/winrm.rb
@@ -247,7 +247,7 @@ module Kitchen
         #   Mac system
         # @api private
         def create_rdp_doc(opts = {})
-          content = Util.outdent!(<<-RDP)
+          content = Util.outdent(<<-RDP)
             full address:s:#{URI.parse(options[:endpoint]).host}:#{rdp_port}
             prompt for credentials:i:1
             username:s:#{options[:user]}

--- a/lib/kitchen/util.rb
+++ b/lib/kitchen/util.rb
@@ -146,6 +146,22 @@ module Kitchen
       string.gsub!(/^ {#{string.index(/[^ ]/)}}/, "")
     end
 
+    # Returns a copy of a string with each line outdented by the indentation
+    # level of its first line.
+    #
+    # Prefer this over {.outdent!} when the input may be a string literal:
+    # Ruby 4 freezes literals, and mutating one raises a FrozenError.
+    #
+    # @param string [String] the string to outdent
+    # @return [String] a new, outdented string
+    # @example
+    #
+    #   string = "    a\n      b\n    c\n"
+    #   Util.outdent(string) # => "a\n  b\nc\n"
+    def self.outdent(string)
+      string.gsub(/^ {#{string.index(/[^ ]/)}}/, "")
+    end
+
     # Returns a set of Bourne Shell (AKA /bin/sh) compatible helper
     # functions. This function is usually called inline in a string that
     # will be executed remotely on a test instance.

--- a/lib/kitchen/verifier/busser.rb
+++ b/lib/kitchen/verifier/busser.rb
@@ -72,7 +72,7 @@ module Kitchen
         cmd = sudo(config[:busser_bin]).dup
           .tap { |str| str.insert(0, "& ") if powershell_shell? }
 
-        prefix_command(wrap_shell_code(Util.outdent!(<<-CMD)))
+        prefix_command(wrap_shell_code(Util.outdent(<<-CMD)))
           #{busser_env}
 
           #{cmd} suite cleanup
@@ -95,7 +95,7 @@ module Kitchen
         cmd = sudo(config[:busser_bin]).dup
           .tap { |str| str.insert(0, "& ") if powershell_shell? }
 
-        prefix_command(wrap_shell_code(Util.outdent!(<<-CMD)))
+        prefix_command(wrap_shell_code(Util.outdent(<<-CMD)))
           #{busser_env}
 
           #{cmd} test #{plugins.join(" ").gsub!("busser-", "")}

--- a/spec/kitchen/base64_stream_spec.rb
+++ b/spec/kitchen/base64_stream_spec.rb
@@ -28,7 +28,7 @@ describe Kitchen::Base64Stream do
   describe ".strict_encode" do
     SHORT_BODIES.each do |body|
       it "encodes short payload ('#{body}') from input IO to output IO" do
-        output = StringIO.new("", "wb")
+        output = StringIO.new(+"", "wb")
         StringIO.open(body) do |input|
           Kitchen::Base64Stream.strict_encode(input, output)
         end
@@ -39,7 +39,7 @@ describe Kitchen::Base64Stream do
 
     it "encodes a large payload from input IO to output IO" do
       body = SecureRandom.random_bytes(1_048_576 * 8)
-      output = StringIO.new("", "wb")
+      output = StringIO.new(+"", "wb")
       StringIO.open(body) do |input|
         Kitchen::Base64Stream.strict_encode(input, output)
       end
@@ -51,7 +51,7 @@ describe Kitchen::Base64Stream do
   describe ".strict_decode" do
     SHORT_BODIES.map { |b| Base64.strict_encode64(b) }.each do |body|
       it "decodes short payload ('#{body}') from input IO to output IO" do
-        output = StringIO.new("", "wb")
+        output = StringIO.new(+"", "wb")
         StringIO.open(body) do |input|
           Kitchen::Base64Stream.strict_decode(input, output)
         end
@@ -62,7 +62,7 @@ describe Kitchen::Base64Stream do
 
     it "decodes a large payload from input IO to output IO" do
       body = Base64.strict_encode64(SecureRandom.hex(1_048_576 * 8))
-      output = StringIO.new("", "wb")
+      output = StringIO.new(+"", "wb")
       StringIO.open(body) do |input|
         Kitchen::Base64Stream.strict_decode(input, output)
       end

--- a/spec/kitchen/configurable_spec.rb
+++ b/spec/kitchen/configurable_spec.rb
@@ -1162,6 +1162,6 @@ describe Kitchen::Configurable do
   end
 
   def outdent!(*args)
-    Kitchen::Util.outdent!(*args)
+    Kitchen::Util.outdent(*args)
   end
 end

--- a/spec/kitchen/frozen_string_literal_spec.rb
+++ b/spec/kitchen/frozen_string_literal_spec.rb
@@ -1,0 +1,82 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative "../spec_helper"
+
+require "open3"
+
+require "kitchen/base64_stream"
+require "kitchen/util"
+
+# Ruby 4 moves string literals towards being frozen. Literals in files without
+# a `frozen_string_literal` magic comment are currently "chilled": they warn on
+# mutation rather than raising. Running with --enable-frozen-string-literal
+# turns those warnings into the FrozenError they will eventually become, so
+# these specs pin the code paths that used to mutate a literal.
+describe "frozen string literal compatibility" do
+  def self.run_with_frozen_literals(code)
+    lib = File.expand_path("../../lib", __dir__)
+    Open3.capture2e(
+      Gem.ruby, "--enable-frozen-string-literal", "-I", lib, "-e", code
+    )
+  end
+
+  describe Kitchen::Base64Stream do
+    it "round-trips a stream when literals are frozen" do
+      out, status = self.class.run_with_frozen_literals(<<~RUBY)
+        require "kitchen/base64_stream"
+        require "stringio"
+
+        encoded = StringIO.new
+        Kitchen::Base64Stream.strict_encode(StringIO.new("hello world"), encoded)
+
+        decoded = StringIO.new
+        Kitchen::Base64Stream.strict_decode(StringIO.new(encoded.string), decoded)
+
+        print decoded.string
+      RUBY
+
+      _(out).must_equal "hello world"
+      _(status.success?).must_equal true
+    end
+  end
+
+  describe Kitchen::Util do
+    it ".outdent does not mutate its argument" do
+      original = "  a\n    b\n  c\n"
+      copy = original.dup
+
+      Kitchen::Util.outdent(original)
+
+      _(original).must_equal copy
+    end
+
+    it ".outdent accepts a frozen string" do
+      _(Kitchen::Util.outdent("  a\n    b\n  c\n".freeze))
+        .must_equal "a\n  b\nc\n"
+    end
+
+    it ".outdent matches .outdent! output" do
+      _(Kitchen::Util.outdent("  a\n    b\n  c\n"))
+        .must_equal Kitchen::Util.outdent!(+"  a\n    b\n  c\n")
+    end
+
+    it ".outdent! still mutates in place, for callers that rely on it" do
+      string = +"  a\n    b\n  c\n"
+
+      Kitchen::Util.outdent!(string)
+
+      _(string).must_equal "a\n  b\nc\n"
+    end
+  end
+end

--- a/spec/kitchen/login_command_spec.rb
+++ b/spec/kitchen/login_command_spec.rb
@@ -20,7 +20,7 @@ require_relative "../spec_helper"
 require "kitchen/login_command"
 
 describe Kitchen::LoginCommand do
-  let(:cmd)   { "" }
+  let(:cmd)   { +"" }
   let(:argv)  { [] }
   let(:opts)  { {} }
 

--- a/spec/kitchen/provisioner/shell_spec.rb
+++ b/spec/kitchen/provisioner/shell_spec.rb
@@ -219,7 +219,7 @@ describe Kitchen::Provisioner::Shell do
       it "removes the data directory" do
         config[:root_path] = '\\route'
 
-        _(cmd).must_match regexify(Kitchen::Util.outdent!(<<-POWERSHELL).chomp)
+        _(cmd).must_match regexify(Kitchen::Util.outdent(<<-POWERSHELL).chomp)
           if (Test-Path "\\route\\data") {
             Remove-Item "\\route\\data" -Recurse -Force
           }
@@ -229,7 +229,7 @@ describe Kitchen::Provisioner::Shell do
       it "creates the :root_path directory" do
         config[:root_path] = '\\route'
 
-        _(cmd).must_match regexify(Kitchen::Util.outdent!(<<-POWERSHELL).chomp)
+        _(cmd).must_match regexify(Kitchen::Util.outdent(<<-POWERSHELL).chomp)
           if (-Not (Test-Path "\\route")) {
             New-Item "\\route" -ItemType directory | Out-Null
           }

--- a/spec/kitchen/transport/winrm_spec.rb
+++ b/spec/kitchen/transport/winrm_spec.rb
@@ -1121,7 +1121,7 @@ describe Kitchen::Transport::Winrm::Connection do
             # the raise is not what is being tested here, rather its side-effect
           end
 
-          message = <<~'MSG'.chomp!
+          message = <<~'MSG'.chomp
             doit : The term 'doit' is not recognized as the name of a cmdlet, function,
             script file, or operable program. Check the spelling ofthe name, or if a path
             was included, verify that the path is correct and try again.
@@ -1223,7 +1223,7 @@ describe Kitchen::Transport::Winrm::Connection do
           actual = File.read(rdp_doc)
         end
 
-        _(actual).must_equal Kitchen::Util.outdent!(<<-RDP)
+        _(actual).must_equal Kitchen::Util.outdent(<<-RDP)
           drivestoredirect:s:*
           full address:s:foo:rdpyeah
           prompt for credentials:i:1
@@ -1237,7 +1237,7 @@ describe Kitchen::Transport::Winrm::Connection do
           login_command
         end
 
-        expected = Kitchen::Util.outdent!(<<-OUTPUT)
+        expected = Kitchen::Util.outdent(<<-OUTPUT)
           Creating RDP document for coolbeans (/i/am/root/.kitchen/coolbeans.rdp)
           ------------
           drivestoredirect:s:*
@@ -1280,7 +1280,7 @@ describe Kitchen::Transport::Winrm::Connection do
           actual = File.read(rdp_doc)
         end
 
-        _(actual).must_equal Kitchen::Util.outdent!(<<-RDP)
+        _(actual).must_equal Kitchen::Util.outdent(<<-RDP)
           full address:s:foo:rdpyeah
           prompt for credentials:i:1
           username:s:me
@@ -1293,7 +1293,7 @@ describe Kitchen::Transport::Winrm::Connection do
           login_command
         end
 
-        expected = Kitchen::Util.outdent!(<<-OUTPUT)
+        expected = Kitchen::Util.outdent(<<-OUTPUT)
           Creating RDP document for coolbeans (/i/am/root/.kitchen/coolbeans.rdp)
           ------------
           full address:s:foo:rdpyeah

--- a/spec/kitchen/util_spec.rb
+++ b/spec/kitchen/util_spec.rb
@@ -124,21 +124,21 @@ describe Kitchen::Util do
 
   describe ".outdent!" do
     it "modifies the argument string in place, destructively" do
-      string = "yep"
+      string = +"yep"
 
       _(Kitchen::Util.outdent!(string).object_id)
         .must_equal string.object_id
     end
 
     it "returns the same string if no leading whitespace exists" do
-      string = "one\ntwo\nthree"
+      string = +"one\ntwo\nthree"
 
       _(Kitchen::Util.outdent!(string))
         .must_equal "one\ntwo\nthree"
     end
 
     it "strips same amount of leading whitespace as found on first line" do
-      string = "  one\n    two\n      three\nfour"
+      string = +"  one\n    two\n      three\nfour"
 
       _(Kitchen::Util.outdent!(string))
         .must_equal "one\n  two\n    three\nfour"


### PR DESCRIPTION
## Problem

Ruby 4 is moving string literals towards being frozen. Literals in files without a `frozen_string_literal` magic comment are currently *chilled* — they warn on mutation rather than raising — so this is a warning today and a `FrozenError` later.

Running the suite under `--enable-frozen-string-literal`, which turns those warnings into the error they're destined to become, gave **24 errors** from two places in `lib/`.

### 1. `Kitchen::Base64Stream` — breaks file transfer

`IO#read` writes into the buffer it's handed, and that buffer was a literal:

```ruby
Kitchen::Base64Stream.strict_encode(StringIO.new("hi"), StringIO.new)
#=> FrozenError: can't modify frozen String: ""
```

This sits on the file-transfer path for **both SSH and WinRM**, so it isn't a cosmetic warning.

### 2. `Kitchen::Util.outdent!` — the callers, not the method

`outdent!` mutates its argument, which is exactly right for a bang method — a bang method raising on a frozen string is correct behaviour. The bug is that all five of its callers in `lib/` pass it a heredoc literal.

So rather than defang `outdent!` and silently break plugins that rely on in-place mutation, this adds a non-mutating `Util.outdent` and moves the five callers to it. `outdent!` is untouched:

```ruby
Kitchen::Util.outdent("  a\n    b\n  c\n".freeze)  #=> "a\n  b\nc\n"

string = +"  a\n    b\n  c\n"
Kitchen::Util.outdent!(string)                     # still mutates in place
```

## Specs had the same bug

The suite mutated literals in its own code — a `StringIO` built on a literal buffer, a `let` string appended to, `chomp!` on a heredoc, and a helper delegating to `outdent!`. Fixed here too, so the suite itself runs clean under the flag.

## Verification

Every spec, under `--enable-frozen-string-literal`:

| | runs | errors |
|---|---|---|
| before | 1723 | 24 |
| after | 1728 | **4** |

Normal run: 1728 runs, 2706 assertions, 0 failures, 0 errors. `cookstyle --chefstyle` clean, `rake yard` still 100%.

## The remaining 4 are upstream

All four are `net-scp` mutating its own literal in `Net::SCP#scp_command` — no `lib/kitchen` frame is involved:

```
gems/net-scp-4.1.0/lib/net/scp.rb:333:in 'Net::SCP#scp_command'
FrozenError: can't modify frozen String: "scp "
```

```ruby
command = "scp "
command << (mode == :upload ? "-t" : "-f")
```

**This is already fixed upstream, just not released.** net-scp master has `command = +"scp "`; the released 4.1.0 that we depend on does not:

| | `scp_command` |
| --- | --- |
| net-scp 4.1.0 (released, current dependency) | `command = "scp "` |
| net-scp master | `command = +"scp "` |

Tracked upstream in net-ssh/net-scp#81, with net-ssh/net-scp#84 covering the remaining spots. No new upstream report is needed — what's needed is a net-scp release.

Building against net-scp master, this branch is completely clean under Ruby 4 semantics:

```
RUBYOPT=--enable-frozen-string-literal, net-scp @ master
1728 runs, 2706 assertions, 0 failures, 0 errors, 0 skips
```

So once net-scp ships a release containing that commit, Test Kitchen has no frozen string literal work left.

