### PR TITLE
perf: define the LazyHash methods that Configurable actually calls

### DIFF
--- a/lib/kitchen/lazy_hash.rb
+++ b/lib/kitchen/lazy_hash.rb
@@ -95,6 +95,41 @@ module Kitchen
       end
     end
 
+    # Sets the raw value for the given key. Values are stored unrendered, so a
+    # callable assigned here is still evaluated lazily on read.
+    #
+    # SimpleDelegator would forward this through #method_missing; defining it
+    # here keeps the hot path off that dispatch, which every plugin walks once
+    # per default attribute while applying its defaults.
+    #
+    # @param key [Object] hash key
+    # @param value [Object] the value to store
+    # @return [Object] the stored value
+    def []=(key, value)
+      __getobj__[key] = value
+    end
+
+    # Returns whether the given key is present, without rendering its value.
+    #
+    # Defined for the same reason as {#[]=}: to bypass SimpleDelegator's
+    # #method_missing on a hot path.
+    #
+    # @param key [Object] hash key
+    # @return [Boolean] whether the key is present
+    def key?(key)
+      __getobj__.key?(key)
+    end
+
+    # Returns the keys of the underlying hash.
+    #
+    # Defined for the same reason as {#[]=}: to bypass SimpleDelegator's
+    # #method_missing on a hot path.
+    #
+    # @return [Array] the hash keys
+    def keys
+      __getobj__.keys
+    end
+
     # Returns a new Hash with all keys and rendered values of the LazyHash.
     #
     # @return [Hash] a new hash

--- a/spec/kitchen/lazy_hash_spec.rb
+++ b/spec/kitchen/lazy_hash_spec.rb
@@ -73,6 +73,59 @@ describe Kitchen::LazyHash do
     end
   end
 
+  describe "#[]=" do
+    it "stores a regular value" do
+      subject = Kitchen::LazyHash.new(hash_obj, context)
+      subject[:new_key] = "fresh"
+
+      _(subject[:new_key]).must_equal "fresh"
+    end
+
+    it "stores the value unrendered so callables stay lazy" do
+      subject = Kitchen::LazyHash.new(hash_obj, context)
+      subject[:late] = ->(c) { c.color }
+
+      _(subject[:late]).must_equal "blue"
+    end
+
+    it "writes through to the underlying hash" do
+      subject = Kitchen::LazyHash.new(hash_obj, context)
+      subject[:barn] = "open"
+
+      _(hash_obj[:barn]).must_equal "open"
+    end
+  end
+
+  describe "#key?" do
+    it "is true for a key that is set" do
+      _(Kitchen::LazyHash.new(hash_obj, context).key?(:barn)).must_equal true
+    end
+
+    it "is false for a key that is not set" do
+      _(Kitchen::LazyHash.new(hash_obj, context).key?(:nope)).must_equal false
+    end
+
+    it "does not invoke a callable value" do
+      called = false
+      subject = Kitchen::LazyHash.new({ trap: ->(_c) { called = true } }, context)
+
+      _(subject.key?(:trap)).must_equal true
+      _(called).must_equal false
+    end
+  end
+
+  describe "#keys" do
+    it "returns the underlying keys without rendering values" do
+      called = false
+      subject = Kitchen::LazyHash.new(
+        { barn: "locked", trap: ->(_c) { called = true } }, context
+      )
+
+      _(subject.keys).must_equal %i{barn trap}
+      _(called).must_equal false
+    end
+  end
+
   describe "#to_hash" do
     it "invokes any callable values and returns a Hash object" do
       converted = Kitchen::LazyHash.new(hash_obj, context).to_hash


### PR DESCRIPTION
## Summary

`LazyHash` subclasses `SimpleDelegator` and overrides `#[]` and `#fetch`, but left `#[]=`, `#key?`, and `#keys` to `Delegator#method_missing`. Those three are exactly what `Configurable#init_config` uses when a plugin applies its defaults:

```ruby
def init_config(config)
  @config = LazyHash.new(config, self)
  @provided_config = config.dup
  self.class.defaults.each do |attr, value|
    @config[attr] = value unless @config.key?(attr)   # both fall through method_missing
  end
end
```

That loop runs once per default attribute, per plugin, per instance — and every `kitchen` subcommand builds every instance before it can filter them.

Instrumenting `LazyHash#method_missing` on a 100-instance project shows what falls through, and it is only these three:

| method | calls per config build |
| --- | --- |
| `[]=` | 3,100 |
| `key?` | 3,000 |
| `keys` | 500 (via `kitchen diagnose`) |

`Delegator#method_missing` is one of the more expensive dispatch paths in Ruby: `__getobj__`, then `target_respond_to?`, then `__send__`, plus a splat array for the arguments. It also resolves constants through `Delegator.const_missing`, so the same build made **6,107** `const_missing(:Object)` lookups — one per fallthrough.

Forwarding the three methods to the delegated hash directly is semantically identical (`method_missing` was already forwarding to the same receiver) and removes the dispatch entirely. Instrumentation after the change reports zero fallthroughs.

## Benchmark

Building a full `Kitchen::Config` — loader, data munging, and every instance with its plugins — on synthetic projects. Best of 7, after 3 warm-up builds. `before` and `after` were produced by stashing and restoring the patch in the same working tree, with a `grep` guard asserting which version was loaded before each arm.

| instances | before | after | speedup |
| --- | --- | --- | --- |
| 20 | 0.0041s | 0.0036s | 1.14x |
| 100 | 0.0181s | 0.0157s | 1.15x |
| 300 | 0.0586s | 0.0528s | 1.11x |

Allocations for the 100-instance build, `GC.stat(:total_allocated_objects)` with GC disabled:

| | objects |
| --- | --- |
| before | 47,990 |
| after | 41,890 |
| **difference** | **−6,100 (−12.7%)** |

The 6,100 saved objects match the 6,100 eliminated dispatches exactly — one args array per `method_missing` splat.

This is a modest absolute saving (a few milliseconds), but it is free: no behaviour change and less garbage on a path every subcommand walks.

## Correctness

- `#[]=` stores the value **unrendered**, so a callable assigned through it is still evaluated lazily on read — matching what `method_missing` did by forwarding to the underlying `Hash#[]=`.
- `#key?` and `#keys` deliberately do **not** render values; specs assert that a callable value is not invoked by either.
- New specs cover write-through to the underlying hash, lazy storage of callables, `key?` presence/absence, `key?` not invoking a callable, and `keys` not rendering. They **pass against both the old and the new implementation**, so they are regression tests rather than tests fitted to the change.
- `bundle exec rake unit` — 1,806 runs, 2,786 assertions, 0 failures. `bundle exec rake style` — clean.

## Note for reviewers

`LazyHash` includes `Enumerable`, so `#include?` resolves to `Enumerable#include?` (which iterates and renders) rather than `Hash#include?`. That predates this change and I have left it alone, but it is worth knowing if anyone adds a membership check on a config hash.
