### PR TITLE
chore: ignore the bundler vendor directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.gem
 *.rbc
 .bundle
+vendor/
 .config
 .yardoc
 binstubs


### PR DESCRIPTION
Running `bundle install --path vendor/bundle` drops installed gems into `vendor/`, which then shows up as untracked noise in `git status` and risks being accidentally staged.

Ignore it alongside the existing `.bundle` entry.

The trailing slash keeps the rule directory-only. Since `vendor/` was never tracked, no `git rm --cached` is needed for this to take effect.