### PR TITLE
fix: stop cleanup_sandbox from masking the real failure

### DIFF
--- a/lib/kitchen/provisioner/base.rb
+++ b/lib/kitchen/provisioner/base.rb
@@ -230,7 +230,11 @@ module Kitchen
       # will persist after the process terminates. In other words, cleanup is
       # explicit. This method is safe to call multiple times.
       def cleanup_sandbox
-        return if sandbox_path.nil?
+        # Check the ivar, not #sandbox_path, which raises rather than
+        # returning nil when the sandbox was never created. This runs from
+        # an ensure block, so raising here would mask the error that kept
+        # #create_sandbox from finishing.
+        return if @sandbox_path.nil?
 
         debug("Cleaning up local sandbox in #{sandbox_path}")
         @install_script_path = nil

--- a/lib/kitchen/verifier/base.rb
+++ b/lib/kitchen/verifier/base.rb
@@ -115,7 +115,11 @@ module Kitchen
       # will persist after the process terminates. In other words, cleanup is
       # explicit. This method is safe to call multiple times.
       def cleanup_sandbox
-        return if sandbox_path.nil?
+        # Check the ivar, not #sandbox_path, which raises rather than
+        # returning nil when the sandbox was never created. This runs from
+        # an ensure block, so raising here would mask the error that kept
+        # #create_sandbox from finishing.
+        return if @sandbox_path.nil?
 
         debug("Cleaning up local sandbox in #{sandbox_path}")
         FileUtils.rmtree(sandbox_path)

--- a/spec/kitchen/provisioner/base_spec.rb
+++ b/spec/kitchen/provisioner/base_spec.rb
@@ -344,13 +344,20 @@ describe Kitchen::Provisioner::Base do
   end
 
   describe "sandbox" do
-    after do
-      provisioner.cleanup_sandbox
-    rescue # rubocop:disable Lint/HandleExceptions
-    end
+    after { provisioner.cleanup_sandbox }
 
     it "raises ClientError if #sandbox_path is called before #create_sandbox" do
       _ { provisioner.sandbox_path }.must_raise Kitchen::ClientError
+    end
+
+    it "#cleanup_sandbox does nothing when the sandbox was never created" do
+      provisioner.cleanup_sandbox
+    end
+
+    it "#call surfaces the error from a failed #create_sandbox" do
+      provisioner.stubs(:create_sandbox).raises(Errno::ENOSPC, "/tmp")
+
+      _ { provisioner.call({}) }.must_raise Errno::ENOSPC
     end
 
     it "#create_sandbox creates a temporary directory" do

--- a/spec/kitchen/verifier/base_spec.rb
+++ b/spec/kitchen/verifier/base_spec.rb
@@ -315,13 +315,20 @@ describe Kitchen::Verifier::Base do
   end
 
   describe "sandbox" do
-    after do
-      verifier.cleanup_sandbox
-    rescue # rubocop:disable Lint/HandleExceptions
-    end
+    after { verifier.cleanup_sandbox }
 
     it "raises ClientError if #sandbox_path is called before #create_sandbox" do
       _ { verifier.sandbox_path }.must_raise Kitchen::ClientError
+    end
+
+    it "#cleanup_sandbox does nothing when the sandbox was never created" do
+      verifier.cleanup_sandbox
+    end
+
+    it "#call surfaces the error from a failed #create_sandbox" do
+      verifier.stubs(:create_sandbox).raises(Errno::ENOSPC, "/tmp")
+
+      _ { verifier.call({}) }.must_raise Errno::ENOSPC
     end
 
     it "#create_sandbox creates a temporary directory" do


### PR DESCRIPTION
`Provisioner::Base#cleanup_sandbox` and `Verifier::Base#cleanup_sandbox` both open with:

```ruby
return if sandbox_path.nil?
```

But `#sandbox_path` never returns nil — it *raises* `ClientError` when the sandbox has not been created:

```ruby
def sandbox_path
  @sandbox_path ||= raise ClientError, "Sandbox directory has not yet been created. ..."
end
```

So the guard is dead code, and the method raises in precisely the case it was written to handle.

Both `#call` methods run `cleanup_sandbox` from an `ensure` block, and `#create_sandbox` is their first statement. When `Dir.mktmpdir` fails — full disk, unwritable `TMPDIR` — the `ensure` raises over the top of the real error and the user sees:

```
Kitchen::ClientError: Sandbox directory has not yet been created.
Please run Kitchen::Verifier::Base#create_sandbox before trying to access the path.
```

which reads as an internal Test Kitchen bug rather than a full disk. The actual `Errno::ENOSPC` never surfaces.

### The fix

Check the ivar instead of the raising accessor. `#sandbox_path` keeps raising for genuine misuse — that behavior has its own spec and is untouched.

### Testing

Two specs each for the provisioner and the verifier: `cleanup_sandbox` on a never-created sandbox, and `call` surfacing `Errno::ENOSPC` from a failing `create_sandbox`. All four fail on `main`, the second pair with `ClientError` in place of the real error.

The sandbox specs also wrapped their `after` hook in a bare `rescue` to swallow this exact raise; that workaround is dropped now that cleanup is safe to call unconditionally.