### PR TITLE
fix: log exec transport output to the instance log

### DIFF
--- a/lib/kitchen/transport/exec.rb
+++ b/lib/kitchen/transport/exec.rb
@@ -134,11 +134,11 @@ module Kitchen
       # @return [Hash] hash of connection options
       # @api private
       def connection_options(data)
-        opts = {
+        {
           instance_name: instance.name,
-          kitchen_root: Dir.pwd,
+          kitchen_root: data[:kitchen_root] || Dir.pwd,
+          logger:,
         }
-        opts
       end
     end
   end

--- a/spec/kitchen/transport/exec_spec.rb
+++ b/spec/kitchen/transport/exec_spec.rb
@@ -69,24 +69,24 @@ describe Kitchen::Transport::Exec do
 
         make_connection
       end
+    end
 
-      describe "called without a block" do
-        def make_connection(s = state) # rubocop:disable Lint/NestedMethodDefinition
-          transport.connection(s)
-        end
-
-        common_connection_specs
+    describe "called without a block" do
+      def make_connection(s = state)
+        transport.connection(s)
       end
 
-      describe "called with a block" do
-        def make_connection(s = state) # rubocop:disable Lint/NestedMethodDefinition
-          transport.connection(s) do |conn|
-            conn
-          end
-        end
+      common_connection_specs
+    end
 
-        common_connection_specs
+    describe "called with a block" do
+      def make_connection(s = state)
+        transport.connection(s) do |conn|
+          conn
+        end
       end
+
+      common_connection_specs
     end
   end
 end


### PR DESCRIPTION
`Transport::Exec#connection_options` builds its options hash without a `:logger` key:

```ruby
def connection_options(data)
  opts = {
    instance_name: instance.name,
    kitchen_root: Dir.pwd,
  }
  opts
end
```

`Base::Connection#init_options` therefore falls through to its default:

```ruby
@logger = @options.delete(:logger) || Kitchen.logger
```

So every Exec connection logs to the shared `kitchen.log` instead of `.kitchen/logs/<instance>.log`. And since `ShellOut#run_command` passes the connection's logger as `live_stream`, that takes **all command output** with it — per-instance logs come out empty for runs using the exec transport. Every other transport passes its logger through; `Ssh#connection_options` starts with `logger:`.

The same method also hardcodes `kitchen_root: Dir.pwd`, ignoring the `config[:kitchen_root]` it is handed — that value decides where the Windows exec script gets written.

### Why no test caught it

The specs for `#connection` never ran. The `end` closing `def self.common_connection_specs` was placed *after* the two `describe "called with/without a block"` blocks that call it:

```ruby
def self.common_connection_specs
  it "sets :kitchen_root to the transport's kitchen_root" do ... end

  describe "called without a block" do
    common_connection_specs      # only call site, inside the definition
  end
  ...
end                              # <- belongs above the describes
```

So the helper enclosed its own only call sites and was never invoked — `#connection` had zero executing tests, and the file ran 10 specs where it should run 16. `ssh_spec.rb` has the identical helper with the `end` in the right place.

Moving it makes all six specs run, and they fail on `main` catching both bugs — `NoMethodError: undefined method 'logger' for module Kitchen`, and `Connection.new({..., kitchen_root: "/Users/tsmith/dev/oss/test-kitchen"})` against an expected `/i/am/root`. With the fix they pass. `Dir.pwd` is kept as the fallback when no `:kitchen_root` is configured.