### PR TITLE
fix: report every problem `kitchen doctor` finds

### DIFF
--- a/lib/kitchen/command/doctor.rb
+++ b/lib/kitchen/command/doctor.rb
@@ -28,10 +28,12 @@ module Kitchen
         end
         # By default only doctor the first instance to avoid output spam.
         results = [results.first] unless options[:all]
-        failed = results.any? do |instance|
+        # Doctor every instance before deciding the outcome. #any? would
+        # stop at the first instance reporting a problem and skip the rest.
+        failed = results.map do |instance|
           debug "Doctor on #{instance.name}."
           instance.doctor_action
-        end
+        end.any?
         exit(1) if failed
       end
     end

--- a/lib/kitchen/instance.rb
+++ b/lib/kitchen/instance.rb
@@ -242,9 +242,12 @@ module Kitchen
     #
     def doctor_action
       banner "The doctor is in"
-      [driver, provisioner, transport, verifier].any? do |obj|
+      # Each plugin reports its own problems as it finds them, so run all of
+      # them and reduce afterwards. #any? would stop at the first plugin with
+      # something to say and hide the rest.
+      [driver, provisioner, transport, verifier].map do |obj|
         obj.doctor(state_file.read)
-      end
+      end.any?
     end
 
     # Returns a Hash of configuration and other useful diagnostic information.

--- a/spec/kitchen/command/doctor_spec.rb
+++ b/spec/kitchen/command/doctor_spec.rb
@@ -1,0 +1,56 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative "../../spec_helper"
+
+require "kitchen"
+require "kitchen/collection"
+require "kitchen/command/doctor"
+
+describe Kitchen::Command::Doctor do
+  let(:healthy) { stub(name: "healthy", doctor_action: false) }
+  let(:shell)   { stub }
+
+  def doctor(instances, options = {})
+    command = Kitchen::Command::Doctor.new(
+      ["all"],
+      { all: true }.merge(options),
+      action: "doctor",
+      help: -> {},
+      config: stub(instances: Kitchen::Collection.new(instances)),
+      shell:
+    )
+    capture_io { command.call }
+  end
+
+  it "doctors the remaining instances after one reports a problem" do
+    sick = stub(name: "sick", doctor_action: true)
+    later = mock("later")
+    later.stubs(:name).returns("later")
+    later.expects(:doctor_action).returns(false)
+
+    _ { doctor([sick, later]) }.must_raise SystemExit
+  end
+
+  it "exits non-zero when an instance reports a problem" do
+    sick = stub(name: "sick", doctor_action: true)
+
+    error = _ { doctor([healthy, sick]) }.must_raise SystemExit
+
+    _(error.status).must_equal 1
+  end
+
+  it "does not exit when no instance reports a problem" do
+    doctor([healthy])
+  end
+end

--- a/spec/kitchen/instance_spec.rb
+++ b/spec/kitchen/instance_spec.rb
@@ -364,6 +364,36 @@ describe Kitchen::Instance do
     _ { instance.login }.must_raise Kitchen::UserError
   end
 
+  describe "#doctor_action" do
+    it "runs the doctor on every plugin" do
+      driver.expects(:doctor).returns(false)
+      provisioner.expects(:doctor).returns(false)
+      transport.expects(:doctor).returns(false)
+      verifier.expects(:doctor).returns(false)
+
+      instance.doctor_action
+    end
+
+    it "runs the remaining plugins after one reports a problem" do
+      driver.stubs(:doctor).returns(true)
+      provisioner.expects(:doctor).returns(false)
+      transport.expects(:doctor).returns(false)
+      verifier.expects(:doctor).returns(false)
+
+      instance.doctor_action
+    end
+
+    it "returns false when no plugin reports a problem" do
+      _(instance.doctor_action).must_equal false
+    end
+
+    it "returns true when a plugin reports a problem" do
+      verifier.stubs(:doctor).returns(true)
+
+      _(instance.doctor_action).must_equal true
+    end
+  end
+
   describe "#status" do
     it "returns the driver status" do
       state_file.write(my_id: "instance-123")


### PR DESCRIPTION
`Instance#doctor_action` runs the driver, provisioner, transport and verifier doctors through `Enumerable#any?`:

```ruby
[driver, provisioner, transport, verifier].any? do |obj|
  obj.doctor(state_file.read)
end
```

`#any?` stops at the first truthy element. Each `doctor` both *prints* its findings and returns a verdict, so as soon as the driver reports a problem the other three never run and their diagnostics are never shown. You fix the driver, run again, and discover the provisioner also had something to say — one round trip per problem.

`Command::Doctor#call` short-circuits the same way one level up, so `kitchen doctor --all` stops examining instances at the first failing one.

### The fix

`.map { … }.any?` in both places: force the side effects across the whole collection, then reduce the verdicts. The exit status is unchanged — still non-zero if anything was found.

### Testing

`spec/kitchen/instance_spec.rb` gains a `#doctor_action` block and `spec/kitchen/command/doctor_spec.rb` is new (the command had no spec). One test in each fails on `main`:

```
- expected exactly once, invoked never: #<Kitchen::Provisioner::Dummy>.doctor(any_parameters)
- expected exactly once, invoked never: #<Kitchen::Transport::Dummy>.doctor(any_parameters)
- expected exactly once, invoked never: #<Kitchen::Verifier::Dummy>.doctor(any_parameters)
```

The remaining tests cover the return value in both directions and pass before and after, guarding the reduce. Full suite green, `rake style` clean.