### PR TITLE
fix: keep user environment in the shell verifier

### DIFF
--- a/lib/kitchen/verifier/shell.rb
+++ b/lib/kitchen/verifier/shell.rb
@@ -39,13 +39,12 @@ module Kitchen
       def call(state)
         info("[#{name}] Verify on instance #{instance.name} with state=#{state}")
         sleep_if_set
-        merge_state_to_env(state)
         if config[:remote_exec]
           instance.transport.connection(state) do |conn|
             conn.execute(config[:command])
           end
         else
-          shellout
+          shellout(state)
         end
         debug("[#{name}] Verify completed.")
       end
@@ -72,8 +71,8 @@ module Kitchen
         end
       end
 
-      def shellout
-        cmd = Mixlib::ShellOut.new(config[:command], config[:shellout_opts])
+      def shellout(state = {})
+        cmd = Mixlib::ShellOut.new(config[:command], shellout_opts(state))
         cmd.live_stream = config[:live_stream]
         cmd.run_command
         begin
@@ -83,16 +82,38 @@ module Kitchen
         end
       end
 
-      def merge_state_to_env(state)
-        env_state = { environment: {} }
-        env_state[:environment]["KITCHEN_INSTANCE"] = instance.name
-        env_state[:environment]["KITCHEN_PLATFORM"] = instance.platform.name
-        env_state[:environment]["KITCHEN_SUITE"] = instance.suite.name
-        env_state[:environment]["KITCHEN_USERNAME"] = instance.transport[:username] if instance.respond_to?(:transport)
+      # Returns the options to run the command with: whatever the user
+      # configured, with the KITCHEN_* variables merged into their environment
+      # rather than replacing it.
+      #
+      # This builds a new Hash instead of writing back to config. Nested config
+      # hashes are shared between every instance, so mutating :shellout_opts
+      # would leak one instance's environment into the others.
+      #
+      # @param state [Hash] mutable instance state
+      # @return [Hash] options for Mixlib::ShellOut
+      # @api private
+      def shellout_opts(state)
+        opts = config[:shellout_opts].to_h
+        opts.merge(
+          environment: opts.fetch(:environment, {}).to_h.merge(kitchen_environment(state))
+        )
+      end
+
+      # @param state [Hash] mutable instance state
+      # @return [Hash] the KITCHEN_* environment variables for this instance
+      # @api private
+      def kitchen_environment(state)
+        env = {
+          "KITCHEN_INSTANCE" => instance.name,
+          "KITCHEN_PLATFORM" => instance.platform.name,
+          "KITCHEN_SUITE" => instance.suite.name,
+        }
+        env["KITCHEN_USERNAME"] = instance.transport[:username] if instance.respond_to?(:transport)
         state.each_pair do |key, value|
-          env_state[:environment]["KITCHEN_" + key.to_s.upcase] = value.to_s
+          env["KITCHEN_" + key.to_s.upcase] = value.to_s
         end
-        config[:shellout_opts].merge!(env_state)
+        env
       end
     end
   end

--- a/spec/kitchen/verifier/shell_spec.rb
+++ b/spec/kitchen/verifier/shell_spec.rb
@@ -78,6 +78,19 @@ describe Kitchen::Verifier::Shell do
     end
   end
 
+  # Returns the options the verifier actually hands to Mixlib::ShellOut, which
+  # is what decides the environment the command runs with.
+  def shellout_opts_for(state)
+    captured = nil
+    Mixlib::ShellOut.stubs(:new).with do |_command, opts|
+      captured = opts
+      true
+    end.returns(stub("live_stream=": nil, run_command: nil, error!: nil))
+
+    verifier.call(state)
+    captured
+  end
+
   describe "#call" do
     describe "#shell_out" do
       it "calls sleep if :sleep value is greater than 0" do
@@ -91,20 +104,41 @@ describe Kitchen::Verifier::Shell do
         state[:hostname] = "testhost"
         state[:server_id] = "i-xxxxxx"
         state[:port] = 22
