### PR TITLE
fix: do not skip every instance when --concurrency is zero

### DIFF
--- a/lib/kitchen/command.rb
+++ b/lib/kitchen/command.rb
@@ -195,18 +195,20 @@ module Kitchen
       end
 
       # Determines how many instances may be acted on at once, clamped to the
-      # number of instances available.
+      # number of instances available and to at least one worker. Without the
+      # lower bound a zero or negative --concurrency would start no worker
+      # threads at all, so every instance would be skipped and the run would
+      # still report success.
       #
       # @param instances [Array<Instance>] the instances to be acted on
       # @return [Integer] the number of worker threads to start
       # @api private
       def concurrency_setting(instances)
-        concurrency = 1
-        if options[:concurrency]
-          concurrency = options[:concurrency] || instances.size
-          concurrency = instances.size if concurrency > instances.size
-        end
-        concurrency
+        return 1 unless options[:concurrency]
+
+        concurrency = options[:concurrency]
+        concurrency = instances.size if concurrency > instances.size
+        [concurrency, 1].max
       end
 
       # Performs an action on a single instance, recording any instance or

--- a/spec/kitchen/command_spec.rb
+++ b/spec/kitchen/command_spec.rb
@@ -37,10 +37,16 @@ class RunActionInstance
     @name = name
     @failure = failure
     @cleaned = false
+    @created = false
   end
 
   def create(*)
+    @created = true
     raise @failure if @failure
+  end
+
+  def created?
+    @created
   end
 
   def cleaned?
@@ -76,6 +82,30 @@ describe Kitchen::Command::RunAction do
       .must_raise Kitchen::ActionFailed
 
     _(instance.cleaned?).must_equal true
+  end
+
+  it "runs the action when concurrency is zero" do
+    instance = RunActionInstance.new("one")
+
+    RunActionDummy.new(concurrency: 0).run_action(:create, [instance])
+
+    _(instance.created?).must_equal true
+  end
+
+  it "runs the action when concurrency is negative" do
+    instance = RunActionInstance.new("one")
+
+    RunActionDummy.new(concurrency: -4).run_action(:create, [instance])
+
+    _(instance.created?).must_equal true
+  end
+
+  it "runs every instance when concurrency exceeds the instance count" do
+    instances = [RunActionInstance.new("one"), RunActionInstance.new("two")]
+
+    RunActionDummy.new(concurrency: 9).run_action(:create, instances)
+
+    _(instances.map(&:created?)).must_equal [true, true]
   end
 
   it "restores Thread.abort_on_exception after fail fast runs" do


### PR DESCRIPTION
`concurrency_setting` clamps `--concurrency` down to the number of instances but has no lower bound:

```ruby
concurrency = 1
if options[:concurrency]
  concurrency = options[:concurrency] || instances.size
  concurrency = instances.size if concurrency > instances.size
end
concurrency
```

`0` is truthy in Ruby, so it passes straight through to `run_action`. `Integer#times` then starts no worker threads, nothing ever pops the queue, `threads.map(&:join)` joins nothing and `report_errors` finds no errors. The run finishes instantly having done nothing at all — and exits `0`, so CI reads it as a pass. A negative value behaves the same way.

```
$ kitchen converge -c 0
-----> Starting Test Kitchen (v3.9.1)
-----> Test Kitchen is finished. (0m0.00s)
```

### The fix

Clamp to at least one worker, which runs the instances serially — the same as invoking the action with no `--concurrency` flag. That seemed better than erroring: a lower bound of one is the sane reading of "at most zero at a time", and it keeps the flag from ever being able to turn a run into a no-op.

Also drops the `options[:concurrency] || instances.size` fallback, which sat inside `if options[:concurrency]` and so could never evaluate its right-hand side.

### Testing

Three new specs in `spec/kitchen/command_spec.rb`. The zero and negative cases fail on `main`; the third pins the existing clamp to the instance count so this doesn't regress in the other direction. Full suite green, `rake style` clean.