### PR TITLE
perf: drop the unused rubygems/gem_runner require

### DIFF
--- a/lib/kitchen/generator/init.rb
+++ b/lib/kitchen/generator/init.rb
@@ -15,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "rubygems/gem_runner"
 require "thor/group"
 
 module Kitchen


### PR DESCRIPTION
## Summary

`lib/kitchen/generator/init.rb` requires `"rubygems/gem_runner"` and never uses it.

```ruby
require "rubygems/gem_runner"   # <- nothing in this file references it
require "thor/group"
```

`grep -rn "Gem::" lib/ spec/ features/ bin/ templates/` finds exactly one hit in the whole project: `Gem::Specification` inside `templates/driver/gemspec.erb`, which is rendered to disk and evaluated by RubyGems in a **separate process** when someone builds the generated gem. Nothing in the running `kitchen` process touches `Gem::GemRunner`, `Gem::Command`, or `Gem::CommandManager`.

`lib/kitchen/cli.rb` requires the generator at load time, so **every** `kitchen` invocation paid for it — `converge`, `verify`, `list`, `test`, all of them — not just `kitchen init`.

Loading it pulls in five files, and RubyGems' vendored `optparse` is not small:

```
rubygems/command.rb
rubygems/command_manager.rb
rubygems/gem_runner.rb
rubygems/vendor/optparse/lib/optparse.rb
rubygems/vendored_optparse.rb
```

## Benchmark

Wall time for `require "kitchen"; require "kitchen/cli"`, fifteen before/after alternations in fresh processes. Process startup is noisy, so all three statistics are reported. Each run asserted which version it loaded (`$LOADED_FEATURES.any? { |f| f.include?("gem_runner") }`) so a mis-selected arm could not pass silently.

| | min | median | mean |
| --- | --- | --- | --- |
| before | 110.9 ms | 129.5 ms | 128.3 ms |
| after | 102.8 ms | 118.1 ms | 116.8 ms |
| **saved** | **8.1 ms** | **11.4 ms** | **11.5 ms** |

`$LOADED_FEATURES` drops from **307 files to 302**.

That is roughly 9% off require time on every invocation, for deleting one line.

## Correctness

- `bundle exec ruby -Ilib -e 'require "kitchen/generator/init"'` still loads standalone, which the repo cares about after #2100.
- `bundle exec rake unit` — 1,799 runs, 2,777 assertions, 0 failures.
- `bundle exec rake style` — clean.
- `bundle exec rake features`, which exercises `kitchen init` end to end, reports **identical** results before and after: 61 scenarios (1 undefined, 60 passed), 327 steps (7 skipped, 1 undefined, 319 passed). I ran it on both sides specifically to confirm the one undefined step is pre-existing and unrelated.

## Relationship to the other perf PRs

Independent of #2106–#2110 and branches from `main` like the rest; it is the only one touching `lib/kitchen/generator/init.rb`.