-        verifier.call(state)
-        _(config[:shellout_opts][:environment]["KITCHEN_HOSTNAME"]).must_equal "testhost"
-        _(config[:shellout_opts][:environment]["KITCHEN_SERVER_ID"]).must_equal "i-xxxxxx"
-        _(config[:shellout_opts][:environment]["KITCHEN_PORT"]).must_equal "22"
-        _(config[:shellout_opts][:environment]["KITCHEN_INSTANCE"]).must_equal "coolbeans-fries"
-        _(config[:shellout_opts][:environment]["KITCHEN_PLATFORM"]).must_equal "coolbeans"
-        _(config[:shellout_opts][:environment]["KITCHEN_SUITE"]).must_equal "fries"
-        _(config[:shellout_opts][:environment]["KITCHEN_USERNAME"]).must_be_nil
+
+        env = shellout_opts_for(state)[:environment]
+
+        _(env["KITCHEN_HOSTNAME"]).must_equal "testhost"
+        _(env["KITCHEN_SERVER_ID"]).must_equal "i-xxxxxx"
+        _(env["KITCHEN_PORT"]).must_equal "22"
+        _(env["KITCHEN_INSTANCE"]).must_equal "coolbeans-fries"
+        _(env["KITCHEN_PLATFORM"]).must_equal "coolbeans"
+        _(env["KITCHEN_SUITE"]).must_equal "fries"
+        _(env["KITCHEN_USERNAME"]).must_be_nil
       end
 
       it "transport username is set to environment" do
         transport.stubs(:[]).with(:username).returns("demigod")
-        verifier.call(state)
-        _(config[:shellout_opts][:environment]["KITCHEN_USERNAME"]).must_equal "demigod"
+
+        _(shellout_opts_for(state)[:environment]["KITCHEN_USERNAME"]).must_equal "demigod"
+      end
+
+      it "keeps environment variables the user configured" do
+        config[:shellout_opts] = { environment: { "MY_VAR" => "keepme" } }
+
+        _(shellout_opts_for(state)[:environment]["MY_VAR"]).must_equal "keepme"
+      end
+
+      it "keeps other shellout options the user configured" do
+        config[:shellout_opts] = { timeout: 30 }
+
+        _(shellout_opts_for(state)[:timeout]).must_equal 30
+      end
+
+      it "does not modify the configured shellout options" do
+        config[:shellout_opts] = { environment: { "MY_VAR" => "keepme" } }
+        shellout_opts_for(state)
+
+        _(config[:shellout_opts]).must_equal(environment: { "MY_VAR" => "keepme" })
       end
 
       it "raises ActionFailed if set false to :command" do


### PR DESCRIPTION
`Verifier::Shell#merge_state_to_env` builds a fresh environment hash and applies it with `merge!`:

```ruby
env_state = { environment: {} }
env_state[:environment]["KITCHEN_INSTANCE"] = instance.name
# ...
config[:shellout_opts].merge!(env_state)
```

`Hash#merge!` is **shallow**, so the nested `:environment` hash is replaced rather than merged, and every variable the user configured is dropped:

```yaml
verifier:
  name: shell
  command: ./run-tests.sh
  shellout_opts:
    environment:
      AWS_PROFILE: test     # never reaches the command
```

Sibling keys like `:timeout` survive the top-level merge, so most of `shellout_opts` keeps working and only the environment quietly empties out — which makes it a confusing one to chase.

### The second half

Writing back to `config` is a problem in its own right. `DataMunger` hands every instance the same nested hash objects — `rmerge` only copies a sub-hash when both sides define the key — so `:shellout_opts` is *literally the same object* across instances:

```ruby
a = dm.verifier_data_for("s1", "p1")
b = dm.verifier_data_for("s1", "p2")
a[:shellout_opts].equal?(b[:shellout_opts])           # => true
a[:shellout_opts].equal?(data[:verifier][:shellout_opts])  # => true
```

Under `--concurrency`, two instances race on that one `:environment` hash, and a command can run with another instance's `KITCHEN_INSTANCE` and `KITCHEN_HOSTNAME`.

### The fix

Build the options per run — merge the `KITCHEN_*` variables *into* the configured environment and leave `config` alone. `merge_state_to_env` becomes `shellout_opts(state)` + `kitchen_environment(state)`, and `#shellout` takes the state it needs rather than reading it back out of mutated config.

### Testing

Three new specs (user environment survives, sibling options survive, config is not modified); the first and third fail on `main`.

The two existing specs asserted `config[:shellout_opts][:environment]` — that is, they asserted the mutation, which is why the bug lived here. They now assert on the options actually handed to `Mixlib::ShellOut`, which is what decides the command's environment. Same coverage, at the real boundary.