### PR TITLE
docs: use Cinc in the homepage example and install guide

### DIFF
--- a/docs/content/docs/getting-started/01-installing.md
+++ b/docs/content/docs/getting-started/01-installing.md
@@ -47,7 +47,7 @@ VirtualBox is a popular open-source hypervisor that enables you to run multiple 
 
 ```bash
 $ VBoxManage --version
-7.1.8r168469
+7.2.16r174877
 ```
 
 ##### Vagrant
@@ -56,7 +56,7 @@ Vagrant acts as a wrapper for hypervisors like VirtualBox, simplifying the proce
 
 ```bash
 $ vagrant --version
-Vagrant 2.4.7
+Vagrant 2.4.9
 ```
 
 With Test Kitchen, VirtualBox, and Vagrant installed, you're ready to create a local virtual machine. By default, `kitchen init` generates a `kitchen-vagrant` driver configuration and a shell provisioner. This guide uses Vagrant with VirtualBox for virtualization, and Cinc Workstation for the cookbook examples.

--- a/docs/content/docs/getting-started/01-installing.md
+++ b/docs/content/docs/getting-started/01-installing.md
@@ -23,7 +23,9 @@ Unfortunately Hyper-V doesn't like other hypervisors running at the same time an
 
 ##### Test Kitchen and Workstation tooling
 
-Install Test Kitchen from RubyGems, your system packages, [Cinc Workstation](https://cinc.sh/start/workstation/), or [Chef Workstation](https://www.chef.io/downloads). Test Kitchen itself does not bundle Chef or Cinc tooling. When you use a Workstation package, the available drivers, provisioners, verifiers, and Chef-compatible commands are the ones bundled by that package.
+Install Test Kitchen from RubyGems, your system packages, or [Cinc Workstation](https://cinc.sh/start/workstation/). This guide uses Cinc Workstation, the community distribution, which bundles Test Kitchen along with the drivers, provisioners, and verifiers you need to follow along.
+
+Test Kitchen itself does not bundle Cinc or Chef tooling. When you use a Workstation package, the available drivers, provisioners, verifiers, and commands are the ones bundled by that package. [Chef Workstation](https://www.chef.io/downloads) works the same way — substitute `chef` for `cinc` in the commands below, and `chef_infra` for `cinc_infra` in the examples.
 
 For a RubyGems install:
 
@@ -36,7 +38,7 @@ Test Kitchen version 4.0.0
 For a Workstation install, use the Workstation command to see what it bundles:
 
 ```bash
-$ chef --version
+$ cinc --version
 ```
 
 ##### VirtualBox
@@ -57,9 +59,9 @@ $ vagrant --version
 Vagrant 2.4.7
 ```
 
-With Test Kitchen, VirtualBox, and Vagrant installed, you're ready to create a local virtual machine. By default, `kitchen init` generates a `kitchen-vagrant` driver configuration and a shell provisioner. This guide uses Vagrant with VirtualBox for virtualization, and a Chef-compatible Workstation environment for the Chef Infra examples.
+With Test Kitchen, VirtualBox, and Vagrant installed, you're ready to create a local virtual machine. By default, `kitchen init` generates a `kitchen-vagrant` driver configuration and a shell provisioner. This guide uses Vagrant with VirtualBox for virtualization, and Cinc Workstation for the cookbook examples.
 
-Test Kitchen is highly modular, allowing you to mix and match drivers (such as Vagrant, VMware, Azure, EC2, or Docker), provisioners (such as shell, Chef/Cinc, Ansible, Puppet, Salt, or DSC), and verifiers (including InSpec, Serverspec, or BATS). Install those plugins into the same Ruby environment that runs `kitchen`.
+Test Kitchen is highly modular, allowing you to mix and match drivers (such as Vagrant, VMware, Azure, EC2, or Docker), provisioners (such as shell, Cinc/Chef, Ansible, Puppet, Salt, or DSC), and verifiers (including InSpec, Serverspec, or BATS). Install those plugins into the same Ruby environment that runs `kitchen`.
 
 <div class="sidebar--footer">
 <a class="button primary-cta" href="/docs/getting-started/getting-help">Next - Getting Help</a>

--- a/docs/themes/kitchen/layouts/index.html
+++ b/docs/themes/kitchen/layouts/index.html
@@ -13,7 +13,7 @@ Kitchen will know what to do.</p></div></div><div class="columns large-8"><div c
   <span style="color: #66d9ef">name</span><span style="color: #f8f8f2">:</span> <span style="color: #a6e22e">vagrant</span>
 
 <span style="color: #66d9ef">provisioner</span><span style="color: #f8f8f2">:</span>
-  <span style="color: #66d9ef">name</span><span style="color: #f8f8f2">:</span> <span style="color: #a6e22e">chef_infra</span>
+  <span style="color: #66d9ef">name</span><span style="color: #f8f8f2">:</span> <span style="color: #a6e22e">cinc_infra</span>
 
 <span style="color: #66d9ef">platforms</span><span style="color: #f8f8f2">:</span>
   <span style="color: #f8f8f2">-</span> <span style="color: #66d9ef">name</span><span style="color: #f8f8f2">:</span> <span style="color: #a6e22e">ubuntu-24.04</span>


### PR DESCRIPTION
The homepage `kitchen.yml` example and the Getting Started install step both led with Chef. Cinc is the community distribution and the one someone can install and follow the guide with without a commercial license, so it should be what we show first. Also refreshes the sample tool versions in the install step, which had drifted.

## Cinc as the default

**Homepage example** — `themes/kitchen/layouts/index.html`

```diff
 provisioner:
-  name: chef_infra
+  name: cinc_infra
```

**Getting Started → Installing** — `content/docs/getting-started/01-installing.md`

- Leads with [Cinc Workstation](https://cinc.sh/start/workstation/) rather than listing it alongside Chef Workstation
- Verification command is now `cinc --version` instead of `chef --version`
- The closing paragraph says the guide uses Cinc Workstation for the cookbook examples

Chef Workstation is still called out, with a one-line note that it works the same way and what to substitute (`chef` for `cinc`, `chef_infra` for `cinc_infra`), so nobody using it is left guessing.

## Version refresh

The sample command output in the install step was stale:

| Tool | Was | Now |
| ---- | ---- | ---- |
| VirtualBox | `7.1.8r168469` | `7.2.16r174877` |
| Vagrant | `2.4.7` | `2.4.9` |

## Verification

Builds clean on Hugo 0.165.0 — the version `netlify.toml` pins — with no warnings. Confirmed in the rendered output that the homepage emits `cinc_infra`, and the install page emits `cinc --version`, `7.2.16r174877`, and `Vagrant 2.4.9`.

## Note

The `kitchen.yml` examples in Getting Started steps 4, 12, 14 and 17 still use `chef_infra`. Those are not broken — kitchen-cinc registers the `chef_*` names as aliases — but they are now inconsistent with an install step that tells you to install Cinc Workstation. Happy to switch them in this PR or a follow-up, whichever you prefer.