### PR TITLE
perf: cut a syscall and two allocations per structured log event

### DIFF
--- a/lib/kitchen/logger.rb
+++ b/lib/kitchen/logger.rb
@@ -312,8 +312,10 @@ module Kitchen
 
     # @return [Hash] metadata added to structured log events
     def metadata
-      metadata_stack.inject(@base_metadata.dup) do |result, values|
-        result.merge(values)
+      # Merge in place into the fresh dup rather than allocating a new hash per
+      # stack entry; this runs once per structured log event.
+      metadata_stack.each_with_object(@base_metadata.dup) do |values, result|
+        result.merge!(values)
       end
     end
 
@@ -808,9 +810,11 @@ module Kitchen
             message: message.to_s,
             progname:,
             sequence: next_sequence
-          ).compact
-          @logdev.write(JSON.generate(event))
-          @logdev.write("\n")
+          )
+          event.compact!
+          # One writev rather than two writes: the log device is opened with
+          # sync = true, so each call is a syscall.
+          @logdev.write(JSON.generate(event), "\n")
         end
         true
       end

--- a/spec/kitchen/logger_spec.rb
+++ b/spec/kitchen/logger_spec.rb
@@ -456,6 +456,31 @@ describe Kitchen::Logger do
         .must_equal %w{banner stream stream stream stream}
     end
 
+    it "layers nested metadata scopes with the innermost winning" do
+      logger.with_metadata(action: "create", depth: "outer") do
+        logger.with_metadata(depth: "inner") do
+          logger.info("nested")
+        end
+        logger.info("outer only")
+      end
+
+      nested, outer = structured_events(structured_logdev)
+      _(nested["action"]).must_equal "create"
+      _(nested["depth"]).must_equal "inner"
+      _(outer["depth"]).must_equal "outer"
+    end
+
+    it "does not let a metadata scope mutate the base metadata" do
+      logger.with_metadata(instance: "overridden") do
+        logger.info("inside")
+      end
+      logger.info("after")
+
+      inside, after = structured_events(structured_logdev)
+      _(inside["instance"]).must_equal "overridden"
+      _(after["instance"]).must_equal "default-ubuntu-2404"
+    end
+
     it "applies temporary metadata to structured events" do
       logger.with_metadata(instance_session_id: "session-123", action: "create") do
         logger.info("inside action")


### PR DESCRIPTION
## Summary

`Kitchen::Config#new_instance_logger` gives **every** instance a `structured_logdev`, so `StructuredLogdevLogger#write_event` runs once per log call and once per streamed line. A profile of a full `test` action pipeline (create/converge/verify/destroy against the dummy driver) put 61% of all `IO#write` samples in this one method.

Three costs were paid on every event:

**Two syscalls per event.** `DeviceFactory#resolve_logdev` opens the log file with `sync = true`, so each `write` is a real syscall — and the event was written in two calls:

```ruby
@logdev.write(JSON.generate(event))
@logdev.write("\n")
```

`IO#write` accepts multiple arguments and emits a single `writev(2)`, which also avoids allocating the concatenated string that `write("#{json}\n")` would build. `StringIO#write` honours the same multi-arg contract, so the specs' StringIO sinks are unaffected.

**A throwaway hash from `.compact`.** The receiver comes straight out of `#merge`, so it is already private to the method and can be compacted in place with `compact!`.

**A hash per metadata scope.** `#metadata` folded the `with_metadata` stack with `inject` + `#merge`, allocating a fresh hash per entry. `each_with_object` + `#merge!` mutates the fresh `@base_metadata.dup` instead, so the cost no longer scales with nesting depth.

## Benchmark

20,000 events streamed through a real `Kitchen::Logger` whose structured sink is a real file with `sync = true` (a StringIO would hide the syscall cost, which is the point of the change). Five before/after alternations, best-of-5 within each; `before` and `after` produced by stashing and restoring the patch in the same working tree.

| | min | median |
| --- | --- | --- |
| before | 0.1893s | 0.1952s |
| after | 0.1481s | 0.1492s |
| **speedup** | **1.28x** | **1.31x** |

Allocations for the same run, `GC.stat(:total_allocated_objects)` with GC disabled:

| | objects |
| --- | --- |
| before | 560,415 |
| after | 520,415 |
| **difference** | **−40,000 (2 per event)** |

Attributing the two, measured in isolation:

| change | objects/call before | after |
| --- | --- | --- |
| `.compact` → `compact!` | 3.0 | 2.0 |
| metadata fold, stack depth 0 | 3.0 | 2.0 |
| metadata fold, stack depth 1 | 4.0 | 2.0 |
| metadata fold, stack depth 2 | 5.0 | 2.0 |

The write consolidation contributes no allocation saving — measured at 4.0 objects/call either way. Its win is the syscall, which is where most of the wall-clock difference comes from.

## Correctness

- Output is byte-identical: the randomized stream harness (every prefix plus near-misses, UTF-8, empty lines, unterminated tails, random 1–2048 byte chunk boundaries) replayed through the stdout, logdev, and structured sinks produces identical bytes across 4 seeds, timestamps and pids normalized.
- `compact!` returns `nil` when it removes nothing, so it is called as a statement rather than chained.
- New specs pin the nesting semantics the metadata fold touches: an inner `with_metadata` scope overriding an outer key, and a scope overriding a *base* metadata key without leaking past the block. Both **pass against the old and the new implementation**.
- `bundle exec rake unit` — 1,801 runs, 2,782 assertions, 0 failures. `bundle exec rake style` — clean.

## Relationship to #2106

Independent, and both branch from `main`. #2106 rewrites `LineBuffer`/`StreamLineFormatter`; this touches `StructuredLogdevLogger#write_event` and `Logger#metadata`. Different regions of `lib/kitchen/logger.rb`, so they merge in either order. The two compound: #2106 cuts the cost of turning a read into lines, this cuts the cost of recording each one.

## Note for reviewers

While profiling I noticed something outside this PR's scope, worth a separate look: every subcommand builds **all** instances before name filtering, and each instance eagerly opens two log files (`.log` and `.ndjson`). On a 100-instance project `kitchen list` opens — and with `log_overwrite` truncates — 200 files it never writes to. Making the devices open lazily would remove that, but it changes when logs are created and truncated, so it wants a deliberate decision rather than a perf patch.
