### PR TITLE
perf: resolve the console color escapes once per logger, not per line

### DIFF
--- a/lib/kitchen/logger.rb
+++ b/lib/kitchen/logger.rb
@@ -449,15 +449,20 @@ module Kitchen
 
       private
 
+      # Builds the formatter used for console output.
+      #
+      # The colour is fixed for the life of the logger, so both escape
+      # sequences are resolved once here rather than on every line. An
+      # uncolourised logger, and one whose colour did not resolve, share the
+      # same uncoloured formatter.
       def stdout_formatter(color, colorize)
-        if colorize
-          proc do |_severity, _datetime, _progname, msg|
-            Color.colorize(msg.dup.to_s, color).concat("\n")
-          end
+        escape = colorize ? Color.escape(color) : ""
+
+        if escape.empty?
+          proc { |_severity, _datetime, _progname, msg| "#{msg}\n" }
         else
-          proc do |_severity, _datetime, _progname, msg|
-            msg.dup.concat("\n")
-          end
+          reset = Color.escape(:reset)
+          proc { |_severity, _datetime, _progname, msg| "#{escape}#{msg}#{reset}\n" }
         end
       end
 

--- a/spec/kitchen/logger_spec.rb
+++ b/spec/kitchen/logger_spec.rb
@@ -136,6 +136,38 @@ describe Kitchen::Logger do
       _(stdout.string).must_equal "       hello\n"
     end
 
+    it "emits no escape sequences when the color does not resolve" do
+      opts[:color] = :not_a_real_color
+      logger.info("hello")
+
+      _(stdout.string).must_equal "       hello\n"
+    end
+
+    it "emits no escape sequences when the color is nil" do
+      opts[:color] = nil
+      logger.info("hello")
+
+      _(stdout.string).must_equal "       hello\n"
+    end
+
+    it "wraps each line in the color and a reset" do
+      opts[:color] = :cyan
+      logger.info("hello")
+
+      _(stdout.string).must_equal "\e[36m       hello\e[0m\n"
+    end
+
+    it "passes binary stream bytes through unaltered" do
+      opts[:color] = :cyan
+      logger << "caf\xC3\xA9 \xFF\n".dup.force_encoding(Encoding::ASCII_8BIT)
+
+      # \e[36m + seven-space info prefix + the original bytes + \e[0m + newline
+      _(stdout.string.bytes).must_equal(
+        [27, 91, 51, 54, 109] + ([32] * 7) +
+        [99, 97, 102, 195, 169, 32, 255] + [27, 91, 48, 109, 10]
+      )
+    end
+
     describe "for severity" do
       before { opts[:level] = Kitchen::Util.to_logger_level(:debug) }
 


### PR DESCRIPTION
## Summary

Profiling a stdout logger streaming 20,000 lines put **8.3%** of samples in `Kitchen::Color.escape` alone, and 11.5% in `Color.colorize` overall. The reason is that the formatter rebuilt both ANSI escape sequences on every single line:

```ruby
proc do |_severity, _datetime, _progname, msg|
  Color.colorize(msg.dup.to_s, color).concat("\n")
end
```

`Color.colorize` calls `Color.escape` twice — once for the logger's colour, once for `:reset` — and each call does two `ANSI` hash lookups and interpolates a fresh string. Both results are **constant for the life of the logger**: the colour is fixed at construction.

Resolving them once when the formatter is built removes that work from the per-line path entirely. A logger that isn't colourised, and one whose colour doesn't resolve, now share a single uncoloured formatter, which also drops the `dup` and the `concat`.

```ruby
def stdout_formatter(color, colorize)
  escape = colorize ? Color.escape(color) : ""

  if escape.empty?
    proc { |_severity, _datetime, _progname, msg| "#{msg}\n" }
  else
    reset = Color.escape(:reset)
    proc { |_severity, _datetime, _progname, msg| "#{escape}#{msg}#{reset}\n" }
  end
end
```

`Color` itself is untouched — it's public API that plugins call, so the win is taken at the call site rather than by memoising inside it.

## Benchmark

20,000 lines streamed through a real `Kitchen::Logger`, three before/after alternations, best-of-5 within each; `before`/`after` produced by stashing and restoring the patch in the same working tree with a `grep` guard on each arm. Results were stable to ±0.001s across alternations.

| | before | after | speedup |
| --- | --- | --- | --- |
| `colorize: true` | 0.0669s | 0.0571s | **1.17x** |
| `colorize: false` | 0.0555s | 0.0557s | neutral |

Allocations, `GC.stat(:total_allocated_objects)` with GC disabled:

| | before | after | per line |
| --- | --- | --- | --- |
| `colorize: true` | 400,571 | 300,574 | **−5** |
| `colorize: false` | 320,570 | 300,571 | **−1** |

The five saved objects per colourised line are the `dup`, the two escape strings, the intermediate string `colorize` returns, and the `concat` growth.

`colorize: true` is what an interactive terminal gets; `colorize: false` is CI, which keeps its timing and still allocates less.

## Correctness

Output is byte-identical. A randomized stream harness (every log prefix plus near-misses, UTF-8, empty lines, unterminated tails, random 1–1024 byte chunk boundaries) compared the two implementations across **3 seeds × 5 colours × 2 colorize settings** — including `:not_a_color` and `nil` — and produced identical bytes every time.

Behavioural equivalence, branch by branch:

- **valid colour, colorize on** — `"#{esc}#{msg}#{reset}\n"` is exactly what `Color.colorize(...).concat("\n")` built.
- **unresolvable or nil colour, colorize on** — `Color.escape` returns `""`, `Color.colorize` returned `str` untouched, so no escapes were emitted. The new `escape.empty?` branch preserves that; without it the code would have appended a stray reset.
- **colorize off** — `msg.dup.concat("\n")` and `"#{msg}\n"` produce the same String. The interpolation additionally tolerates a non-String message, which the old `concat` form would have raised on; the colourised branch already called `.to_s`, so this makes the two consistent.
- **binary streams** — every literal introduced is 7-bit ASCII, so encoding negotiation adopts the message's encoding rather than forcing UTF-8. Verified byte-for-byte against the old implementation with high-byte binary input, and pinned by a spec.

New specs cover the unresolvable-colour path, the nil-colour path, the exact escape sequences emitted, and binary pass-through. All four **pass against the old and the new implementation**.

`bundle exec rake unit` — 1,803 runs, 2,781 assertions, 0 failures. `bundle exec rake style` — clean.

## Relationship to the other perf PRs

Independent of #2106, #2107 and #2108, and branches from `main` like the rest. This touches `DeviceFactory#stdout_formatter` only; #2106 touches `LineBuffer`/`StreamLineFormatter` and #2108 touches `StructuredLogdevLogger#write_event`/`Logger#metadata`. Different regions of the file, so they merge in any order.

They also compose along one path: #2106 makes turning a read into lines linear, this one makes painting each line cheap, and #2108 makes recording it cheap.
