### PR TITLE
docs: lead the homepage frameworks list with Cinc Auditor

### DIFF
--- a/docs/themes/kitchen/layouts/index.html
+++ b/docs/themes/kitchen/layouts/index.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html><html><head><meta content="IE=edge" http-equiv="X-UA-Compatible" /><meta charset="utf-8" /><meta content="width=device-width,initial-scale=1.0,minimum-scale=1.0,maximum-scale=1.0,user-scalable=no" name="viewport" /><title>Welcome to Test Kitchen - KitchenCI</title><link href="/stylesheets/site.css" rel="stylesheet" /></head><body class="index"><nav id="main-nav"><div class="row"><div class="columns medium-12"><a href="/" class="main-nav--logo"><img alt="KitchenCI Logo" src="/images/logo.png" /></a><ul class="main-nav--links"><li><a href="/docs/getting-started/introduction" class="main-nav--link">Docs</a></li><li><a href="https://github.com/test-kitchen/test-kitchen" class="main-nav--link">GitHub</a></li></ul><a href="https://github.com/test-kitchen/test-kitchen/tree/main/docs" class="main-nav--github"><img alt="Fork me on GitHub" src="/images/github-banner.svg" /></a></div></div></nav><div class="home--hero row"><div class="columns medium-12 text-center"><h1 class="home--heading">Infrastructure Code Deserves Tests Too</h1><a href="/docs/getting-started/introduction" class="button primary-cta">Get Started</a></div></div><div class="row content"><div class="columns large-4"><div class="home--text"><h2 class="body-heading">What is Test Kitchen?</h2><p>Test Kitchen provides a test harness to execute infrastructure code on one
 or more platforms in isolation.</p><p>A driver plugin architecture is used to run code on various cloud
 providers and virtualization technologies such as Vagrant, Amazon
-EC2, Microsoft Azure, Google Compute Engine, VMware vSphere, Docker, and more. <a href="/docs/drivers">Read more</a></p><p>Many testing frameworks are supported out of the box including
-<a href="https://community.chef.io/tools/chef-inspec">Chef InSpec</a>,
-<a href="https://serverspec.org/">Serverspec</a>, and
-<a href="https://github.com/bats-core/bats-core">Bats</a></p><p>For Chef Infra workflows, cookbook dependency resolution via
+EC2, Microsoft Azure, Google Compute Engine, VMware vSphere, Docker, and more. <a href="/docs/drivers">Read more</a></p><p>Many testing frameworks are supported out of the box, including
+<a href="https://cinc.sh/start/auditor/">Cinc Auditor</a>,
+<a href="https://community.chef.io/tools/chef-inspec">Chef InSpec</a>, and
+<a href="https://serverspec.org/">Serverspec</a>.</p><p>For Chef Infra workflows, cookbook dependency resolution via
 <a href="https://docs.chef.io/workstation/berkshelf/">Berkshelf</a> or
 <a href="https://docs.chef.io/policyfile/">Policyfiles</a>
 is supported or include a <code>cookbooks/</code> directory and


### PR DESCRIPTION
## What

Reworks the testing-frameworks sentence on the homepage.

**Before**
> Many testing frameworks are supported out of the box including [Chef InSpec](https://community.chef.io/tools/chef-inspec), [Serverspec](https://serverspec.org/), and [Bats](https://github.com/bats-core/bats-core)

**After**
> Many testing frameworks are supported out of the box, including [Cinc Auditor](https://cinc.sh/start/auditor/), [Chef InSpec](https://community.chef.io/tools/chef-inspec), and [Serverspec](https://serverspec.org/).

## Why

- **Cinc Auditor leads.** #2113 and #2114 moved the homepage example and install guide to a Cinc-first framing; the frameworks list was still trailing that. It links to `cinc.sh/start/auditor/`, the same target `docs/verifiers/cinc-auditor` already uses.
- **Bats is dropped** from the sentence.
- Picks up the serial comma after "box" and the terminal period the sentence was missing.

## Scope

Homepage copy only. Bats is still mentioned in two other places, left alone deliberately — say the word if you want either followed up:

- `docs/content/docs/getting-started/01-installing.md` — prose listing verifiers, same shape as this sentence.
- `docs/content/docs/verifiers/_index.md` — both a prose mention and the `busser-bats` entry in the plugin catalogue. The catalogue entry documents a plugin that does still exist, so removing it is a different call from trimming marketing copy.