### PR TITLE
perf: index platform and suite data by name instead of scanning

### DIFF
--- a/lib/kitchen/data_munger.rb
+++ b/lib/kitchen/data_munger.rb
@@ -1037,9 +1037,7 @@ module Kitchen
     #   Hash if not found
     # @api private
     def platform_data_for(name)
-      data.fetch(:platforms, {}).find(-> { {} }) do |platform|
-        platform.fetch(:name, nil) == name
-      end
+      platform_index[name] || {}
     end
 
     # Destructively sets a base kitchen config key/value pair at the root of
@@ -1068,8 +1066,41 @@ module Kitchen
     #   Hash if not found
     # @api private
     def suite_data_for(name)
-      data.fetch(:suites, {}).find(-> { {} }) do |suite|
-        suite.fetch(:name, nil) == name
+      suite_index[name] || {}
+    end
+
+    # Name-keyed index of the platform data, built once on first use.
+    #
+    # Every plugin lookup for every instance resolves a platform and a suite by
+    # name, so the linear scans this replaces made building a project's
+    # instances quadratic in its size.
+    #
+    # @return [Hash{String => Hash}] platform name to platform data
+    # @api private
+    def platform_index
+      @platform_index ||= index_by_name(data.fetch(:platforms, []))
+    end
+
+    # Name-keyed index of the suite data, built once on first use.
+    #
+    # @return [Hash{String => Hash}] suite name to suite data
+    # @api private
+    def suite_index
+      @suite_index ||= index_by_name(data.fetch(:suites, []))
+    end
+
+    # Indexes a collection of named data hashes by their :name value.
+    #
+    # An earlier entry wins over a later duplicate, matching the first match
+    # that a linear search would have returned.
+    #
+    # @param collection [Enumerable<Hash>] platform or suite data
+    # @return [Hash{String => Hash}] name to entry
+    # @api private
+    def index_by_name(collection)
+      collection.each_with_object({}) do |entry, index|
+        key = entry.fetch(:name, nil)
+        index[key] = entry unless index.key?(key)
       end
     end
   end

--- a/spec/kitchen/data_munger_spec.rb
+++ b/spec/kitchen/data_munger_spec.rb
@@ -53,6 +53,54 @@ module Kitchen # rubocop:disable Metrics/ModuleLength
       end
     end
 
+    describe "resolving platforms and suites by name" do
+      it "uses the first entry when a platform name is duplicated" do
+        result = DataMunger.new(
+          driver: "dummy",
+          platforms: [
+            { name: "dupe", driver: { flavor: "first" } },
+            { name: "dupe", driver: { flavor: "second" } },
+          ],
+          suites: [{ name: "default" }]
+        ).driver_data_for("default", "dupe")
+
+        _(result[:flavor]).must_equal "first"
+      end
+
+      it "uses the first entry when a suite name is duplicated" do
+        result = DataMunger.new(
+          driver: "dummy",
+          platforms: [{ name: "plat" }],
+          suites: [
+            { name: "dupe", driver: { flavor: "first" } },
+            { name: "dupe", driver: { flavor: "second" } },
+          ]
+        ).driver_data_for("dupe", "plat")
+
+        _(result[:flavor]).must_equal "first"
+      end
+
+      it "falls back to common data for an unknown platform name" do
+        result = DataMunger.new(
+          driver: { name: "dummy", flavor: "common" },
+          platforms: [{ name: "known" }],
+          suites: [{ name: "default" }]
+        ).driver_data_for("default", "nonexistent")
+
+        _(result[:flavor]).must_equal "common"
+      end
+
+      it "resolves an entry that carries no name under a nil lookup" do
+        result = DataMunger.new(
+          driver: "dummy",
+          platforms: [{ driver: { flavor: "nameless" } }],
+          suites: [{ name: "default" }]
+        ).driver_data_for("default", nil)
+
+        _(result[:flavor]).must_equal "nameless"
+      end
+    end
+
     describe "#suite_data" do
       it "returns an array of suite data" do
         result = DataMunger.new(


### PR DESCRIPTION
## Summary

`DataMunger#platform_data_for` and `#suite_data_for` each ran a linear `Array#find` over the entire platform or suite list on every call:

```ruby
def platform_data_for(name)
  data.fetch(:platforms, {}).find(-> { {} }) do |platform|
    platform.fetch(:name, nil) == name
  end
end
```

Every plugin resolution for every instance calls both — `driver_data_for`, `provisioner_data_for`, `verifier_data_for`, and `transport_data_for` all route through `normalized_platform_data` / `normalized_suite_data`. A project with **P** platforms and **S** suites therefore performs `P × S × 4` lookups, each scanning up to P or S entries: building the instances was quadratic in project size.

A profile of the munger in isolation put **28% of samples in `Array#find`**, with `platform_data_for` and `suite_data_for` together accounting for another 31%.

This indexes both lists by name once, on first use.

## Why memoising is safe here

- `data`, `platform_data_for`, and `suite_data_for` are all **private** (`@api private`), so there is no external mutation path.
- The lists are populated from the loader before any lookup runs. `LegacyConfigNormalizer#normalize!` runs in the constructor and iterates `data.fetch(:platforms, [])` directly — it never calls these lookups, so an index built on first use is never built mid-normalization.
- Normalization mutates the entry **hashes in place**; it never replaces or appends to the lists (no `data[:platforms] =` or `<<` anywhere in the file). The index maps name → the same hash object, so in-place mutation stays visible through it.

## Benchmark

Resolving all four plugins for every suite/platform pair, best of 5, `before`/`after` produced by stashing and restoring the patch in the same working tree with a `grep` guard on each arm.

| suites × platforms | lookups | before | after | speedup |
| --- | --- | --- | --- | --- |
| 10 × 10 | 400 | 0.0013s | 0.0010s | 1.30x |
| 15 × 20 | 1,200 | 0.0043s | 0.0027s | **1.59x** |
| 30 × 30 | 3,600 | 0.0161s | 0.0086s | **1.87x** |

The speedup *growing* with project size is the quadratic term going away.

Munging is only one part of building a config, so the effect on a full `Kitchen::Config` build is more modest — and I would rather state that plainly than quote only the isolated number:

| instances | before | after |
| --- | --- | --- |
| 100 | 0.0192s | 0.0190s (within noise) |
| 300 | 0.0635s | 0.0595s (≈6%) |
| 900 | 0.1969s | 0.1835s (≈7%) |

So: a clear algorithmic fix, worth a few percent on realistic projects today and more as a project grows. The remaining config-build cost is elsewhere (plugin `require` resolution and the per-instance log file opens noted in #2108).

## Correctness

`Array#find` returns the **first** match, so the index deliberately keeps the first entry when a name is duplicated rather than the last:

```ruby
index[key] = entry unless index.key?(key)
```

New specs pin that for both platforms and suites, plus an unknown name falling back to common data, and an entry carrying no `:name` resolving under a `nil` lookup (which `platform.fetch(:name, nil) == nil` matched before). All four **pass against both the old and the new implementation**.

`bundle exec rake unit` — 1,803 runs, 2,781 assertions, 0 failures. `bundle exec rake style` — clean.

## Relationship to the other perf PRs

Independent of #2106, #2107, #2108 and #2109, and branches from `main` like the rest. This is the only one touching `lib/kitchen/data_munger.rb`. I merged all five together locally to confirm they combine cleanly with no conflicts and a green suite.
