### PR TITLE
test: fix specs that could not fail

### DIFF
--- a/spec/kitchen/driver/base_spec.rb
+++ b/spec/kitchen/driver/base_spec.rb
@@ -78,12 +78,11 @@ describe Kitchen::Driver::Base do
     _(logged_output.string).must_match(/yo\n/)
   end
 
-  %i{create setup verify destroy}.each do |action|
-    it "has a #{action} method that takes state" do
-      # TODO: revert back
-      # state = Hash.new
-      # driver.public_send(action, state).must_be_nil
-      driver.respond_to?(action)
+  # Base has no #setup or #verify: since 2.0 those actions belong to the
+  # transport and the verifier, which Instance::ActionRunner dispatches to.
+  %i{create destroy package}.each do |action|
+    it "has a #{action} method that takes state and returns nil" do
+      _(driver.public_send(action, {})).must_be_nil
     end
   end
 

--- a/spec/kitchen/driver/dummy_spec.rb
+++ b/spec/kitchen/driver/dummy_spec.rb
@@ -80,16 +80,13 @@ describe Kitchen::Driver::Dummy do
       _ { driver.create(state) }.must_raise Kitchen::ActionFailed
     end
 
-    it "will only raise ActionFailed if :random_failure is set" do
+    it "completes normally if :random_failure is set but the roll misses" do
       config[:random_failure] = true
+      driver.stubs(:randomly_fail?).returns(false)
 
-      begin
-        driver.create(state)
-      rescue Kitchen::ActionFailed
-        # If exception is anything other than Kitchen::ActionFailed, this spec
-        # will fail
-        true
-      end
+      driver.create(state)
+
+      _(state[:my_id]).must_match(/^coolbeans-/)
     end
 
     it "logs a create event to INFO" do
@@ -167,7 +164,7 @@ describe Kitchen::Driver::Dummy do
       config[:sleep] = 12.5
       driver.expects(:sleep).with(12.5).returns(true)
 
-      driver.verify(state)
+      driver.destroy(state)
     end
 
     it "raises ActionFailed if :fail_destroy is set" do

--- a/spec/kitchen/driver/proxy_spec.rb
+++ b/spec/kitchen/driver/proxy_spec.rb
@@ -71,7 +71,8 @@ describe Kitchen::Driver::Proxy do
 
     it "does not require reset_command" do
       config.delete(:reset_command)
-      driver # Just make sure it doesn't raise
+
+      _(driver[:reset_command]).must_be_nil
     end
   end
 

--- a/spec/kitchen/shell_out_spec.rb
+++ b/spec/kitchen/shell_out_spec.rb
@@ -134,9 +134,6 @@ describe Kitchen::ShellOut do
         .must_equal "[thed command] BEGIN (tenac)"
     end
 
-    it "truncates the debug BEGIN command if it spans multiple lines" do
-    end
-
     it "logs a debug END message" do
       subject.run_command("echo whoopa doopa")
 

--- a/spec/kitchen/util_spec.rb
+++ b/spec/kitchen/util_spec.rb
@@ -103,8 +103,10 @@ describe Kitchen::Util do
     end
   end
 
-  describe ".wrap_unix_command" do
+  describe ".wrap_command" do
     it "returns the wrapped command" do
+      _(Kitchen::Util.wrap_command("yoyo"))
+        .must_equal("sh -c '\nyoyo\n'")
     end
 
     it "returns a false if command is nil" do
@@ -113,8 +115,8 @@ describe Kitchen::Util do
     end
 
     it "returns a true if command string is empty" do
-      _(Kitchen::Util.wrap_command("yoyo"))
-        .must_equal("sh -c '\nyoyo\n'")
+      _(Kitchen::Util.wrap_command(""))
+        .must_equal("sh -c '\ntrue\n'")
     end
 
     it "handles a command string with a trailing newline" do

--- a/spec/kitchen/verifier/shell_spec.rb
+++ b/spec/kitchen/verifier/shell_spec.rb
@@ -161,7 +161,7 @@ describe Kitchen::Verifier::Shell do
 
   describe "#run_command" do
     it "execute locally and returns nil" do
-      verifier.run_command
+      _(verifier.run_command).must_be_nil
     end
 
     it "returns string when remote_exec" do


### PR DESCRIPTION
An audit for tests that cannot discover anything. Nine specs made **zero assertions**, and mutation testing confirmed the production code several of them name can be deleted with the suite still green.

### Empty bodies

```ruby
it "returns the wrapped command" do
end

it "truncates the debug BEGIN command if it spans multiple lines" do
end
```

`Util.wrap_command`'s neighbour is the worse half of that pair. The spec named *"returns a true if command string is empty"* passes `"yoyo"` — a non-empty string — so the `cmd = "true" if cmd.to_s.empty?` branch had **no test at all**:

```console
$ sed -i 's|cmd = "true" if cmd.to_s.empty?|# MUTANT|' lib/kitchen/util.rb
$ bundle exec rake unit
1799 runs, 2777 assertions, 0 failures, 0 errors, 0 skips
```

The empty spec gets the body its name promises, the mis-named one is pointed at the branch it names, and the block is renamed to `.wrap_command` — `.wrap_unix_command` is not a method that exists.

`ShellOut`'s empty spec names behaviour `run_command` has never had, and the spec directly above it asserts the *opposite* — that a three-line command is logged in full. **Removed** rather than reworked; there is nothing there to test.

### Claims that are false

```ruby
%i{create setup verify destroy}.each do |action|
  it "has a #{action} method that takes state" do
    # TODO: revert back
    # driver.public_send(action, state).must_be_nil
    driver.respond_to?(action)      # result discarded
  end
end
```

`Driver::Base` has no `#setup` and no `#verify` — they have belonged to the transport and the verifier since 2.0, as `Instance::ActionRunner#plugin_class_for_action` shows. Two of the four specs assert something untrue and pass only because nothing looks at the value. Restores the assertion the commented-out TODO intended, over the actions `Base` really implements.

### Nondeterministic and duplicated

`Driver::Dummy`'s *"will only raise ActionFailed if :random_failure is set"* called `#create` with a real `#randomly_fail?` — which is `[true, false].sample`. On half its runs nothing raised and nothing was asserted; on the other half it duplicated the spec above it. Reworked onto the branch that had no coverage: the roll coming up false.

### Wrong subject

Also in `dummy_spec`, the `describe "#destroy"` sleep spec called `driver.verify(state)` — re-testing `#verify` and leaving `#destroy`'s sleep uncovered. Found by scanning for specs under `describe "#X"` that call a sibling `#Y` and never `X`; it was the only real hit in the suite.

### Subject stated but never checked

`Proxy`'s *"does not require reset_command"* ran the constructor bare (`driver # Just make sure it doesn't raise`), and the shell verifier's *"execute locally and returns nil"* never looked at the return value. Both now assert the outcome.

### Verification

Every reworked spec was run against a deliberately broken version of the code it covers and confirmed to **fail** — that is the only evidence a test discovers anything. Full suite green, `rake style` clean.

Two fewer tests, eight more assertions: 1799 runs / 2777 assertions → 1797 runs / 2785 assertions.