### PR TITLE
fix: show the nested exception's own backtrace

### DIFF
--- a/lib/kitchen/errors.rb
+++ b/lib/kitchen/errors.rb
@@ -52,7 +52,7 @@ module Kitchen
                else
                  [
                    formatted_exception(exception.original, "Nested Exception"),
-                   formatted_backtrace(exception),
+                   formatted_backtrace(exception.original),
                  ].flatten
                end
       end

--- a/spec/kitchen/errors_spec.rb
+++ b/spec/kitchen/errors_spec.rb
@@ -58,9 +58,10 @@ describe Kitchen::Error do
     end
 
     it "returns an array containing a nested exception, if given" do
-      raise IOError, "no disk, yo"
-    rescue
-      e = Kitchen::StandardError.new("shoot")
+      # Neither exception is raised, so neither carries a backtrace and the
+      # formatted output is only the two exception blocks. The nested
+      # exception's backtrace has its own test below.
+      e = Kitchen::StandardError.new("shoot", IOError.new("no disk, yo"))
 
       _(Kitchen::Error.formatted_trace(e))
         .must_equal([
@@ -73,6 +74,25 @@ describe Kitchen::Error do
           "Message: no disk, yo",
           "----------------------",
         ])
+    end
+
+    it "shows the nested exception's own backtrace, not the wrapper's" do
+      inner = begin
+        raise IOError, "no disk, yo"
+      rescue => ex
+        ex
+      end
+      outer = begin
+        raise Kitchen::StandardError.new("shoot", inner)
+      rescue => ex
+        ex
+      end
+
+      trace = Kitchen::Error.formatted_trace(outer)
+      nested = trace[trace.index("---Nested Exception---")..]
+
+      _(nested).must_include inner.backtrace.first
+      _(nested).wont_include outer.backtrace.first
     end
 
     it "returns an array when an error has more than one error in original" do


### PR DESCRIPTION
`Error.formatted_trace` prints a wrapped exception under a `---Nested Exception---` header, then prints `formatted_backtrace(exception)` beneath it — the **outer** exception again, rather than `exception.original`.

So the wrapper's backtrace appears twice under two different headers, and the nested exception's own backtrace — the one pointing at the line that actually broke — is never shown.

`Kitchen::StandardError` captures `$!` on construction, so nearly every failure surfaced through Test Kitchen is a nested exception, and `ActionRunner#log_failure` sends all of them through here into `.kitchen/logs/<instance>.log`. Debugging a driver or provisioner crash meant reading the same frames twice with no sight of the real one.

Before / after, for an `IOError` raised inside `inner_boom` and re-raised as `ActionFailed`:

```diff
 ---Nested Exception---
 Class: IOError
 Message: the real failure
 ----------------------
 ------Backtrace-------
--e:5:in '<main>'                    # the wrapper's frame, again
+-e:3:in 'Object#inner_boom'         # where it actually broke
+-e:5:in '<main>'
 ----End Backtrace-----
```

One-word fix. The composite-exception branch already recursed correctly through `formatted_trace` and is unchanged.

### Testing

A new spec raises both exceptions so each has a real backtrace, then asserts the nested section contains the inner exception's first frame and *not* the outer's. It fails on `main` showing `errors_spec.rb:85` (the wrapper) where `:80` (the `raise IOError`) belongs.

The existing nested-exception spec was pinning the bug by accident: it rescued a raised `IOError` and let `Kitchen::StandardError.new` pick it up from `$!`, but asserted output containing no backtrace section at all — which only held because the wrong argument happened to have no backtrace. It now builds the nested exception explicitly so it stays an exact structural assertion, with the backtrace covered by its own test.