### PR TITLE
docs: link to Cinc Workstation from the homepage

### DIFF
--- a/docs/themes/kitchen/layouts/index.html
+++ b/docs/themes/kitchen/layouts/index.html
@@ -50,7 +50,7 @@ Finished verifying
 
 <span style="color: #f4bf75">--</span><span style="color: #f8f8f2">&gt;</span> Test Kitchen is finished.
 <span style="color: #f8f8f2">(</span>1m44.11s<span style="color: #f8f8f2">)</span>
-</code></pre></div></div></div><div class="columns medium-6"><div class="home--text--rightcol"><h2 class="body-heading">How do I get started?</h2><p>Install the <a href="https://www.chef.io/downloads/tools/workstation">Chef
+</code></pre></div></div></div><div class="columns medium-6"><div class="home--text--rightcol"><h2 class="body-heading">How do I get started?</h2><p>Install <a href="https://cinc.sh/start/workstation/">Cinc
 Workstation</a> to get started. Alternatively,
 install the gem directly with <code>gem install
 test-kitchen</code>.</p><a href="/docs/getting-started/introduction" class="button secondary-cta">Get Started</a></div></div></div></div></div><footer class="main-footer"><div class="row"><p class="main-footer--copyright">Apache License, Version 2.0 (see <a href="https://github.com/test-kitchen/test-kitchen/blob/main/LICENSE">LICENSE</a>)</p><ul class="main-footer--links"><li><a href="/" class="main-footer--link">Home</a></li><li><a href="/docs/getting-started/introduction" class="main-footer--link">Docs</a></li><li><a href="https://github.com/test-kitchen/test-kitchen" class="main-footer--link">GitHub</a></li></ul></div></div></footer><script src="/javascripts/all.js"></script><script>$(document).foundation();</script></body></html>


### PR DESCRIPTION
The "How do I get started?" panel on the homepage pointed at Chef Workstation, while the `kitchen.yml` example directly beside it now uses the `cinc_infra` provisioner (#2113). Following that link left you with tooling that did not match the example next to it.

## Change

`themes/kitchen/layouts/index.html`

```diff
-Install the <a href="https://www.chef.io/downloads/tools/workstation">Chef
+Install <a href="https://cinc.sh/start/workstation/">Cinc
 Workstation</a> to get started.
```

This lines the homepage up with the [Getting Started install step](https://kitchen.ci/docs/getting-started/installing/), which installs Cinc Workstation and verifies with `cinc --version`.

## Verification

Builds clean on Hugo 0.165.0 — the version `netlify.toml` pins — with no warnings. Confirmed in the rendered homepage that the link is `https://cinc.sh/start/workstation/`, that no `chef.io/downloads/tools/workstation` link remains, and that the target URL returns HTTP 200.