### PR TITLE
fix: mask secrets in Ruby 3.4+ Hash#inspect output

### DIFF
--- a/lib/kitchen/util.rb
+++ b/lib/kitchen/util.rb
@@ -99,17 +99,35 @@ module Kitchen
       end
     end
 
+    # The text substituted for a masked value.
+    MASK = "******".freeze
+
+    # A double-quoted string value, allowing for backslash escapes so that a
+    # quote inside the value does not end the match early.
+    QUOTED_VALUE = /"(?:\\.|[^"\\])*"/.source
+
     # Returns a string with masked values for specified parameters.
+    #
+    # Hashes are commonly interpolated into these strings via Hash#inspect,
+    # whose rendering has changed over time, so every spelling a key/value
+    # pair has had is matched:
+    #
+    #   :key=>"value"     symbol key, Ruby <= 3.3
+    #   "key"=>"value"    string key, Ruby <= 3.3
+    #   key: "value"      symbol key, Ruby >= 3.4
+    #   "key" => "value"  string key, Ruby >= 3.4
     #
     # @param string_to_mask [String] the object whose string representation is parsed
     # @param keys [Array] the list of keys whose values should be masked
-    # @return [String] the string representation of passed object with masked values
+    # @return [String] a new string with the values of the given keys masked
     def self.mask_values(string_to_mask, keys)
-      masked_string = string_to_mask
-      keys.each do |key|
-        masked_string.gsub!(/:#{key}=>"([^"]*)"/, %{:#{key}=>"******"})
+      keys.reduce(string_to_mask.to_s) do |masked, key|
+        key = ::Regexp.escape(key.to_s)
+        masked.gsub(
+          /(?<assignment>(?::#{key}|"#{key}")\s*=>\s*|(?<!\w)#{key}:\s*)#{QUOTED_VALUE}/,
+          %{\\k<assignment>"#{MASK}"}
+        )
       end
-      masked_string
     end
 
     # Returns a formatted string representing a duration in seconds.

--- a/spec/kitchen/util_spec.rb
+++ b/spec/kitchen/util_spec.rb
@@ -86,6 +86,65 @@ describe Kitchen::Util do
     end
   end
 
+  describe ".mask_values" do
+    it "masks a symbol-keyed value in a modern Hash#inspect string" do
+      hash = { password: "s3cr3t", user: "root" }
+
+      _(Kitchen::Util.mask_values("[SSH] <#{hash.inspect}>", %w{password}))
+        .wont_include "s3cr3t"
+    end
+
+    it "masks a string-keyed value in a modern Hash#inspect string" do
+      hash = { "password" => "s3cr3t" }
+
+      _(Kitchen::Util.mask_values("[SSH] <#{hash.inspect}>", %w{password}))
+        .wont_include "s3cr3t"
+    end
+
+    it "masks a value in a legacy hash rocket string" do
+      _(Kitchen::Util.mask_values(%{<{:password=>"s3cr3t"}>}, %w{password}))
+        .wont_include "s3cr3t"
+    end
+
+    it "masks every requested key" do
+      hash = { password: "s3cr3t", ssh_http_proxy_password: "pr0xy" }
+      masked = Kitchen::Util.mask_values(
+        "[SSH] <#{hash.inspect}>", %w{password ssh_http_proxy_password}
+      )
+
+      _(masked).wont_include "s3cr3t"
+      _(masked).wont_include "pr0xy"
+    end
+
+    it "leaves keys that were not requested alone" do
+      hash = { password: "s3cr3t", user: "root" }
+
+      _(Kitchen::Util.mask_values("[SSH] <#{hash.inspect}>", %w{password}))
+        .must_include "root"
+    end
+
+    it "does not mask a key that merely ends with a requested key" do
+      hash = { not_a_password: "keepme" }
+
+      _(Kitchen::Util.mask_values("<#{hash.inspect}>", %w{password}))
+        .must_include "keepme"
+    end
+
+    it "does not modify the string it was given" do
+      hash = { password: "s3cr3t" }
+      original = "[SSH] <#{hash.inspect}>"
+
+      Kitchen::Util.mask_values(original, %w{password})
+
+      _(original).must_include "s3cr3t"
+    end
+
+    it "masks a frozen string" do
+      _(Kitchen::Util.mask_values(%{<{password: "s3cr3t"}>}.freeze, %w{password}))
+        .wont_include "s3cr3t"
+    end
+  end
+
   describe ".duration" do
     it "turns nil into a zero" do
       _(Kitchen::Util.duration(nil))


### PR DESCRIPTION
`Util.mask_values` is what keeps credentials out of the debug log. It matches `:key=>"value"` — the shape `Hash#inspect` produced through Ruby 3.3. Ruby 3.4 changed that rendering, so the pattern stopped matching and the mask became a silent no-op.

Every caller interpolates a hash of connection options into the string it hands over (`Ssh::Connection#to_s` is `"#{username}@#{hostname}<#{options.inspect}>"`), so on Ruby 3.4+ `kitchen -l debug` prints the SSH and WinRM password verbatim, to the terminal and to `.kitchen/logs/*.log`:

```
[SSH] root@1.2.3.4<{user: "root", password: "s3cr3t", port: 22}> (ls)
```

The gemspec allows `>= 3.1`, and 3.4 is over a year old.

### The fix

Match all four spellings a key/value pair has had:

| rendering | Ruby |
| --- | --- |
| `:key=>"value"` | symbol key, <= 3.3 |
| `"key"=>"value"` | string key, <= 3.3 |
| `key: "value"` | symbol key, >= 3.4 |
| `"key" => "value"` | string key, >= 3.4 |

The modern symbol form has no leading sigil, so it is anchored with a lookbehind — otherwise `not_a_password:` would match a naive `password:` pattern. There is a test for that. The value pattern also allows backslash escapes now, so a quote inside a password no longer ends the match early and leaks the tail.

While in here, stop mutating the argument. `gsub!` edited the caller's string in place and raised `FrozenError` on a frozen one; Ruby already warns about this under chilled string literals:

```
lib/kitchen/util.rb:110: warning: literal string will be frozen in the future
```

Every caller uses the return value, and `Provisioner::External` carried a defensive `.dup` to work around it.

### Testing

Eight new specs in `spec/kitchen/util_spec.rb`, which had no coverage for this method at all. Four of them fail on `main` (both modern renderings, the multi-key case, and the frozen string). Full suite green, `rake style` clean.