### PR TITLE
fix: accept Regexp platform filters without raising

### DIFF
--- a/lib/kitchen/platform_filter.rb
+++ b/lib/kitchen/platform_filter.rb
@@ -32,9 +32,10 @@ module Kitchen
     # A string "looks-like" a regexp if it starts with / and ends with / + Regexp options i or x
     #
     # @return [Array] filters with regexp-like string converted to PlatformRegexpFilter
+    # @raise [ArgumentError] if a filter is neither a String nor a Regexp
     def self.convert(filters)
       ::Kernel.Array(filters).map do |filter|
-        if (match = filter.match(REGEXP_LIKE_PATTERN))
+        if filter.is_a?(::String) && (match = filter.match(REGEXP_LIKE_PATTERN))
           options = match["options"].include?("i") ? ::Regexp::IGNORECASE : 0
           options |= ::Regexp::EXTENDED if match["options"].include?("x")
           filter = ::Regexp.new(match["pattern"], options)
@@ -51,7 +52,8 @@ module Kitchen
     # @param [Regexp,String] value of the filter
     def initialize(value)
       unless value.is_a?(::Regexp) || value.is_a?(::String)
-        raise ::ArgumentError, "PlatformFilter#new requires value to be a String or a Regexp"
+        raise ::ArgumentError, "PlatformFilter#new requires value to be a String or a Regexp, " \
+          "got #{value.inspect} (#{value.class})"
       end
 
       @value = value

--- a/spec/kitchen/platform_filter_spec.rb
+++ b/spec/kitchen/platform_filter_spec.rb
@@ -48,6 +48,29 @@ describe Kitchen::PlatformFilter do
       _(Kitchen::PlatformFilter.convert(%w{/win/ix /win/xi})).must_equal [Kitchen::PlatformFilter.new(/win/ix),
                                                                        Kitchen::PlatformFilter.new(/win/ix)]
     end
+
+    it "wraps a Regexp without treating it as a string" do
+      _(Kitchen::PlatformFilter.convert(/^win/)).must_equal [Kitchen::PlatformFilter.new(/^win/)]
+    end
+
+    it "keeps the options of a wrapped Regexp" do
+      _(Kitchen::PlatformFilter.convert(/win/ix).first.value).must_equal(/win/ix)
+    end
+
+    it "wraps a mix of strings and Regexps" do
+      _(Kitchen::PlatformFilter.convert(["CentOS", /^win/])).must_equal [Kitchen::PlatformFilter.new("CentOS"),
+                                                                        Kitchen::PlatformFilter.new(/^win/)]
+    end
+
+    it "raises an ArgumentError naming a filter that is neither a string nor a Regexp" do
+      error = _ { Kitchen::PlatformFilter.convert([2019]) }.must_raise ::ArgumentError
+
+      _(error.message).must_include "2019"
+    end
+
+    it "raises an ArgumentError for a nil filter in a list" do
+      _ { Kitchen::PlatformFilter.convert([nil]) }.must_raise ::ArgumentError
+    end
   end
 
   describe ".new" do


### PR DESCRIPTION
`PlatformFilter.convert` documents that it handles "both strings and Regexp", but it calls `String#match` on every filter to spot the regexp-like `"/^win/"` string form. Hand it an actual Regexp and it raises:

```ruby
Kitchen::Suite.new(name: "s", excludes: [/^win/])
# TypeError: no implicit conversion of Regexp into String
```

So the Regexp half of the contract has never worked, even though `PlatformFilter#new`, `#value` and `#==` all handle Regexps and are tested with them.

### The fix

Only test the regexp-like string form when the filter really is a String; let everything else go straight to the constructor, which already validates its input.

That also improves the failure for a filter that is neither. A value YAML parses as something other than a string —

```yaml
suites:
  - name: default
    excludes:
      - 2019
```

— used to surface as `NoMethodError: undefined method 'match' for an instance of Integer`, with nothing pointing back at kitchen.yml. It now raises the class's own `ArgumentError`, extended to name the offending value:

```
ArgumentError: PlatformFilter#new requires value to be a String or a Regexp, got 2019 (Integer)
```

### Testing

Five new specs in `spec/kitchen/platform_filter_spec.rb`, all failing on `main` (two `TypeError`, one wrong error class, two more on the Regexp path). Full suite green, `rake style` clean.